### PR TITLE
Allow reading config from files

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,17 @@ uv sync
 
 ## Running the Server
 
+### Configuration
+
+Your Garmin Connect credentials are read from environment variables:
+
+- `GARMIN_EMAIL`: Your Garmin Connect email address
+- `GARMIN_EMAIL_FILE`: Path to a file containing your Garmin Connect email address
+- `GARMIN_PASSWORD`: Your Garmin Connect password
+- `GARMIN_PASSWORD_FILE`: Path to a file containing your Garmin Connect password
+
+File-based secrets are useful in certain environments, such as inside a Docker container. Note that you cannot set both `GARMIN_EMAIL` and `GARMIN_EMAIL_FILE`, similarly you cannot set both `GARMIN_PASSWORD` and `GARMIN_PASSWORD_FILE`.
+
 ### With Claude Desktop
 
 1. Create a configuration in Claude Desktop:

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -23,14 +23,34 @@ from garmin_mcp import workouts
 from garmin_mcp import data_management
 from garmin_mcp import womens_health
 
+
 def get_mfa() -> str:
     """Get MFA code from user input"""
     print("\nGarmin Connect MFA required. Please check your email/phone for the code.")
     return input("Enter MFA code: ")
 
+
 # Get credentials from environment
 email = os.environ.get("GARMIN_EMAIL")
+email_file = os.environ.get("GARMIN_EMAIL_FILE")
+if email and email_file:
+    raise ValueError(
+        "Must only provide one of GARMIN_EMAIL and GARMIN_EMAIL_FILE, got both"
+    )
+elif email_file:
+    with open(email_file, "r") as email_file:
+        email = email_file.read().rstrip()
+
 password = os.environ.get("GARMIN_PASSWORD")
+password_file = os.environ.get("GARMIN_PASSWORD_FILE")
+if password and password_file:
+    raise ValueError(
+        "Must only provide one of GARMIN_PASSWORD and GARMIN_PASSWORD_FILE, got both"
+    )
+elif password_file:
+    with open(password_file, "r") as password_file:
+        password = password_file.read().rstrip()
+
 tokenstore = os.getenv("GARMINTOKENS") or "~/.garminconnect"
 tokenstore_base64 = os.getenv("GARMINTOKENS_BASE64") or "~/.garminconnect_base64"
 


### PR DESCRIPTION
### Summary

Thanks for making this MCP server!

I'm deploying it inside a Docker container, and the recommended way to pass secrets there is file-based. From [Docker's documentation on the subject](https://docs.docker.com/engine/swarm/secrets/#build-support-for-docker-secrets-into-your-images):

> If you develop a container that can be deployed as a service and requires sensitive data, such as a credential, as an environment variable, consider adapting your image to take advantage of Docker secrets. One way to do this is to ensure that each parameter you pass to the image when creating the container can also be read from a file.

This PR does this!

### Testing

Tested out locally, both the error and non-error cases. Also tried password files that included trailing whitespace (like from `echo`) and without (like from `echo -n` or `printf`).

Success:
<img width="839" height="250" alt="Screenshot 2025-10-31 at 10 04 23 AM" src="https://github.com/user-attachments/assets/e5425841-149b-419a-9c44-5270de67f32a" />

Error:
<img width="715" height="125" alt="Screenshot 2025-10-31 at 10 02 58 AM" src="https://github.com/user-attachments/assets/bfaf8c5d-5eb2-4245-bb8c-031e432e9803" />
