### PR TITLE
Adds MFA to Readme, print errors to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,46 @@ For other issues, check the Claude Desktop logs at:
 
 - macOS: `~/Library/Logs/Claude/mcp-server-garmin.log`
 - Windows: `%APPDATA%\Claude\logs\mcp-server-garmin.log`
+
+### Garming Connect one-time code
+
+If you have one-time codes enabled in your account, you need to login at the command line first to set the token in the interactive cli.
+
+The app expects either the env var GARMIN_EMAIL or GARMIN_EMAIL_FILE. You can store these in files with the following command.
+
+```bash
+echo "your_email@example.com" > ~/.garmin_email
+echo "your_password" > ~/.garmin_password
+chmod 600 ~/.garmin_email ~/.garmin_password
+```
+
+Then you can manually run the login script.
+
+```bash
+GARMIN_EMAIL_FILE=~/.garmin_email GARMIN_PASSWORD_FILE=~/.garmin_password uvx --python 3.12 --from git+https://github.com/Taxuspt/garmin_mcp garmin-mcp
+```
+
+You will likely see
+
+```bash
+Garmin Connect MFA required. Please check your email/phone for the code.
+Enter MFA code: XXXXXX
+Oauth tokens stored in '~/.garminconnect' directory for future use. (first method)
+
+Oauth tokens encoded as base64 string and saved to '~/.garminconnect_base64' file for future use. (second method)
+```
+
+After setting the token at the cli, you can use the following in Claude, without the env vars because the Oauth tokens have been set.
+
+```bash
+"garmin": {
+  "command": "uvx",
+  "args": [
+    "--python",
+    "3.12",
+    "--from",
+    "git+https://github.com/Taxuspt/garmin_mcp",
+    "garmin-mcp"
+  ]
+}
+```

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -3,6 +3,7 @@ Modular MCP Server for Garmin Connect Data
 """
 
 import os
+import sys
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -26,7 +27,7 @@ from garmin_mcp import womens_health
 
 def get_mfa() -> str:
     """Get MFA code from user input"""
-    print("\nGarmin Connect MFA required. Please check your email/phone for the code.")
+    print("\nGarmin Connect MFA required. Please check your email/phone for the code.", file=sys.stderr)
     return input("Enter MFA code: ")
 
 
@@ -62,7 +63,7 @@ def init_api(email, password):
         # Using Oauth1 and OAuth2 token files from directory
         print(
             f"Trying to login to Garmin Connect using token data from directory '{tokenstore}'...\n"
-        )
+        , file=sys.stderr)
 
         # Using Oauth1 and Oauth2 tokens from base64 encoded string
         # print(
@@ -80,7 +81,7 @@ def init_api(email, password):
         print(
             "Login tokens not present, login with your Garmin Connect credentials to generate them.\n"
             f"They will be stored in '{tokenstore}' for future use.\n"
-        )
+        , file=sys.stderr)
         try:
             garmin = Garmin(
                 email=email, password=password, is_cn=False, prompt_mfa=get_mfa
@@ -90,7 +91,7 @@ def init_api(email, password):
             garmin.garth.dump(tokenstore)
             print(
                 f"Oauth tokens stored in '{tokenstore}' directory for future use. (first method)\n"
-            )
+            , file=sys.stderr)
             # Encode Oauth1 and Oauth2 tokens to base64 string and safe to file for next login (alternative way)
             token_base64 = garmin.garth.dumps()
             dir_path = os.path.expanduser(tokenstore_base64)
@@ -98,14 +99,14 @@ def init_api(email, password):
                 token_file.write(token_base64)
             print(
                 f"Oauth tokens encoded as base64 string and saved to '{dir_path}' file for future use. (second method)\n"
-            )
+            , file=sys.stderr)
         except (
             FileNotFoundError,
             GarthHTTPError,
             GarminConnectAuthenticationError,
             requests.exceptions.HTTPError,
         ) as err:
-            print(err)
+            print(err, file=sys.stderr)
             return None
 
     return garmin
@@ -117,10 +118,10 @@ def main():
     # Initialize Garmin client
     garmin_client = init_api(email, password)
     if not garmin_client:
-        print("Failed to initialize Garmin Connect client. Exiting.")
+        print("Failed to initialize Garmin Connect client. Exiting.", file=sys.stderr)
         return
 
-    print("Garmin Connect client initialized successfully.")
+    print("Garmin Connect client initialized successfully.", file=sys.stderr)
 
     # Configure all modules with the Garmin client
     activity_management.configure(garmin_client)


### PR DESCRIPTION
1. Adds MFA instructions to the readme. 

Since MFA is interactive, it needs to be set outside of connecting in Claude. I put what I did in the readme to hopefully help the next person. I'm happy to change if you'd prefer different details. 

2. Send print to stderror

This suggestion is to print to stderr from the error blocks.