### PR TITLE
Add nutrition endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ This MCP server implements **96+ tools** covering ~89% of the [python-garminconn
 - ✅ Gear Management (5 tools)
 - ✅ Weight Tracking (5 tools)
 - ✅ Challenges & Badges (10 tools)
+- ✅ Nutrition (8 tools) - food logs, meals, custom foods, and food logging
 - ✅ Women's Health (3 tools)
 - ✅ User Profile (3 tools)
 
@@ -524,7 +525,7 @@ garmin-mcp-auth --verify
 
 ## Testing
 
-This project includes comprehensive tests for all 96 MCP tools. **All 111 tests are currently passing (100%)**.
+This project includes comprehensive tests for all MCP tools. **All tests are currently passing (100%)**.
 
 ### Running Tests
 
@@ -544,5 +545,5 @@ uv run pytest tests/e2e/ -m e2e -v
 
 ### Test Structure
 
-- **Integration tests** (96 tests): Test all MCP tools using FastMCP integration with mocked Garmin API responses
+- **Integration tests** (130 tests): Test all MCP tools using FastMCP integration with mocked Garmin API responses
 - **End-to-end tests** (4 tests): Test with real MCP server and Garmin API (requires valid credentials)

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -24,6 +24,7 @@ from garmin_mcp import workouts
 from garmin_mcp import workout_templates
 from garmin_mcp import data_management
 from garmin_mcp import womens_health
+from garmin_mcp import nutrition
 
 
 def is_interactive_terminal() -> bool:
@@ -223,6 +224,7 @@ def main():
     workouts.configure(garmin_client)
     data_management.configure(garmin_client)
     womens_health.configure(garmin_client)
+    nutrition.configure(garmin_client)
 
     # Create the MCP app
     app = FastMCP("Garmin Connect v1.0")
@@ -239,6 +241,7 @@ def main():
     app = workouts.register_tools(app)
     app = data_management.register_tools(app)
     app = womens_health.register_tools(app)
+    app = nutrition.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -1,0 +1,368 @@
+"""
+Nutrition/food logging functions for Garmin Connect MCP Server
+"""
+import json
+from typing import Optional
+
+from garth.exc import GarthHTTPError
+
+# The garmin_client will be set by the main file
+garmin_client = None
+
+
+def _num_to_str(value: float) -> str:
+    """Format a number as string, dropping .0 for whole numbers.
+
+    Garmin's API expects integer strings like "160" not "160.0".
+    """
+    return str(int(value)) if value == int(value) else str(value)
+
+
+def configure(client):
+    """Configure the module with the Garmin client instance"""
+    global garmin_client
+    garmin_client = client
+
+
+def register_tools(app):
+    """Register all nutrition tools with the MCP server app"""
+
+    @app.tool()
+    async def get_nutrition_daily_food_log(date: str) -> str:
+        """Get daily food consumption records for a date
+
+        Returns food items logged throughout the day including calories,
+        macronutrients, and meal associations.
+
+        Args:
+            date: Date in YYYY-MM-DD format
+        """
+        try:
+            url = f"/nutrition-service/food/logs/{date}"
+            data = garmin_client.connectapi(url)
+            if not data:
+                return f"No food log data found for {date}."
+            return json.dumps(data, indent=2)
+        except Exception as e:
+            return f"Error retrieving food log data: {str(e)}"
+
+    @app.tool()
+    async def get_nutrition_daily_meals(date: str) -> str:
+        """Get daily meal summaries for a date
+
+        Returns meal-level summaries (breakfast, lunch, dinner, snacks)
+        with nutritional totals for each meal. Each meal includes a mealId
+        needed for logging food items to that meal.
+
+        Args:
+            date: Date in YYYY-MM-DD format
+        """
+        try:
+            url = f"/nutrition-service/meals/{date}"
+            data = garmin_client.connectapi(url)
+            if not data:
+                return f"No meal data found for {date}."
+            return json.dumps(data, indent=2)
+        except Exception as e:
+            return f"Error retrieving meal data: {str(e)}"
+
+    @app.tool()
+    async def get_nutrition_daily_settings(date: str) -> str:
+        """Get nutrition plan/settings for a date
+
+        Returns the user's nutrition goals and targets including
+        calorie targets, macronutrient goals, and plan configuration.
+
+        Args:
+            date: Date in YYYY-MM-DD format
+        """
+        try:
+            url = f"/nutrition-service/settings/{date}"
+            data = garmin_client.connectapi(url)
+            if not data:
+                return f"No nutrition settings found for {date}."
+            return json.dumps(data, indent=2)
+        except Exception as e:
+            return f"Error retrieving nutrition settings: {str(e)}"
+
+    @app.tool()
+    async def get_custom_foods(
+        search: str = "",
+        start: int = 0,
+        limit: int = 20,
+    ) -> str:
+        """Search or list user's custom foods
+
+        Returns custom foods the user has created, with optional search
+        filtering. Use this to find foodId and servingId for logging.
+
+        Args:
+            search: Optional search expression to filter foods
+            start: Starting index for pagination (default 0)
+            limit: Maximum number of results (default 20)
+        """
+        try:
+            url = (
+                f"/nutrition-service/customFood"
+                f"?searchExpression={search}"
+                f"&start={start}&limit={limit}"
+                f"&includeContent=true"
+            )
+            data = garmin_client.connectapi(url)
+            if not data:
+                return "No custom foods found."
+            return json.dumps(data, indent=2)
+        except Exception as e:
+            return f"Error retrieving custom foods: {str(e)}"
+
+    @app.tool()
+    async def get_custom_food_serving_units() -> str:
+        """Get available serving units for custom foods
+
+        Returns the list of valid serving units (e.g. G, ML, OZ)
+        that can be used when creating custom foods.
+        """
+        try:
+            url = "/nutrition-service/metadata/customFoodServingUnits"
+            data = garmin_client.connectapi(url)
+            if not data:
+                return "No serving units found."
+            return json.dumps(data, indent=2)
+        except Exception as e:
+            return f"Error retrieving serving units: {str(e)}"
+
+    @app.tool()
+    async def create_custom_food(
+        food_name: str,
+        calories: float,
+        serving_unit: str = "G",
+        number_of_units: float = 100,
+        carbs: Optional[float] = None,
+        protein: Optional[float] = None,
+        fat: Optional[float] = None,
+        fiber: Optional[float] = None,
+        sugar: Optional[float] = None,
+        saturated_fat: Optional[float] = None,
+        sodium: Optional[float] = None,
+        cholesterol: Optional[float] = None,
+        potassium: Optional[float] = None,
+    ) -> str:
+        """Create a custom food in the user's Garmin nutrition library
+
+        Creates a new food item with nutritional information per serving.
+        The response includes foodId and servingId needed for logging.
+
+        Args:
+            food_name: Name of the custom food (e.g. "Homemade Chocolate Cookies")
+            calories: Calories per serving
+            serving_unit: Unit for serving size (e.g. "G", "ML", "OZ"). Default "G"
+            number_of_units: Serving size in the specified unit. Default 100
+            carbs: Carbohydrates in grams per serving
+            protein: Protein in grams per serving
+            fat: Total fat in grams per serving
+            fiber: Fiber in grams per serving
+            sugar: Sugar in grams per serving
+            saturated_fat: Saturated fat in grams per serving
+            sodium: Sodium in mg per serving
+            cholesterol: Cholesterol in mg per serving
+            potassium: Potassium in mg per serving
+        """
+        try:
+            nutrition = {
+                "servingUnit": serving_unit,
+                "numberOfUnits": _num_to_str(number_of_units),
+                "calories": _num_to_str(calories),
+            }
+            # Only include optional fields that have values
+            optional_fields = {
+                "carbs": carbs,
+                "protein": protein,
+                "fat": fat,
+                "fiber": fiber,
+                "sugar": sugar,
+                "saturatedFat": saturated_fat,
+                "sodium": sodium,
+                "cholesterol": cholesterol,
+                "potassium": potassium,
+            }
+            for key, value in optional_fields.items():
+                if value is not None:
+                    nutrition[key] = _num_to_str(value)
+
+            payload = {
+                "foodMetaData": {
+                    "foodName": food_name,
+                    "foodType": "GENERIC",
+                    "source": "GARMIN",
+                    "regionCode": "US",
+                    "languageCode": "en",
+                },
+                "nutritionContents": [nutrition],
+            }
+            url = "/nutrition-service/customFood"
+            resp = garmin_client.garth.put(
+                "connectapi", url, json=payload, api=True
+            )
+            if resp.status_code == 204:
+                return "Custom food created (no response data returned)."
+            return json.dumps(resp.json(), indent=2)
+        except GarthHTTPError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error creating custom food: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error creating custom food: {str(e)}"
+
+    @app.tool()
+    async def update_custom_food(
+        food_id: str,
+        serving_id: str,
+        food_name: str,
+        calories: float,
+        serving_unit: str = "G",
+        number_of_units: float = 100,
+        carbs: Optional[float] = None,
+        protein: Optional[float] = None,
+        fat: Optional[float] = None,
+        fiber: Optional[float] = None,
+        sugar: Optional[float] = None,
+        saturated_fat: Optional[float] = None,
+        sodium: Optional[float] = None,
+        cholesterol: Optional[float] = None,
+        potassium: Optional[float] = None,
+    ) -> str:
+        """Update an existing custom food in the user's Garmin nutrition library
+
+        Modifies a custom food's name and/or nutritional information.
+        Use get_custom_foods first to find the foodId and servingId.
+
+        Args:
+            food_id: ID of the custom food to update (from get_custom_foods)
+            serving_id: Serving ID of the food (from get_custom_foods)
+            food_name: Name of the custom food
+            calories: Calories per serving
+            serving_unit: Unit for serving size (e.g. "G", "ML", "OZ"). Default "G"
+            number_of_units: Serving size in the specified unit. Default 100
+            carbs: Carbohydrates in grams per serving
+            protein: Protein in grams per serving
+            fat: Total fat in grams per serving
+            fiber: Fiber in grams per serving
+            sugar: Sugar in grams per serving
+            saturated_fat: Saturated fat in grams per serving
+            sodium: Sodium in mg per serving
+            cholesterol: Cholesterol in mg per serving
+            potassium: Potassium in mg per serving
+        """
+        try:
+            nutrition = {
+                "servingId": serving_id,
+                "servingUnit": serving_unit,
+                "numberOfUnits": _num_to_str(number_of_units),
+                "calories": _num_to_str(calories),
+            }
+            optional_fields = {
+                "carbs": carbs,
+                "protein": protein,
+                "fat": fat,
+                "fiber": fiber,
+                "sugar": sugar,
+                "saturatedFat": saturated_fat,
+                "sodium": sodium,
+                "cholesterol": cholesterol,
+                "potassium": potassium,
+            }
+            for key, value in optional_fields.items():
+                if value is not None:
+                    nutrition[key] = _num_to_str(value)
+
+            payload = {
+                "foodMetaData": {
+                    "foodId": food_id,
+                    "foodName": food_name,
+                    "foodType": "GENERIC",
+                    "source": "GARMIN",
+                    "regionCode": "US",
+                    "languageCode": "en",
+                },
+                "nutritionContents": [nutrition],
+            }
+            url = "/nutrition-service/customFood"
+            resp = garmin_client.garth.put(
+                "connectapi", url, json=payload, api=True
+            )
+            if resp.status_code == 204:
+                return "Custom food updated (no response data returned)."
+            return json.dumps(resp.json(), indent=2)
+        except GarthHTTPError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error updating custom food: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error updating custom food: {str(e)}"
+
+    @app.tool()
+    async def log_food(
+        meal_date: str,
+        meal_time: str,
+        meal_id: int,
+        food_id: str,
+        serving_id: str,
+        serving_qty: float = 1,
+    ) -> str:
+        """Log a food item to a specific meal on a date
+
+        Adds a food entry to the user's nutrition log. Requires IDs
+        from the meals endpoint (mealId) and from custom/searched
+        foods (foodId, servingId).
+
+        Args:
+            meal_date: Date in YYYY-MM-DD format
+            meal_time: Time in HH:MM:SS format (e.g. "12:30:00")
+            meal_id: Meal ID from get_nutrition_daily_meals
+            food_id: Food ID from create_custom_food or get_custom_foods
+            serving_id: Serving ID from create_custom_food or get_custom_foods
+            serving_qty: Number of servings (default 1)
+        """
+        try:
+            from datetime import datetime, timezone
+
+            log_timestamp = datetime.now(timezone.utc).strftime(
+                "%Y-%m-%dT%H:%M:%S.000Z"
+            )
+            payload = {
+                "mealDate": meal_date,
+                "foodLogItems": [
+                    {
+                        "logTimestamp": log_timestamp,
+                        "logSource": "GCW",
+                        "logCategory": "REGULAR_LOG",
+                        "mealTime": meal_time,
+                        "action": "ADD",
+                        "mealId": meal_id,
+                        "foodId": food_id,
+                        "servingId": serving_id,
+                        "source": "GARMIN",
+                        "regionCode": "US",
+                        "languageCode": "en",
+                        "servingQty": serving_qty,
+                    }
+                ],
+            }
+            url = "/nutrition-service/food/logs"
+            resp = garmin_client.garth.put(
+                "connectapi", url, json=payload, api=True
+            )
+            if resp.status_code == 204:
+                return "Food logged successfully."
+            return json.dumps(resp.json(), indent=2)
+        except GarthHTTPError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error logging food: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error logging food: {str(e)}"
+
+    return app

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -1,0 +1,441 @@
+"""
+Integration tests for nutrition module MCP tools
+
+Tests tools from:
+- nutrition (8 tools: 5 read + 2 write + 1 metadata)
+"""
+import json
+import pytest
+from unittest.mock import Mock, MagicMock
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import nutrition
+
+
+@pytest.fixture
+def app_with_nutrition(mock_garmin_client):
+    """Create FastMCP app with nutrition tools registered"""
+    nutrition.configure(mock_garmin_client)
+    app = FastMCP("Test Nutrition")
+    app = nutrition.register_tools(app)
+    return app
+
+
+# get_nutrition_daily_food_log tests
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_food_log(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_food_log tool returns food log data"""
+    food_log = {
+        "foodLogEntries": [
+            {
+                "foodName": "Banana",
+                "calories": 105,
+                "carbs": 27.0,
+                "fat": 0.4,
+                "protein": 1.3,
+                "mealType": "BREAKFAST"
+            }
+        ],
+        "totalCalories": 105
+    }
+    mock_garmin_client.connectapi.return_value = food_log
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_food_log",
+        {"date": "2024-01-15"}
+    )
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with("/nutrition-service/food/logs/2024-01-15")
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_food_log_empty(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_food_log tool with no data"""
+    mock_garmin_client.connectapi.return_value = None
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_food_log",
+        {"date": "2024-01-15"}
+    )
+    assert "No food log data found" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_food_log_error(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_food_log tool handles errors"""
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_food_log",
+        {"date": "2024-01-15"}
+    )
+    assert "Error retrieving food log data" in result[0][0].text
+
+
+# get_nutrition_daily_meals tests
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_meals(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_meals tool returns meal data"""
+    meals = {
+        "meals": [
+            {
+                "mealId": 185360,
+                "mealType": "BREAKFAST",
+                "totalCalories": 450,
+            }
+        ]
+    }
+    mock_garmin_client.connectapi.return_value = meals
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_meals",
+        {"date": "2024-01-15"}
+    )
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with("/nutrition-service/meals/2024-01-15")
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_meals_empty(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_meals tool with no data"""
+    mock_garmin_client.connectapi.return_value = None
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_meals",
+        {"date": "2024-01-15"}
+    )
+    assert "No meal data found" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_meals_error(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_meals tool handles errors"""
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_meals",
+        {"date": "2024-01-15"}
+    )
+    assert "Error retrieving meal data" in result[0][0].text
+
+
+# get_nutrition_daily_settings tests
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_settings(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_settings tool returns settings data"""
+    settings = {
+        "calorieGoal": 2000,
+        "carbsGoalPercent": 50,
+        "fatGoalPercent": 30,
+        "proteinGoalPercent": 20
+    }
+    mock_garmin_client.connectapi.return_value = settings
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_settings",
+        {"date": "2024-01-15"}
+    )
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with("/nutrition-service/settings/2024-01-15")
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_settings_empty(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_settings tool with no data"""
+    mock_garmin_client.connectapi.return_value = None
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_settings",
+        {"date": "2024-01-15"}
+    )
+    assert "No nutrition settings found" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_daily_settings_error(app_with_nutrition, mock_garmin_client):
+    """Test get_nutrition_daily_settings tool handles errors"""
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_daily_settings",
+        {"date": "2024-01-15"}
+    )
+    assert "Error retrieving nutrition settings" in result[0][0].text
+
+
+# get_custom_foods tests
+
+@pytest.mark.asyncio
+async def test_get_custom_foods(app_with_nutrition, mock_garmin_client):
+    """Test get_custom_foods tool returns custom food list"""
+    custom_foods = [
+        {
+            "foodId": "abc123",
+            "foodName": "Homemade Cookies",
+            "servingId": "srv456",
+        }
+    ]
+    mock_garmin_client.connectapi.return_value = custom_foods
+    result = await app_with_nutrition.call_tool("get_custom_foods", {})
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/customFood?searchExpression=&start=0&limit=20&includeContent=true"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_custom_foods_with_search(app_with_nutrition, mock_garmin_client):
+    """Test get_custom_foods tool with search filter"""
+    mock_garmin_client.connectapi.return_value = []
+    result = await app_with_nutrition.call_tool(
+        "get_custom_foods",
+        {"search": "cookie", "start": 0, "limit": 10}
+    )
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/customFood?searchExpression=cookie&start=0&limit=10&includeContent=true"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_custom_foods_empty(app_with_nutrition, mock_garmin_client):
+    """Test get_custom_foods tool with no results"""
+    mock_garmin_client.connectapi.return_value = None
+    result = await app_with_nutrition.call_tool("get_custom_foods", {})
+    assert "No custom foods found" in result[0][0].text
+
+
+# get_custom_food_serving_units tests
+
+@pytest.mark.asyncio
+async def test_get_custom_food_serving_units(app_with_nutrition, mock_garmin_client):
+    """Test get_custom_food_serving_units returns unit list"""
+    units = [{"unitKey": "G", "unitName": "Grams"}, {"unitKey": "ML", "unitName": "Milliliters"}]
+    mock_garmin_client.connectapi.return_value = units
+    result = await app_with_nutrition.call_tool("get_custom_food_serving_units", {})
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/metadata/customFoodServingUnits"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_custom_food_serving_units_error(app_with_nutrition, mock_garmin_client):
+    """Test get_custom_food_serving_units handles errors"""
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool("get_custom_food_serving_units", {})
+    assert "Error retrieving serving units" in result[0][0].text
+
+
+# create_custom_food tests
+
+@pytest.mark.asyncio
+async def test_create_custom_food(app_with_nutrition, mock_garmin_client):
+    """Test create_custom_food creates a food item"""
+    response_data = {
+        "foodId": "abc123",
+        "foodName": "Homemade Cookies",
+        "servingId": "srv456",
+    }
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = response_data
+    mock_garmin_client.garth.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "create_custom_food",
+        {
+            "food_name": "Homemade Cookies",
+            "calories": 150,
+            "serving_unit": "G",
+            "number_of_units": 30,
+            "carbs": 20,
+            "protein": 2,
+            "fat": 7,
+        }
+    )
+    assert result is not None
+    call_args = mock_garmin_client.garth.put.call_args
+    assert call_args[0][0] == "connectapi"
+    assert call_args[0][1] == "/nutrition-service/customFood"
+    payload = call_args[1]["json"]
+    assert payload["foodMetaData"]["foodName"] == "Homemade Cookies"
+    assert payload["nutritionContents"][0]["calories"] == "150"
+    assert payload["nutritionContents"][0]["carbs"] == "20"
+    assert payload["nutritionContents"][0]["protein"] == "2"
+    assert payload["nutritionContents"][0]["fat"] == "7"
+    assert payload["nutritionContents"][0]["servingUnit"] == "G"
+    assert payload["nutritionContents"][0]["numberOfUnits"] == "30"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_food_minimal(app_with_nutrition, mock_garmin_client):
+    """Test create_custom_food with only required fields"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_garmin_client.garth.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "create_custom_food",
+        {"food_name": "Simple Food", "calories": 100}
+    )
+    assert "Custom food created" in result[0][0].text
+    call_args = mock_garmin_client.garth.put.call_args
+    payload = call_args[1]["json"]
+    # Optional fields should NOT be present in the payload
+    assert "carbs" not in payload["nutritionContents"][0]
+    assert "protein" not in payload["nutritionContents"][0]
+    assert "fat" not in payload["nutritionContents"][0]
+
+
+@pytest.mark.asyncio
+async def test_create_custom_food_error(app_with_nutrition, mock_garmin_client):
+    """Test create_custom_food handles errors"""
+    mock_garmin_client.garth.put.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "create_custom_food",
+        {"food_name": "Test", "calories": 100}
+    )
+    assert "Error creating custom food" in result[0][0].text
+
+
+# update_custom_food tests
+
+@pytest.mark.asyncio
+async def test_update_custom_food(app_with_nutrition, mock_garmin_client):
+    """Test update_custom_food updates an existing food item"""
+    response_data = {
+        "foodId": "abc123",
+        "foodName": "Homemade Cookies Updated",
+        "servingId": "srv456",
+    }
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = response_data
+    mock_garmin_client.garth.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "update_custom_food",
+        {
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "food_name": "Homemade Cookies Updated",
+            "calories": 160,
+            "serving_unit": "G",
+            "number_of_units": 30,
+            "carbs": 22,
+            "protein": 3,
+            "fat": 8,
+        }
+    )
+    assert result is not None
+    call_args = mock_garmin_client.garth.put.call_args
+    assert call_args[0][0] == "connectapi"
+    assert call_args[0][1] == "/nutrition-service/customFood"
+    payload = call_args[1]["json"]
+    assert payload["foodMetaData"]["foodId"] == "abc123"
+    assert payload["foodMetaData"]["foodName"] == "Homemade Cookies Updated"
+    assert payload["nutritionContents"][0]["servingId"] == "srv456"
+    assert payload["nutritionContents"][0]["calories"] == "160"
+    assert payload["nutritionContents"][0]["carbs"] == "22"
+    assert payload["nutritionContents"][0]["protein"] == "3"
+    assert payload["nutritionContents"][0]["fat"] == "8"
+
+
+@pytest.mark.asyncio
+async def test_update_custom_food_204(app_with_nutrition, mock_garmin_client):
+    """Test update_custom_food with 204 response"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_garmin_client.garth.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "update_custom_food",
+        {
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "food_name": "Simple Food",
+            "calories": 100,
+        }
+    )
+    assert "Custom food updated" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_update_custom_food_error(app_with_nutrition, mock_garmin_client):
+    """Test update_custom_food handles errors"""
+    mock_garmin_client.garth.put.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "update_custom_food",
+        {
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "food_name": "Test",
+            "calories": 100,
+        }
+    )
+    assert "Error updating custom food" in result[0][0].text
+
+
+# log_food tests
+
+@pytest.mark.asyncio
+async def test_log_food(app_with_nutrition, mock_garmin_client):
+    """Test log_food logs a food item to a meal"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"status": "ok"}
+    mock_garmin_client.garth.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "log_food",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:30:00",
+            "meal_id": 185360,
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "serving_qty": 3,
+        }
+    )
+    assert result is not None
+    call_args = mock_garmin_client.garth.put.call_args
+    assert call_args[0][0] == "connectapi"
+    assert call_args[0][1] == "/nutrition-service/food/logs"
+    payload = call_args[1]["json"]
+    assert payload["mealDate"] == "2024-01-15"
+    assert len(payload["foodLogItems"]) == 1
+    item = payload["foodLogItems"][0]
+    assert item["mealId"] == 185360
+    assert item["foodId"] == "abc123"
+    assert item["servingId"] == "srv456"
+    assert item["servingQty"] == 3
+    assert item["action"] == "ADD"
+    assert item["mealTime"] == "12:30:00"
+
+
+@pytest.mark.asyncio
+async def test_log_food_default_qty(app_with_nutrition, mock_garmin_client):
+    """Test log_food with default serving quantity of 1"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_garmin_client.garth.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "log_food",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "08:00:00",
+            "meal_id": 185360,
+            "food_id": "abc123",
+            "serving_id": "srv456",
+        }
+    )
+    assert "Food logged successfully" in result[0][0].text
+    payload = mock_garmin_client.garth.put.call_args[1]["json"]
+    assert payload["foodLogItems"][0]["servingQty"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_food_error(app_with_nutrition, mock_garmin_client):
+    """Test log_food handles errors"""
+    mock_garmin_client.garth.put.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "log_food",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:00:00",
+            "meal_id": 185360,
+            "food_id": "abc123",
+            "serving_id": "srv456",
+        }
+    )
+    assert "Error logging food" in result[0][0].text


### PR DESCRIPTION
## Summary

- Adds a nutrition module with 9 tools: 5 read, 3 write, 1 metadata
- Implements direct Garmin Connect API calls via `garth` since `python-garminconnect` has no nutrition endpoints yet
- Includes integration tests for all tools

## Tools Added

### Read
| Tool | Description |
|------|-------------|
| `get_nutrition_daily_food_log` | Get all food entries logged for a given date |
| `get_nutrition_daily_meals` | Get meal slots (breakfast, lunch, dinner, snacks) with `mealId` needed for logging |
| `get_nutrition_daily_settings` | Get the user's nutrition plan/goals (calorie target, macros, weight goal) |
| `get_custom_foods` | Search or list user-created custom foods (returns `foodId` and `servingId`) |
| `get_custom_food_serving_units` | List valid serving units (`G`, `ML`, `PIECE`, `SERVING`, `SLICE`, etc.) |

### Write
| Tool | Description |
|------|-------------|
| `create_custom_food` | Create a new custom food with full nutritional info |
| `update_custom_food` | Edit an existing custom food (requires `foodId` + `servingId` from `get_custom_foods`) |
| `log_food` | Log a food item to a specific meal on a date |

## Note on `python-garminconnect`

No nutrition methods exist in the library yet. Uses direct `garth` calls to `/nutrition-service/*`, same pattern as the other write tools in this project.

## Nutritional Fields Supported

All write tools accept these optional per-serving fields:

| Field | Unit |
|-------|------|
| `calories` | kcal (required) |
| `carbs` | grams |
| `protein` | grams |
| `fat` | grams |
| `fiber` | grams |
| `sugar` | grams |
| `saturated_fat` | grams |
| `sodium` | mg |
| `cholesterol` | mg |
| `potassium` | mg |

## Usage Examples

With the MCP server connected, users can interact through Claude:

> User: "Add this recipe as a custom food on Garmin: https://www.noracooks.com/vegan-chocolate-chip-cookies/"
>
> Claude fetches the recipe page, extracts the nutritional info (160 kcal, 24g carbs, 2g protein, 7g fat per cookie at ~40g), and calls `create_custom_food`. The food appears in Garmin Connect immediately.

> User: "Log 2 of those cookies as a snack for today"
>
> Claude calls `get_custom_foods` to find the food ID, `get_nutrition_daily_meals` to get the snack meal ID, then `log_food` with `serving_qty=2`.

> User: "I recalculated the recipe, it's actually 155 kcal per cookie — update it"
>
> Claude calls `get_custom_foods` to get the existing food/serving IDs, then `update_custom_food` with the corrected values. No need to delete and recreate — the food is updated in place.

> User: "What did I eat yesterday?"
>
> Claude calls `get_nutrition_daily_food_log` and summarizes all logged meals with totals.

> User: "Show me my nutrition goals"
>
> Claude calls `get_nutrition_daily_settings` and returns the calorie target, macro split, weight goal, etc.
