### PR TITLE
Add delete_workout tool

### DIFF
--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -346,6 +346,35 @@ def register_tools(app):
             return f"Error uploading workout: {str(e)}"
 
     @app.tool()
+    async def delete_workout(workout_id: int) -> str:
+        """Delete a workout from Garmin Connect
+
+        Permanently removes a workout from your Garmin Connect workout library.
+
+        Args:
+            workout_id: ID of the workout to delete (get IDs from get_workouts)
+        """
+        try:
+            url = f"{garmin_client.garmin_workouts}/workout/{workout_id}"
+            response = garmin_client.garth.delete("connectapi", url, api=True)
+
+            if response.status_code == 204 or response.status_code == 200:
+                return json.dumps({
+                    "status": "success",
+                    "workout_id": workout_id,
+                    "message": f"Workout {workout_id} deleted successfully"
+                }, indent=2)
+            else:
+                return json.dumps({
+                    "status": "failed",
+                    "workout_id": workout_id,
+                    "http_status": response.status_code,
+                    "message": f"Failed to delete workout: HTTP {response.status_code}"
+                }, indent=2)
+        except Exception as e:
+            return f"Error deleting workout: {str(e)}"
+
+    @app.tool()
     async def get_scheduled_workouts(start_date: str, end_date: str) -> str:
         """Get scheduled workouts between two dates with curated summary list
 

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -314,6 +314,101 @@ async def test_get_training_plan_workouts_tool(app_with_workouts, mock_garmin_cl
     assert workouts[1]["activity_id"] == 987654
 
 
+# Delete workout tests
+@pytest.mark.asyncio
+async def test_delete_workout_success_204(app_with_workouts, mock_garmin_client):
+    """Test delete_workout tool with 204 response"""
+    import json as json_module
+    from unittest.mock import MagicMock
+
+    # Setup mock for garth.delete call
+    mock_response = MagicMock()
+    mock_response.status_code = 204
+    mock_garmin_client.garth.delete.return_value = mock_response
+
+    # Call tool
+    workout_id = 123456
+    result = await app_with_workouts.call_tool(
+        "delete_workout",
+        {"workout_id": workout_id}
+    )
+
+    # Verify
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "success"
+    assert result_data["workout_id"] == 123456
+    assert "deleted successfully" in result_data["message"]
+
+
+@pytest.mark.asyncio
+async def test_delete_workout_success_200(app_with_workouts, mock_garmin_client):
+    """Test delete_workout tool with 200 response"""
+    import json as json_module
+    from unittest.mock import MagicMock
+
+    # Setup mock for garth.delete call
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_garmin_client.garth.delete.return_value = mock_response
+
+    # Call tool
+    workout_id = 789012
+    result = await app_with_workouts.call_tool(
+        "delete_workout",
+        {"workout_id": workout_id}
+    )
+
+    # Verify
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "success"
+    assert result_data["workout_id"] == 789012
+
+
+@pytest.mark.asyncio
+async def test_delete_workout_failure(app_with_workouts, mock_garmin_client):
+    """Test delete_workout tool when deletion fails (non-200/204 status)"""
+    import json as json_module
+    from unittest.mock import MagicMock
+
+    # Setup mock for garth.delete call with error status
+    mock_response = MagicMock()
+    mock_response.status_code = 404
+    mock_garmin_client.garth.delete.return_value = mock_response
+
+    # Call tool
+    workout_id = 999999
+    result = await app_with_workouts.call_tool(
+        "delete_workout",
+        {"workout_id": workout_id}
+    )
+
+    # Verify
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "failed"
+    assert result_data["workout_id"] == 999999
+    assert result_data["http_status"] == 404
+
+
+@pytest.mark.asyncio
+async def test_delete_workout_exception(app_with_workouts, mock_garmin_client):
+    """Test delete_workout tool when an exception is raised"""
+    # Setup mock to raise exception
+    mock_garmin_client.garth.delete.side_effect = Exception("Network error")
+
+    # Call tool
+    result = await app_with_workouts.call_tool(
+        "delete_workout",
+        {"workout_id": 123456}
+    )
+
+    # Verify error is handled gracefully
+    assert result is not None
+    assert "Error deleting workout" in result[0][0].text
+
+
 # Error handling tests
 @pytest.mark.asyncio
 async def test_get_workouts_no_data(app_with_workouts, mock_garmin_client):


### PR DESCRIPTION
## Summary

Adds a `delete_workout` MCP tool that removes a workout from Garmin Connect by ID.

- Uses `DELETE /workout-service/workout/{workout_id}` endpoint
- Returns success on HTTP 200/204, failure with status code otherwise
- Follows the same pattern as the existing `upload_workout` and `download_workout` tools

## Motivation

When programmatically creating workouts via the `upload_workout` tool, there's currently no way to clean up old or duplicate workouts without going into the Garmin Connect app manually. This completes the CRUD cycle for workouts.

## Testing

Tested against the Garmin Connect API — confirmed HTTP 204 response on successful deletion.