### PR TITLE
fix: correct strength_training sportTypeId and add strength workout support

### DIFF
--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -146,20 +146,22 @@ TEMPO_RUN_TEMPLATE = {
 
 STRENGTH_CIRCUIT_TEMPLATE = {
     "workoutName": "Strength Circuit",
-    "description": "Strength training circuit: warmup, 3x circuit (work + rest), cooldown",
-    "sportType": {"sportTypeId": 4, "sportTypeKey": "strength_training"},
+    "description": "Strength training circuit: warmup, 3x(bench press 10 reps + 2min rest), 3x(pull-ups 8 reps + 2min rest), cooldown",
+    "sportType": {"sportTypeId": 5, "sportTypeKey": "strength_training"},
     "workoutSegments": [{
         "segmentOrder": 1,
-        "sportType": {"sportTypeId": 4, "sportTypeKey": "strength_training"},
+        "sportType": {"sportTypeId": 5, "sportTypeKey": "strength_training"},
         "workoutSteps": [
             {
                 "type": "ExecutableStepDTO",
                 "stepOrder": 1,
                 "stepType": {"stepTypeId": 1, "stepTypeKey": "warmup"},
                 "description": "Warmup 5 min",
-                "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
-                "endConditionValue": 300.0,
-                "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"}
+                "endCondition": {"conditionTypeId": 1, "conditionTypeKey": "lap.button"},
+                "endConditionValue": 10.0,
+                "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+                "category": "CARDIO",
+                "exerciseName": ""
             },
             {
                 "type": "RepeatGroupDTO",
@@ -170,15 +172,44 @@ STRENGTH_CIRCUIT_TEMPLATE = {
                         "type": "ExecutableStepDTO",
                         "stepOrder": 1,
                         "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
-                        "description": "Circuit work 10 min",
-                        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
-                        "endConditionValue": 600.0,
-                        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"}
+                        "description": "Bench Press 10 reps",
+                        "endCondition": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
+                        "endConditionValue": 10.0,
+                        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+                        "category": "BENCH_PRESS",
+                        "exerciseName": "BARBELL_BENCH_PRESS"
                     },
                     {
                         "type": "ExecutableStepDTO",
                         "stepOrder": 2,
-                        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+                        "stepType": {"stepTypeId": 5, "stepTypeKey": "rest"},
+                        "description": "Rest 2 min",
+                        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+                        "endConditionValue": 120.0,
+                        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"}
+                    }
+                ]
+            },
+            {
+                "type": "RepeatGroupDTO",
+                "stepOrder": 3,
+                "numberOfIterations": 3,
+                "workoutSteps": [
+                    {
+                        "type": "ExecutableStepDTO",
+                        "stepOrder": 1,
+                        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+                        "description": "Pull-ups 8 reps",
+                        "endCondition": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
+                        "endConditionValue": 8.0,
+                        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+                        "category": "PULL_UP",
+                        "exerciseName": "PULL_UP"
+                    },
+                    {
+                        "type": "ExecutableStepDTO",
+                        "stepOrder": 2,
+                        "stepType": {"stepTypeId": 5, "stepTypeKey": "rest"},
                         "description": "Rest 2 min",
                         "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
                         "endConditionValue": 120.0,
@@ -188,7 +219,7 @@ STRENGTH_CIRCUIT_TEMPLATE = {
             },
             {
                 "type": "ExecutableStepDTO",
-                "stepOrder": 3,
+                "stepOrder": 4,
                 "stepType": {"stepTypeId": 2, "stepTypeKey": "cooldown"},
                 "description": "Cooldown stretch 5 min",
                 "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
@@ -209,14 +240,17 @@ WORKOUT_STRUCTURE_REFERENCE = {
     "stepType_values": {
         "1": {"stepTypeKey": "warmup", "description": "Warmup phase"},
         "2": {"stepTypeKey": "cooldown", "description": "Cooldown phase"},
-        "3": {"stepTypeKey": "interval", "description": "Work/effort interval"},
-        "4": {"stepTypeKey": "recovery", "description": "Recovery between intervals"},
-        "5": {"stepTypeKey": "rest", "description": "Complete rest"}
+        "3": {"stepTypeKey": "interval", "description": "Work/effort interval (use for exercises in strength workouts)"},
+        "4": {"stepTypeKey": "recovery", "description": "Recovery between intervals (active recovery)"},
+        "5": {"stepTypeKey": "rest", "description": "Complete rest (use for rest between sets in strength workouts)"},
+        "6": {"stepTypeKey": "repeat", "description": "Repeat group step type (used internally by RepeatGroupDTO)"}
     },
     "endCondition_values": {
-        "1": {"conditionTypeKey": "lap.button", "description": "Manual lap press"},
+        "1": {"conditionTypeKey": "lap.button", "description": "Manual lap press (use for warmup/cooldown in strength workouts)"},
         "2": {"conditionTypeKey": "time", "description": "Duration in seconds"},
-        "3": {"conditionTypeKey": "distance", "description": "Distance in meters"}
+        "3": {"conditionTypeKey": "distance", "description": "Distance in meters"},
+        "7": {"conditionTypeKey": "iterations", "description": "Number of iterations (used internally by RepeatGroupDTO)"},
+        "10": {"conditionTypeKey": "reps", "description": "Number of repetitions (use for strength exercises)"}
     },
     "targetType_values": {
         "1": {"workoutTargetTypeKey": "no.target", "description": "No specific target"},
@@ -226,9 +260,16 @@ WORKOUT_STRUCTURE_REFERENCE = {
     "sportType_values": {
         "1": {"sportTypeKey": "running"},
         "2": {"sportTypeKey": "cycling"},
-        "4": {"sportTypeKey": "strength_training"},
-        "5": {"sportTypeKey": "cardio"},
+        "5": {"sportTypeKey": "strength_training"},
+        "6": {"sportTypeKey": "cardio"},
         "11": {"sportTypeKey": "walking"}
+    },
+    "strength_training_fields": {
+        "description": "Additional fields for strength training workout steps (ExecutableStepDTO)",
+        "category": "Exercise category (e.g., BENCH_PRESS, PULL_UP, CURL, SHOULDER_PRESS, ROW, SQUAT, DEADLIFT, TRICEPS_EXTENSION, PLANK, LUNGE, CARDIO)",
+        "exerciseName": "Specific exercise name (e.g., BARBELL_BENCH_PRESS, PULL_UP, DUMBBELL_BICEPS_CURL, DUMBBELL_SHOULDER_PRESS, BENT_OVER_ROW_WITH_DUMBELL, BODY_WEIGHT_DIP)",
+        "weightValue": "Weight value as number (e.g., 24.0)",
+        "weightUnit": "Weight unit object: {\"unitId\": 8, \"unitKey\": \"kilogram\", \"factor\": 1000.0}"
     }
 }
 

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -336,18 +336,45 @@ def register_tools(app):
         IMPORTANT: For heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
         targetValueOne/targetValueTwo are only for absolute value ranges (e.g. pace in m/s, power in watts).
 
+        IMPORTANT: Sport type IDs for workouts (different from activity API!):
+        - 1 = running, 2 = cycling, 5 = strength_training, 6 = cardio, 11 = walking
+
         **Available Templates:**
         Instead of building workout JSON from scratch, you can use these MCP resources as starting points:
         - workout://templates/simple-run - Basic warmup/run/cooldown structure
         - workout://templates/interval-running - Interval training with repeat groups
         - workout://templates/tempo-run - Tempo run with heart rate zone targets
-        - workout://templates/strength-circuit - Strength training circuit structure
+        - workout://templates/strength-circuit - Strength training with exercises, reps, rest
         - workout://reference/structure - Complete JSON structure reference with all fields
 
         Access these resources using your MCP client's resource reading capability, modify the template
         as needed, and pass the resulting JSON as the workout_data parameter.
 
-        Example workout structure with HR zone target:
+        **Strength training workouts** require these additional fields on each exercise step:
+        - "category": exercise category (e.g. "BENCH_PRESS", "PULL_UP", "CURL", "SHOULDER_PRESS",
+          "ROW", "SQUAT", "DEADLIFT", "TRICEPS_EXTENSION", "PLANK", "LUNGE", "CARDIO")
+        - "exerciseName": specific exercise (e.g. "BARBELL_BENCH_PRESS", "PULL_UP",
+          "DUMBBELL_BICEPS_CURL", "DUMBBELL_SHOULDER_PRESS", "BENT_OVER_ROW_WITH_DUMBELL",
+          "BODY_WEIGHT_DIP", "BARBELL_SQUAT", "BARBELL_DEADLIFT")
+        - "weightValue" (optional): weight as number (e.g. 24.0)
+        - "weightUnit" (optional): {"unitId": 8, "unitKey": "kilogram", "factor": 1000.0}
+        Use endCondition reps (conditionTypeId: 10) for exercises, rest (stepTypeId: 5) between sets.
+
+        Example strength exercise step:
+        {
+            "type": "ExecutableStepDTO",
+            "stepOrder": 1,
+            "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+            "endCondition": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
+            "endConditionValue": 10.0,
+            "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+            "category": "BENCH_PRESS",
+            "exerciseName": "BARBELL_BENCH_PRESS",
+            "weightValue": 60.0,
+            "weightUnit": {"unitId": 8, "unitKey": "kilogram", "factor": 1000.0}
+        }
+
+        Example running workout with HR zone target:
         {
             "workoutName": "My Workout",
             "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -104,6 +104,17 @@ def _curate_workout_step(step: dict) -> dict:
         if step.get('zoneNumber'):
             curated['target_zone'] = step.get('zoneNumber')
 
+    # Strength training exercise info
+    if step.get('category'):
+        curated['category'] = step.get('category')
+    if step.get('exerciseName'):
+        curated['exercise_name'] = step.get('exerciseName')
+    if step.get('weightValue') is not None:
+        curated['weight_value'] = step.get('weightValue')
+        weight_unit = step.get('weightUnit', {})
+        if weight_unit and weight_unit.get('unitKey'):
+            curated['weight_unit'] = weight_unit.get('unitKey')
+
     # Repeat info for repeat steps
     if step.get('type') == 'RepeatGroupDTO':
         curated['repeat_count'] = step.get('numberOfIterations')


### PR DESCRIPTION
## Summary

- **Fix `sportTypeId` for `strength_training`**: was `4` (which maps to swimming), corrected to `5` (verified by inspecting a manually-created workout from Garmin Connect)
- **Add strength-specific fields to workout reference and template**: `category`, `exerciseName`, `weightValue`, `weightUnit`, `endCondition: reps` (conditionTypeId: 10), `stepType: repeat` (6), `endCondition: iterations` (7)
- **Include strength fields in curated workout output**: `_curate_workout_step` was stripping `category`, `exerciseName`, `weightValue` and `weightUnit`, making it impossible for LLMs to inspect existing strength workouts

## How it was discovered

When uploading a strength workout via `upload_workout`, the workout was saved as **swimming** instead of strength training. After inspecting a manually-created strength workout from Garmin Connect (raw JSON via `get_workout_by_id`), the correct `sportTypeId` was found to be `5`, not `4`.

## Verification

- Uploaded a test workout with `sportTypeId: 5` → confirmed `sportTypeKey: "strength_training"` in response
- Exercise steps with `category: "BENCH_PRESS"`, `exerciseName: "BARBELL_BENCH_PRESS"`, `endCondition: reps` all work correctly
- Curated output now includes exercise info when reading back strength workouts

## Test plan

- [ ] Upload strength workout with `sportTypeId: 5` → verify sport type is `strength_training`
- [ ] Upload strength workout with `category`/`exerciseName` fields → verify exercises appear in Garmin Connect app
- [ ] Read back a strength workout via `get_workout_by_id` → verify `category` and `exercise_name` appear in response
- [ ] Verify existing running/cycling templates still work unchanged