### PR TITLE
fix: added main to fix e2e tests execution

### DIFF
--- a/src/garmin_mcp/__main__.py
+++ b/src/garmin_mcp/__main__.py
@@ -1,0 +1,3 @@
+from garmin_workouts_mcp import main
+
+main()


### PR DESCRIPTION
This is to fix the e2e tests that fail to run.

## Description of the bugfix:
The e2e tests launch the MCP server as a subprocess using `python -m garmin_mcp`. When Python runs a package with `-m`, it executes the package's `__main__.py` file. Without it, `python -m garmin_mcp` would fail with _"No module named garmin_mcp.main; 'garmin_mcp' is a package and cannot be directly executed."_

`__main__.py` acts as the entry point that calls `main()`, starting the MCP server process that the test then connects to via stdio.

## Steps to replicate:
Run in the terminal:
` uv run pytest tests/e2e/ -m e2e -v`
 
 ## Result:
```
No module named garmin_mcp.__main__; 'garmin_mcp' is a package and cannot be directly executed
 ================================================================== short test summary info =================================================================== 
FAILED tests/e2e/test_server_e2e.py::test_mcp_server_connection - McpError('Connection closed') [single exception in ExceptionGroup]
FAILED tests/e2e/test_server_e2e.py::test_list_activities_tool - McpError('Connection closed') [single exception in ExceptionGroup]
FAILED tests/e2e/test_server_e2e.py::test_get_steps_data_tool - McpError('Connection closed') [single exception in ExceptionGroup]
FAILED tests/e2e/test_server_e2e.py::test_multiple_tools - McpError('Connection closed') [single exception in ExceptionGroup]
```

