### PR TITLE
Fix: can't login - getting 429

### DIFF
--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -125,6 +125,14 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
 
     try:
         garmin = Garmin(email=email, password=password, is_cn=is_cn, prompt_mfa=get_mfa)
+        garmin.garth.sess.headers.update({
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+                "AppleWebKit/537.36 (KHTML, like Gecko) "
+                "Chrome/131.0.0.0 Safari/537.36"
+            )
+        })
+    
         garmin.login()
 
         # Save tokens to directory


### PR DESCRIPTION
https://github.com/Taxuspt/garmin_mcp/issues/63

Garmin has [made some changes around Auth](https://forums.garmin.com/apps-software/mobile-apps-web/f/garmin-connect-web/433892/tls-fingerprinting-blocks-third-party-clients) and broke Garth and https://github.com/cyberjunky/python-garminconnect/issues/332. As a result [matin ](https://github.com/matin)has deprecated the Garth project (https://github.com/matin/garth/discussions/222). This change follows [the suggestion made here](https://github.com/matin/garth/discussions/222#discussioncomment-16418591) and seems to work.


Update User-Agent header for Garmin session.
workaround Cloudflares block with user agent spoofing