### PR TITLE
feat: expose swim length data in get_activity_splits

### DIFF
--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -231,10 +231,39 @@ def register_tools(app):
                     "calories": lap.get('calories'),
                     "avg_cadence": lap.get('averageRunCadence'),
                     "avg_power_watts": lap.get('averagePower'),
+                    "avg_swim_cadence": lap.get('averageSwimCadence'),
+                    "active_length_count": lap.get('numberOfActiveLengths'),
+                    "total_strokes": lap.get('totalNumberOfStrokes'),
+                    "avg_strokes": lap.get('averageStrokes'),
+                    "avg_swolf": lap.get('averageSWOLF'),
                     "intensity_type": lap.get('intensityType'),
                     "elevation_gain_meters": lap.get('elevationGain'),
                     "elevation_loss_meters": lap.get('elevationLoss'),
                 }
+
+                length_dtos = lap.get('lengthDTOs', [])
+                if length_dtos:
+                    lap_data["lengths"] = []
+                    for length in length_dtos:
+                        length_data = {
+                            "length_number": length.get('lengthIndex'),
+                            "start_time": length.get('startTimeGMT'),
+                            "distance_meters": length.get('distance'),
+                            "duration_seconds": length.get('duration'),
+                            "avg_speed_mps": length.get('averageSpeed'),
+                            "max_speed_mps": length.get('maxSpeed'),
+                            "calories": length.get('calories'),
+                            "avg_hr_bpm": length.get('averageHR'),
+                            "max_hr_bpm": length.get('maxHR'),
+                            "total_strokes": length.get('totalNumberOfStrokes'),
+                            "avg_swolf": length.get('averageSWOLF'),
+                            "stroke": length.get('swimStroke'),
+                        }
+                        length_data = {
+                            k: v for k, v in length_data.items() if v is not None
+                        }
+                        lap_data["lengths"].append(length_data)
+
                 # Remove None values
                 lap_data = {k: v for k, v in lap_data.items() if v is not None}
                 curated["laps"].append(lap_data)

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -224,11 +224,15 @@ def register_tools(app):
                     "start_time": lap.get('startTimeGMT'),
                     "distance_meters": lap.get('distance'),
                     "duration_seconds": lap.get('duration'),
+                    "moving_duration_seconds": lap.get('movingDuration'),
+                    "elapsed_duration_seconds": lap.get('elapsedDuration'),
                     "avg_speed_mps": lap.get('averageSpeed'),
+                    "avg_moving_speed_mps": lap.get('averageMovingSpeed'),
                     "max_speed_mps": lap.get('maxSpeed'),
                     "avg_hr_bpm": lap.get('averageHR'),
                     "max_hr_bpm": lap.get('maxHR'),
                     "calories": lap.get('calories'),
+                    "bmr_calories": lap.get('bmrCalories'),
                     "avg_cadence": lap.get('averageRunCadence'),
                     "avg_power_watts": lap.get('averagePower'),
                     "avg_swim_cadence": lap.get('averageSwimCadence'),
@@ -236,9 +240,11 @@ def register_tools(app):
                     "total_strokes": lap.get('totalNumberOfStrokes'),
                     "avg_strokes": lap.get('averageStrokes'),
                     "avg_swolf": lap.get('averageSWOLF'),
+                    "avg_stroke_distance": lap.get('averageStrokeDistance'),
                     "intensity_type": lap.get('intensityType'),
                     "elevation_gain_meters": lap.get('elevationGain'),
                     "elevation_loss_meters": lap.get('elevationLoss'),
+                    "workout_step_index": lap.get('wktStepIndex'),
                 }
 
                 length_dtos = lap.get('lengthDTOs', [])

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -85,9 +85,13 @@ MOCK_SWIM_ACTIVITY_SPLITS = {
             "startTimeGMT": "2026-04-14T17:19:08.0",
             "distance": 2024.0,
             "duration": 2995.565,
+            "movingDuration": 2995.565,
+            "elapsedDuration": 2995.565,
             "averageSpeed": 0.6759999990463257,
+            "averageMovingSpeed": 0.67566553875138,
             "maxSpeed": 0.7689999938011169,
             "calories": 552.0,
+            "bmrCalories": 85.0,
             "averageHR": 136.0,
             "maxHR": 152.0,
             "averageSwimCadence": 22.0,
@@ -95,6 +99,8 @@ MOCK_SWIM_ACTIVITY_SPLITS = {
             "totalNumberOfStrokes": 1104,
             "averageStrokes": 12.0,
             "averageSWOLF": 45.0,
+            "averageStrokeDistance": 0.0,
+            "wktStepIndex": 0,
             "lengthDTOs": [
                 {
                     "lengthIndex": 1,

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -77,6 +77,58 @@ MOCK_ACTIVITY_SPLITS = {
     ]
 }
 
+MOCK_SWIM_ACTIVITY_SPLITS = {
+    "activityId": 22526515067,
+    "lapDTOs": [
+        {
+            "lapIndex": 1,
+            "startTimeGMT": "2026-04-14T17:19:08.0",
+            "distance": 2024.0,
+            "duration": 2995.565,
+            "averageSpeed": 0.6759999990463257,
+            "maxSpeed": 0.7689999938011169,
+            "calories": 552.0,
+            "averageHR": 136.0,
+            "maxHR": 152.0,
+            "averageSwimCadence": 22.0,
+            "numberOfActiveLengths": 92,
+            "totalNumberOfStrokes": 1104,
+            "averageStrokes": 12.0,
+            "averageSWOLF": 45.0,
+            "lengthDTOs": [
+                {
+                    "lengthIndex": 1,
+                    "startTimeGMT": "2026-04-14T17:19:08.0",
+                    "distance": 22.0,
+                    "duration": 31.0,
+                    "averageSpeed": 0.7099999785423279,
+                    "maxSpeed": 0.7099999785423279,
+                    "calories": 6.0,
+                    "averageHR": 121.0,
+                    "maxHR": 134.0,
+                    "totalNumberOfStrokes": 11,
+                    "averageSWOLF": 42.0,
+                    "swimStroke": "FREESTYLE",
+                },
+                {
+                    "lengthIndex": 2,
+                    "startTimeGMT": "2026-04-14T17:19:39.0",
+                    "distance": 22.0,
+                    "duration": 31.125,
+                    "averageSpeed": 0.7070000171661376,
+                    "maxSpeed": 0.7070000171661376,
+                    "calories": 6.0,
+                    "averageHR": 135.0,
+                    "maxHR": 142.0,
+                    "totalNumberOfStrokes": 12,
+                    "averageSWOLF": 43.0,
+                    "swimStroke": "FREESTYLE",
+                },
+            ],
+        }
+    ],
+}
+
 # Health & Wellness
 MOCK_STATS = {
     "totalKilocalories": 2500,

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -12,6 +12,7 @@ from tests.fixtures.garmin_responses import (
     MOCK_ACTIVITIES,
     MOCK_ACTIVITY_DETAILS,
     MOCK_ACTIVITY_SPLITS,
+    MOCK_SWIM_ACTIVITY_SPLITS,
     MOCK_ACTIVITY_COUNT,
     MOCK_ACTIVITY_TYPES,
 )
@@ -143,6 +144,33 @@ async def test_get_activity_splits_elevation_fields(app_with_activity_management
     # Second lap elevation
     assert data["laps"][1]["elevation_gain_meters"] == 15.0
     assert data["laps"][1]["elevation_loss_meters"] == 30.8
+
+
+@pytest.mark.asyncio
+async def test_get_activity_splits_includes_swim_lengths(app_with_activity_management, mock_garmin_client):
+    """Test get_activity_splits tool preserves swim lap and nested length data."""
+    import json
+
+    mock_garmin_client.get_activity_splits.return_value = MOCK_SWIM_ACTIVITY_SPLITS
+
+    result = await app_with_activity_management.call_tool(
+        "get_activity_splits",
+        {"activity_id": 22526515067}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["activity_id"] == 22526515067
+    assert data["lap_count"] == 1
+    assert data["laps"][0]["avg_swim_cadence"] == 22.0
+    assert data["laps"][0]["active_length_count"] == 92
+    assert data["laps"][0]["total_strokes"] == 1104
+    assert data["laps"][0]["avg_strokes"] == 12.0
+    assert data["laps"][0]["avg_swolf"] == 45.0
+    assert len(data["laps"][0]["lengths"]) == 2
+    assert data["laps"][0]["lengths"][0]["length_number"] == 1
+    assert data["laps"][0]["lengths"][0]["distance_meters"] == 22.0
+    assert data["laps"][0]["lengths"][0]["duration_seconds"] == 31.0
+    assert data["laps"][0]["lengths"][0]["stroke"] == "FREESTYLE"
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -166,6 +166,12 @@ async def test_get_activity_splits_includes_swim_lengths(app_with_activity_manag
     assert data["laps"][0]["total_strokes"] == 1104
     assert data["laps"][0]["avg_strokes"] == 12.0
     assert data["laps"][0]["avg_swolf"] == 45.0
+    assert data["laps"][0]["moving_duration_seconds"] == 2995.565
+    assert data["laps"][0]["elapsed_duration_seconds"] == 2995.565
+    assert data["laps"][0]["avg_moving_speed_mps"] == 0.67566553875138
+    assert data["laps"][0]["bmr_calories"] == 85.0
+    assert data["laps"][0]["avg_stroke_distance"] == 0.0
+    assert data["laps"][0]["workout_step_index"] == 0
     assert len(data["laps"][0]["lengths"]) == 2
     assert data["laps"][0]["lengths"][0]["length_number"] == 1
     assert data["laps"][0]["lengths"][0]["distance_meters"] == 22.0


### PR DESCRIPTION
## Summary
- include swim-specific lap metrics in get_activity_splits
- expose nested lengthDTOs as lengths when Garmin returns swim length data
- preserve additional Garmin lap fields such as moving/elapsed duration, moving speed, BMR calories, stroke distance, and workout step index
- add integration coverage for lap swimming responses

## Why
For lap swimming activities, the Garmin splits endpoint includes detailed lengthDTOs inside each lap, plus additional lap-level timing and stroke fields. The current MCP tool curates only a subset of the outer lap fields, so callers lose part of the structured swim breakdown even though Garmin returns it.

This change keeps the existing lap payload intact for other activity types and only adds the extra swim data when it is present in the Garmin response.

## Example
A lap-swimming response can now include swim-specific lap metrics, additional lap timing data, and nested lengths, for example:

```json
{
  "activity_id": 22526515067,
  "lap_count": 1,
  "laps": [
    {
      "lap_number": 1,
      "distance_meters": 2024.0,
      "duration_seconds": 2995.565,
      "moving_duration_seconds": 2995.565,
      "elapsed_duration_seconds": 2995.565,
      "avg_speed_mps": 0.6759999990463257,
      "avg_moving_speed_mps": 0.67566553875138,
      "avg_hr_bpm": 136.0,
      "bmr_calories": 85.0,
      "avg_swim_cadence": 22.0,
      "active_length_count": 92,
      "total_strokes": 1104,
      "avg_strokes": 12.0,
      "avg_swolf": 45.0,
      "avg_stroke_distance": 0.0,
      "workout_step_index": 0,
      "lengths": [
        {
          "length_number": 1,
          "distance_meters": 22.0,
          "duration_seconds": 31.0,
          "avg_hr_bpm": 121.0,
          "total_strokes": 11,
          "avg_swolf": 42.0,
          "stroke": "FREESTYLE"
        }
      ]
    }
  ]
}
```

Non-swim activities keep the existing lap-only shape.

## Testing
- uv run pytest tests/integration tests/unit -v --tb=short --strict-markers --maxfail=5
- uv lock --check
