### PR TITLE
feat: add cycling FTP training tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,17 +13,18 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 - Access health metrics (steps, heart rate, sleep, stress, respiration)
 - View body composition data
 - Track training status and readiness
+- Access cycling FTP and lactate threshold metrics
 - Manage gear and equipment
 - Access workouts and training plans
 - Weekly health aggregates (steps, stress, intensity minutes)
 
 ### Tool Coverage
 
-This MCP server implements **96+ tools** covering ~89% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.2.38):
+This MCP server implements **97+ tools** covering ~89% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.2.38):
 
 - ✅ Activity Management (14 tools)
 - ✅ Health & Wellness (31 tools) - includes custom lightweight summary tools
-- ✅ Training & Performance (9 tools)
+- ✅ Training & Performance (10 tools)
 - ✅ Workouts (8 tools)
 - ✅ Devices (7 tools)
 - ✅ Gear Management (5 tools)

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -553,6 +553,34 @@ def register_tools(app):
             return f"Error retrieving training status data: {str(e)}"
 
     @app.tool()
+    async def get_cycling_ftp() -> str:
+        """Get the latest cycling Functional Threshold Power (FTP) data.
+
+        Returns the most recent cycling FTP estimate available from Garmin.
+        """
+        try:
+            ftp_data = garmin_client.get_cycling_ftp()
+
+            if not ftp_data:
+                return "No cycling FTP data found"
+
+            curated = {
+                "sport": ftp_data.get("sport"),
+                "functional_threshold_power_watts": ftp_data.get(
+                    "functionalThresholdPower"
+                ),
+                "calendar_date": ftp_data.get("calendarDate"),
+                "is_stale": ftp_data.get("isStale"),
+                "biometric_source_type": ftp_data.get("biometricSourceType"),
+            }
+
+            curated = {k: v for k, v in curated.items() if v is not None}
+
+            return json.dumps(curated, indent=2)
+        except Exception as e:
+            return f"Error retrieving cycling FTP data: {str(e)}"
+
+    @app.tool()
     async def get_lactate_threshold(
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -810,3 +810,14 @@ MOCK_LACTATE_THRESHOLD_RANGE = {
         {"from": "2024-01-15", "until": "2024-01-15", "series": "running", "value": 334.0, "updatedDate": "2024-01-15"},
     ],
 }
+
+MOCK_CYCLING_FTP = {
+    "userProfilePK": 12345678,
+    "version": 1710498600000,
+    "calendarDate": "2024-03-15T10:30:00.000",
+    "isStale": False,
+    "sequence": 1710498600000,
+    "sport": "CYCLING",
+    "functionalThresholdPower": 294,
+    "biometricSourceType": "CHANGE_LOG",
+}

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -1,7 +1,7 @@
 """
 Integration tests for training module MCP tools
 
-Tests all 8 training tools using FastMCP integration with mocked Garmin API responses.
+Tests training tools using FastMCP integration with mocked Garmin API responses.
 """
 import pytest
 from unittest.mock import Mock
@@ -16,6 +16,7 @@ from tests.fixtures.garmin_responses import (
     MOCK_TRAINING_STATUS,
     MOCK_LACTATE_THRESHOLD,
     MOCK_LACTATE_THRESHOLD_RANGE,
+    MOCK_CYCLING_FTP,
     MOCK_ENDURANCE_SCORE,
     MOCK_ACTIVITY_TYPES,
 )
@@ -206,6 +207,24 @@ async def test_get_fitnessage_data_tool(app_with_training, mock_garmin_client):
     # Verify
     assert result is not None
     mock_garmin_client.get_fitnessage_data.assert_called_once_with("2024-01-15")
+
+
+@pytest.mark.asyncio
+async def test_get_cycling_ftp_tool(app_with_training, mock_garmin_client):
+    """Test get_cycling_ftp tool returns latest FTP data"""
+    mock_garmin_client.get_cycling_ftp.return_value = MOCK_CYCLING_FTP
+
+    result = await app_with_training.call_tool("get_cycling_ftp", {})
+
+    assert result is not None
+    mock_garmin_client.get_cycling_ftp.assert_called_once_with()
+
+    data = json.loads(result[0][0].text)
+    assert data["sport"] == "CYCLING"
+    assert data["functional_threshold_power_watts"] == 294
+    assert data["calendar_date"] == "2024-03-15T10:30:00.000"
+    assert data["is_stale"] is False
+    assert data["biometric_source_type"] == "CHANGE_LOG"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- add a dedicated `get_cycling_ftp()` MCP tool in `training.py`
- expose the latest cycling FTP data already available via `python-garminconnect`
- add integration test coverage and a small README update

## Why this approach
The underlying library already exposes `get_cycling_ftp()` as a dedicated method backed by Garmin's `/biometric-service/biometric/latestFunctionalThresholdPower/CYCLING` endpoint.

Surfacing that method directly in the MCP server is the smallest and most explicit fix for cyclists who currently cannot access FTP through MCP.

This also avoids overloading `get_lactate_threshold()` with sport-specific branching and ignored parameters. `get_lactate_threshold()` is currently running-oriented and supports date-range queries; `get_cycling_ftp()` is latest-only in the upstream library, so keeping it as a separate tool preserves a clean contract.

## Notes
- Verified against a real Garmin account that the upstream `get_cycling_ftp()` response includes `functionalThresholdPower`, `calendarDate`, `sport`, `isStale`, and `biometricSourceType`.
- Garmin's raw API appears to support historical cycling FTP as well, but the current upstream `python-garminconnect` helper only exposes the latest value. That can be added in a future upstream/library follow-up without changing this MCP tool contract.

## Testing
- `uv run pytest tests/integration/test_training_tools.py -q`
- `uv run pytest tests/integration tests/unit -v --tb=short --strict-markers --maxfail=5`
- `uv lock --check`

Closes #68
Closes #57
