### PR TITLE
fix: swap argument order in add/remove_gear_to_activity

### DIFF
--- a/src/garmin_mcp/gear_management.py
+++ b/src/garmin_mcp/gear_management.py
@@ -164,7 +164,7 @@ def register_tools(app):
             gear_uuid: UUID of the gear to add (get from get_gear)
         """
         try:
-            garmin_client.add_gear_to_activity(activity_id, gear_uuid)
+            garmin_client.add_gear_to_activity(gear_uuid, activity_id)
 
             return json.dumps(
                 {
@@ -189,7 +189,7 @@ def register_tools(app):
             gear_uuid: UUID of the gear to remove
         """
         try:
-            garmin_client.remove_gear_from_activity(activity_id, gear_uuid)
+            garmin_client.remove_gear_from_activity(gear_uuid, activity_id)
 
             return json.dumps(
                 {


### PR DESCRIPTION
## Summary

Fixes the swapped argument order in `add_gear_to_activity` and `remove_gear_from_activity` calls to the underlying `python-garminconnect` library.

The library's signatures are:
- `add_gear_to_activity(gearUUID, activity_id)`
- `remove_gear_from_activity(gearUUID, activity_id)`

But the MCP tools were passing `(activity_id, gear_uuid)`, causing a `ValueError` when the library tries to convert the UUID string to an integer.

## Changes

- `gear_management.py`: Swap argument order in both `add_gear_to_activity` and `remove_gear_from_activity` calls

Fixes #56