### PR TITLE
feat: add set_activity_name tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 
 - List recent activities with pagination support
 - Get detailed activity information
+- Manage activity names
 - Access health metrics (steps, heart rate, sleep, stress, respiration)
 - View body composition data
 - Track training status and readiness

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -198,6 +198,33 @@ def register_tools(app):
             return f"Error retrieving activity: {str(e)}"
 
     @app.tool()
+    async def set_activity_name(activity_id: int, activity_name: str) -> str:
+        """Set or update the name of an activity.
+
+        Args:
+            activity_id: ID of the activity to update
+            activity_name: New activity name
+        """
+        try:
+            activity_name = activity_name.strip()
+            if not activity_name:
+                return "Activity name cannot be empty"
+
+            garmin_client.set_activity_name(activity_id, activity_name)
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "activity_id": activity_id,
+                    "activity_name": activity_name,
+                    "message": "Activity name successfully updated",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error updating activity name: {str(e)}"
+
+    @app.tool()
     async def get_activity_splits(activity_id: int) -> str:
         """Get splits for an activity
 

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -1,8 +1,9 @@
 """
 Integration tests for activity_management module MCP tools
 
-Tests all 10 activity management tools using FastMCP integration with mocked Garmin API responses.
+Tests activity management tools using FastMCP integration with mocked Garmin API responses.
 """
+import json
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
@@ -96,6 +97,43 @@ async def test_get_activity_tool(app_with_activity_management, mock_garmin_clien
     # Verify
     assert result is not None
     mock_garmin_client.get_activity.assert_called_once_with(activity_id)
+
+
+@pytest.mark.asyncio
+async def test_set_activity_name_tool(app_with_activity_management, mock_garmin_client):
+    """Test set_activity_name tool updates activity name"""
+    activity_id = 12345678901
+    mock_garmin_client.set_activity_name.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_name",
+        {"activity_id": activity_id, "activity_name": "Morning Run - Easy"},
+    )
+
+    assert result is not None
+    mock_garmin_client.set_activity_name.assert_called_once_with(
+        activity_id, "Morning Run - Easy"
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert data["activity_id"] == activity_id
+    assert data["activity_name"] == "Morning Run - Easy"
+
+
+@pytest.mark.asyncio
+async def test_set_activity_name_tool_rejects_blank_name(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_activity_name tool rejects blank names"""
+    result = await app_with_activity_management.call_tool(
+        "set_activity_name",
+        {"activity_id": 12345678901, "activity_name": "   "},
+    )
+
+    assert result is not None
+    mock_garmin_client.set_activity_name.assert_not_called()
+    assert result[0][0].text == "Activity name cannot be empty"
 
 
 @pytest.mark.asyncio
@@ -398,3 +436,17 @@ async def test_get_activity_not_found(app_with_activity_management, mock_garmin_
     # Verify helpful message is returned
     assert result is not None
     # Should indicate activity not found
+
+
+@pytest.mark.asyncio
+async def test_set_activity_name_exception(app_with_activity_management, mock_garmin_client):
+    """Test set_activity_name tool when API raises exception"""
+    mock_garmin_client.set_activity_name.side_effect = Exception("API Error")
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_name",
+        {"activity_id": 12345678901, "activity_name": "Morning Run"},
+    )
+
+    assert result is not None
+    assert result[0][0].text == "Error updating activity name: API Error"


### PR DESCRIPTION
## Summary
- add a dedicated `set_activity_name()` activity management tool
- expose the upstream `python-garminconnect` `set_activity_name` capability through MCP
- return a small curated success payload for activity rename operations
- reject empty or whitespace-only names before calling Garmin
- add integration test coverage for success, validation, and exception handling

## Why
Issue #87 asks for MCP support to rename activities so clients can batch/standardize names. The upstream Garmin library already supports this via `set_activity_name`, so this is a small and direct MCP surface addition.

The tool is intentionally single-activity. Bulk renaming can be orchestrated by the MCP client/agent on top of this primitive without adding a separate bulk API.

## Testing
- `uv run pytest tests/integration/test_activity_management_tools.py -q`
- `uv run pytest tests/integration tests/unit -v --tb=short --strict-markers --maxfail=5`
- `uv lock --check`

Closes #87
