### PR TITLE
fix: handle swim workout targets in get_workout_by_id

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 - Track training status and readiness
 - Manage gear and equipment
 - Access workouts and training plans
+- Inspect detailed workout step structures, including repeat groups and swim pace targets
 - Weekly health aggregates (steps, stress, intensity minutes)
 
 ### Tool Coverage

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -81,7 +81,9 @@ def _curate_step_target(
     prefix: str = "",
 ) -> None:
     """Curate a workout target block, handling Garmin null target payloads safely."""
-    target_type = step.get(target_field) or {}
+    target_type = step.get(target_field)
+    if not isinstance(target_type, dict):
+        target_type = {}
     target_key = target_type.get('workoutTargetTypeKey')
 
     if not target_key or target_key == 'no.target':

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -71,11 +71,36 @@ def _curate_workout_summary(workout: dict) -> dict:
     return {k: v for k, v in summary.items() if v is not None}
 
 
+def _curate_step_target(
+    curated: dict,
+    step: dict,
+    target_field: str,
+    value_one_field: str,
+    value_two_field: str,
+    zone_field: str,
+    prefix: str = "",
+) -> None:
+    """Curate a workout target block, handling Garmin null target payloads safely."""
+    target_type = step.get(target_field) or {}
+    target_key = target_type.get('workoutTargetTypeKey')
+
+    if not target_key or target_key == 'no.target':
+        return
+
+    curated[f'{prefix}target_type'] = target_key
+
+    if step.get(value_one_field) is not None:
+        curated[f'{prefix}target_value_low'] = step.get(value_one_field)
+    if step.get(value_two_field) is not None:
+        curated[f'{prefix}target_value_high'] = step.get(value_two_field)
+    if step.get(zone_field) is not None:
+        curated[f'{prefix}target_zone'] = step.get(zone_field)
+
+
 def _curate_workout_step(step: dict) -> dict:
     """Extract essential workout step information"""
-    step_type = step.get('stepType', {})
-    end_condition = step.get('endCondition', {})
-    target_type = step.get('targetType', {})
+    step_type = step.get('stepType') or {}
+    end_condition = step.get('endCondition') or {}
 
     curated = {
         "order": step.get('stepOrder'),
@@ -93,20 +118,34 @@ def _curate_workout_step(step: dict) -> dict:
         # Value meaning depends on condition type (seconds for time, meters for distance)
         curated['end_condition_value'] = step.get('endConditionValue')
 
-    # Target (heart rate, pace, power, etc.)
-    target_key = target_type.get('workoutTargetTypeKey')
-    if target_key and target_key != 'no.target':
-        curated['target_type'] = target_key
-        if step.get('targetValueOne'):
-            curated['target_value_low'] = step.get('targetValueOne')
-        if step.get('targetValueTwo'):
-            curated['target_value_high'] = step.get('targetValueTwo')
-        if step.get('zoneNumber'):
-            curated['target_zone'] = step.get('zoneNumber')
+    # Primary target (heart rate, pace, power, etc.)
+    _curate_step_target(
+        curated,
+        step,
+        target_field='targetType',
+        value_one_field='targetValueOne',
+        value_two_field='targetValueTwo',
+        zone_field='zoneNumber',
+    )
+
+    # Swim workouts often store pace prescriptions as secondary targets.
+    _curate_step_target(
+        curated,
+        step,
+        target_field='secondaryTargetType',
+        value_one_field='secondaryTargetValueOne',
+        value_two_field='secondaryTargetValueTwo',
+        zone_field='secondaryZoneNumber',
+        prefix='secondary_',
+    )
 
     # Repeat info for repeat steps
     if step.get('type') == 'RepeatGroupDTO':
         curated['repeat_count'] = step.get('numberOfIterations')
+        nested_steps = step.get('workoutSteps', [])
+        if nested_steps:
+            curated['steps'] = [_curate_workout_step(s) for s in nested_steps]
+            curated['step_count'] = len(nested_steps)
 
     return {k: v for k, v in curated.items() if v is not None}
 

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -623,6 +623,74 @@ MOCK_WORKOUT_DETAILS = {
     ]
 }
 
+MOCK_SWIM_WORKOUT_DETAILS = {
+    "workoutId": 1528077786,
+    "workoutName": "Long Swim - intermittent 1000m",
+    "description": "Example swim workout with Garmin secondary pace targets",
+    "sportType": {"sportTypeId": 4, "sportTypeKey": "swimming"},
+    "estimatedDistanceInMeters": 3000.0,
+    "createdDate": "2026-04-06T12:37:29.0",
+    "updatedDate": "2026-04-07T09:59:49.0",
+    "workoutSegments": [
+        {
+            "segmentOrder": 1,
+            "sportType": {"sportTypeId": 4, "sportTypeKey": "swimming"},
+            "workoutSteps": [
+                {
+                    "type": "ExecutableStepDTO",
+                    "stepId": 12984228432,
+                    "stepOrder": 1,
+                    "stepType": {"stepTypeId": 1, "stepTypeKey": "warmup"},
+                    "description": "2:24-3:42/100m",
+                    "endCondition": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
+                    "endConditionValue": 500.0,
+                    "targetType": None,
+                    "secondaryTargetType": {
+                        "workoutTargetTypeId": 6,
+                        "workoutTargetTypeKey": "pace.zone",
+                    },
+                    "secondaryTargetValueOne": 0.45,
+                    "secondaryTargetValueTwo": 0.6916667,
+                },
+                {
+                    "type": "RepeatGroupDTO",
+                    "stepId": 12984228433,
+                    "stepOrder": 2,
+                    "stepType": {"stepTypeId": 6, "stepTypeKey": "repeat"},
+                    "numberOfIterations": 2,
+                    "workoutSteps": [
+                        {
+                            "type": "ExecutableStepDTO",
+                            "stepId": 12984228434,
+                            "stepOrder": 3,
+                            "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+                            "description": "1:56-2:09/100m",
+                            "endCondition": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
+                            "endConditionValue": 1000.0,
+                            "targetType": None,
+                            "secondaryTargetType": {
+                                "workoutTargetTypeId": 6,
+                                "workoutTargetTypeKey": "pace.zone",
+                            },
+                            "secondaryTargetValueOne": 0.7751938,
+                            "secondaryTargetValueTwo": 0.8583333,
+                        },
+                        {
+                            "type": "ExecutableStepDTO",
+                            "stepId": 12984228435,
+                            "stepOrder": 4,
+                            "stepType": {"stepTypeId": 5, "stepTypeKey": "rest"},
+                            "endCondition": {"conditionTypeId": 8, "conditionTypeKey": "fixed.rest"},
+                            "endConditionValue": 60.0,
+                            "targetType": None,
+                        },
+                    ],
+                },
+            ],
+        }
+    ],
+}
+
 # Women's Health
 MOCK_MENSTRUAL_DATA = {
     "calendarDate": "2024-01-15",

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -11,6 +11,7 @@ from garmin_mcp import workouts
 from tests.fixtures.garmin_responses import (
     MOCK_WORKOUTS,
     MOCK_WORKOUT_DETAILS,
+    MOCK_SWIM_WORKOUT_DETAILS,
 )
 
 
@@ -82,6 +83,52 @@ async def test_get_workout_by_id_tool(app_with_workouts, mock_garmin_client):
     assert interval_step["type"] == "interval"
     assert interval_step["target_type"] == "pace.zone"
     assert interval_step["target_zone"] == 4
+
+
+@pytest.mark.asyncio
+async def test_get_workout_by_id_tool_handles_swim_secondary_targets(
+    app_with_workouts, mock_garmin_client
+):
+    """Test swim workouts with null primary targetType still expose secondary pace targets."""
+    import json as json_module
+
+    mock_garmin_client.get_workout_by_id.return_value = MOCK_SWIM_WORKOUT_DETAILS
+
+    result = await app_with_workouts.call_tool(
+        "get_workout_by_id",
+        {"workout_id": 1528077786}
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["id"] == 1528077786
+    assert result_data["sport"] == "swimming"
+    assert result_data["estimated_distance_meters"] == 3000.0
+
+    segment = result_data["segments"][0]
+    assert segment["step_count"] == 2
+
+    warmup_step = segment["steps"][0]
+    assert warmup_step["type"] == "warmup"
+    assert warmup_step["secondary_target_type"] == "pace.zone"
+    assert warmup_step["secondary_target_value_low"] == 0.45
+    assert warmup_step["secondary_target_value_high"] == 0.6916667
+    assert "target_type" not in warmup_step
+
+    repeat_step = segment["steps"][1]
+    assert repeat_step["type"] == "repeat"
+    assert repeat_step["repeat_count"] == 2
+    assert repeat_step["step_count"] == 2
+
+    interval_step = repeat_step["steps"][0]
+    assert interval_step["type"] == "interval"
+    assert interval_step["secondary_target_type"] == "pace.zone"
+    assert interval_step["secondary_target_value_low"] == 0.7751938
+    assert interval_step["secondary_target_value_high"] == 0.8583333
+
+    rest_step = repeat_step["steps"][1]
+    assert rest_step["type"] == "rest"
+    assert rest_step["end_condition"] == "fixed.rest"
+    assert rest_step["end_condition_value"] == 60.0
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -132,6 +132,47 @@ async def test_get_workout_by_id_tool_handles_swim_secondary_targets(
 
 
 @pytest.mark.asyncio
+async def test_get_workout_by_id_tool_ignores_malformed_target_blocks(
+    app_with_workouts, mock_garmin_client
+):
+    """Test malformed Garmin target blocks do not crash workout curation."""
+    import json as json_module
+
+    malformed_workout = {
+        "workoutId": 123457,
+        "workoutName": "Malformed Swim Workout",
+        "sportType": {"sportTypeId": 4, "sportTypeKey": "swimming"},
+        "workoutSegments": [{
+            "segmentOrder": 1,
+            "sportType": {"sportTypeId": 4, "sportTypeKey": "swimming"},
+            "workoutSteps": [{
+                "type": "ExecutableStepDTO",
+                "stepOrder": 1,
+                "stepType": {"stepTypeId": 1, "stepTypeKey": "warmup"},
+                "endCondition": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
+                "endConditionValue": 100.0,
+                "targetType": "pace.zone",
+                "secondaryTargetType": [],
+            }]
+        }],
+    }
+    mock_garmin_client.get_workout_by_id.return_value = malformed_workout
+
+    result = await app_with_workouts.call_tool(
+        "get_workout_by_id",
+        {"workout_id": 123457}
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    step = result_data["segments"][0]["steps"][0]
+    assert step["type"] == "warmup"
+    assert step["end_condition"] == "distance"
+    assert step["end_condition_value"] == 100.0
+    assert "target_type" not in step
+    assert "secondary_target_type" not in step
+
+
+@pytest.mark.asyncio
 async def test_get_workout_by_uuid_tool(app_with_workouts, mock_garmin_client):
     """Test get_workout_by_id tool with UUID (training plan workout)"""
     import json as json_module


### PR DESCRIPTION
## Summary

This fixes `get_workout_by_id()` for swim workouts whose Garmin payload uses `targetType: null` and stores the actual pace prescription in `secondaryTargetType` / `secondaryTargetValueOne` / `secondaryTargetValueTwo`.

It also preserves the detailed structure of repeat groups so the nested swim interval/rest steps remain visible in the curated MCP response.

In addition, the target-block curation is now type-safe for malformed Garmin payloads, not just null-safe.

Closes #89.

## Reproduction

This bug can be reproduced with a minimal Garmin workout payload like this:

```json
{
  "workoutId": 1528077786,
  "workoutName": "Long Swim - intermittent 1000m",
  "sportType": {"sportTypeId": 4, "sportTypeKey": "swimming"},
  "estimatedDistanceInMeters": 3000.0,
  "workoutSegments": [
    {
      "segmentOrder": 1,
      "sportType": {"sportTypeId": 4, "sportTypeKey": "swimming"},
      "workoutSteps": [
        {
          "type": "ExecutableStepDTO",
          "stepOrder": 1,
          "stepType": {"stepTypeId": 1, "stepTypeKey": "warmup"},
          "description": "2:24-3:42/100m",
          "endCondition": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
          "endConditionValue": 500.0,
          "targetType": null,
          "secondaryTargetType": {"workoutTargetTypeKey": "pace.zone"},
          "secondaryTargetValueOne": 0.45,
          "secondaryTargetValueTwo": 0.6916667
        }
      ]
    }
  ]
}
```

Before this change, the curation path called `.get()` on `targetType` directly and failed with:

```text
Error retrieving workout: 'NoneType' object has no attribute 'get'
```

A repo-local repro is also included in the regression test fixture added in this PR:
- `tests/fixtures/garmin_responses.py::MOCK_SWIM_WORKOUT_DETAILS`
- `tests/integration/test_workouts_tools.py::test_get_workout_by_id_tool_handles_swim_secondary_targets`

## Root Cause

The workout curation path assumed `step["targetType"]` was always a dict and called `.get()` on it directly.

For these swim workouts, Garmin returns:
- `targetType: null`
- the actual pace target under `secondaryTargetType`
- interval blocks nested inside a `RepeatGroupDTO`

That caused two problems:
- the tool crashed on `None`
- even after avoiding the crash, the meaningful swim pace targets and nested repeat steps would still be hidden

There was also a more general robustness gap: malformed non-dict target blocks would still have been able to crash the formatter.

## What Changed

- made workout target curation null-safe and type-safe for Garmin target blocks
- added support for curated `secondary_target_*` fields
- preserved nested repeat-group steps in the curated workout output
- added a regression fixture and integration test that matches the failing swim payload shape
- added an extra regression test for malformed non-dict target blocks
- documented the improved workout-step coverage in the README

## Example

A swim warmup step like:

```json
{
  "targetType": null,
  "secondaryTargetType": {"workoutTargetTypeKey": "pace.zone"},
  "secondaryTargetValueOne": 0.45,
  "secondaryTargetValueTwo": 0.6916667
}
```

is now exposed as curated output like:

```json
{
  "type": "warmup",
  "secondary_target_type": "pace.zone",
  "secondary_target_value_low": 0.45,
  "secondary_target_value_high": 0.6916667
}
```

Repeat groups now also retain their nested steps in the MCP response.

## Testing

- `uv run pytest tests/integration/test_workouts_tools.py -q`
- `uv run pytest tests/integration tests/unit -v --tb=short --strict-markers --maxfail=5`
- `uv lock --check`
