### PR TITLE
fix: correct sport type ID reference (4, 5, 11 were wrong) and expand to full validated map

### DIFF
--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -226,9 +226,16 @@ WORKOUT_STRUCTURE_REFERENCE = {
     "sportType_values": {
         "1": {"sportTypeKey": "running"},
         "2": {"sportTypeKey": "cycling"},
+        "3": {"sportTypeKey": "other"},
         "4": {"sportTypeKey": "lap_swimming"},
         "5": {"sportTypeKey": "strength_training"},
-        "11": {"sportTypeKey": "walking"}
+        "6": {"sportTypeKey": "cardio_training"},
+        "7": {"sportTypeKey": "yoga"},
+        "8": {"sportTypeKey": "pilates"},
+        "9": {"sportTypeKey": "hiit"},
+        "11": {"sportTypeKey": "mobility"},
+        "12": {"sportTypeKey": "walking"},
+        "13": {"sportTypeKey": "rucking"}
     }
 }
 

--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -147,10 +147,10 @@ TEMPO_RUN_TEMPLATE = {
 STRENGTH_CIRCUIT_TEMPLATE = {
     "workoutName": "Strength Circuit",
     "description": "Strength training circuit: warmup, 3x circuit (work + rest), cooldown",
-    "sportType": {"sportTypeId": 4, "sportTypeKey": "strength_training"},
+    "sportType": {"sportTypeId": 5, "sportTypeKey": "strength_training"},
     "workoutSegments": [{
         "segmentOrder": 1,
-        "sportType": {"sportTypeId": 4, "sportTypeKey": "strength_training"},
+        "sportType": {"sportTypeId": 5, "sportTypeKey": "strength_training"},
         "workoutSteps": [
             {
                 "type": "ExecutableStepDTO",
@@ -226,8 +226,8 @@ WORKOUT_STRUCTURE_REFERENCE = {
     "sportType_values": {
         "1": {"sportTypeKey": "running"},
         "2": {"sportTypeKey": "cycling"},
-        "4": {"sportTypeKey": "strength_training"},
-        "5": {"sportTypeKey": "cardio"},
+        "4": {"sportTypeKey": "lap_swimming"},
+        "5": {"sportTypeKey": "strength_training"},
         "11": {"sportTypeKey": "walking"}
     }
 }


### PR DESCRIPTION
## Summary

Two corrections in `src/garmin_mcp/workout_templates.py`:

1. **`STRENGTH_CIRCUIT_TEMPLATE`** had `sportTypeId: 4` for strength_training, but Garmin Connect treats `sportTypeId: 4` as `lap_swimming`. Strength is `sportTypeId: 5`. Fixed (both `sportType` occurrences).
2. **`WORKOUT_STRUCTURE_REFERENCE.sportType_values`** had `4: strength_training, 5: cardio, 11: walking`. All three were wrong. Replaced with the empirically validated full mapping.

## How this surfaced

A strength workout uploaded via the template (`sportTypeId: 4 + sportTypeKey: \"strength_training\"`) rendered in Garmin Connect as **Pool Swim**. Re-uploading with `sportTypeId: 5` rendered correctly as Strength.

## Methodology for the full map

Rather than ship a partial fix, I validated every plausible workout sport type empirically:

1. Upload a one-step test workout at each candidate `sportTypeId` (1–25) with a placeholder `sportTypeKey: \"test\"`.
2. Call the workouts list endpoint and read back the `sport` field.
3. Garmin canonicalises by ID and ignores the key sent in — so the returned `sport` is the authoritative `sportTypeKey` for that ID.
4. Delete the test workouts.

## Findings

- Valid workout `sportTypeId`s are 1–13 **excluding 10** (which returns HTTP 400 on upload).
- IDs 14–25 upload \"successfully\" but the list endpoint returns no `sport` field — silently invalid.
- The previous reference's `5: cardio` was wrong (5 is strength_training). `11: walking` was wrong (11 is mobility, walking is 12).

## Validated mapping (now in the PR)

| ID | sportTypeKey |
|---|---|
| 1 | running |
| 2 | cycling |
| 3 | other |
| 4 | lap_swimming |
| 5 | strength_training |
| 6 | cardio_training |
| 7 | yoga |
| 8 | pilates |
| 9 | hiit |
| 11 | mobility |
| 12 | walking |
| 13 | rucking |