### PR TITLE
feat: improve nutrition tools with upsert, delete, and UX fixes (#76)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,5 +27,3 @@ dev-dependencies = [
     "pytest-timeout>=2.3.1",
 ]
 
-[tool.uv.sources]
-garmin-mcp = { workspace = true }

--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -3,6 +3,8 @@ Nutrition/food logging functions for Garmin Connect MCP Server
 """
 import json
 from typing import Optional
+from urllib.parse import quote
+
 from garminconnect import GarminConnectConnectionError
 
 # The garmin_client will be set by the main file
@@ -92,18 +94,19 @@ def register_tools(app):
     ) -> str:
         """Search or list user's custom foods
 
-        Returns custom foods the user has created, with optional search
-        filtering. Use this to find foodId and servingId for logging.
+        Returns custom foods the user has created. Use the search parameter
+        to find existing foods by name before creating duplicates — the
+        response includes foodId and servingId needed for log_custom_food.
 
         Args:
-            search: Optional search expression to filter foods
+            search: Search term to filter foods by name (default: list all)
             start: Starting index for pagination (default 0)
             limit: Maximum number of results (default 20)
         """
         try:
             url = (
                 f"/nutrition-service/customFood"
-                f"?searchExpression={search}"
+                f"?searchExpression={quote(search)}"
                 f"&start={start}&limit={limit}"
                 f"&includeContent=true"
             )
@@ -149,7 +152,9 @@ def register_tools(app):
         """Create a custom food in the user's Garmin nutrition library
 
         Creates a new food item with nutritional information per serving.
-        The response includes foodId and servingId needed for logging.
+        On success the response includes foodId and servingId needed for
+        log_custom_food. If the API returns no data (204), use
+        get_custom_foods(search=food_name) to retrieve those IDs.
 
         Args:
             food_name: Name of the custom food (e.g. "Homemade Chocolate Cookies")
@@ -302,30 +307,50 @@ def register_tools(app):
             return f"Error updating custom food: {str(e)}"
 
     @app.tool()
-    async def log_food(
+    async def log_custom_food(
         meal_date: str,
         meal_time: str,
-        meal_id: int,
         food_id: str,
         serving_id: str,
         serving_qty: float = 1,
     ) -> str:
-        """Log a food item to a specific meal on a date
+        """Log a custom food item to a meal on a date
 
-        Adds a food entry to the user's nutrition log. Requires IDs
-        from the meals endpoint (mealId) and from custom/searched
-        foods (foodId, servingId).
+        Adds a food entry from the user's custom food library to the nutrition
+        log. The meal is determined automatically by matching meal_time against
+        each meal's startTime/endTime window; falls back to SNACKS if no window
+        matches.
+
+        Use get_custom_foods (with the search parameter) to find existing foods
+        and retrieve their foodId and servingId. Alternatively, create a new
+        food with create_custom_food first.
 
         Args:
             meal_date: Date in YYYY-MM-DD format
-            meal_time: Time in HH:MM:SS format (e.g. "12:30:00")
-            meal_id: Meal ID from get_nutrition_daily_meals
-            food_id: Food ID from create_custom_food or get_custom_foods
-            serving_id: Serving ID from create_custom_food or get_custom_foods
+            meal_time: Time in HH:MM:SS format (e.g. "12:30:00", account timezone)
+            food_id: Food ID from get_custom_foods or create_custom_food
+            serving_id: Serving ID from get_custom_foods or create_custom_food
             serving_qty: Number of servings (default 1)
         """
         try:
             from datetime import datetime, timezone
+
+            meals_url = f"/nutrition-service/meals/{meal_date}"
+            meals_data = garmin_client.connectapi(meals_url)
+            meals = (meals_data or {}).get("meals", [])
+
+            meal_id = None
+            for m in meals:
+                start = m.get("startTime")
+                end = m.get("endTime")
+                if start and end and start <= meal_time <= end:
+                    meal_id = m["mealId"]
+                    break
+            if meal_id is None:
+                snacks = next((m for m in meals if m.get("mealName") == "SNACKS"), None)
+                if snacks is None:
+                    return f"Error logging food: could not match meal for time '{meal_time}' and no SNACKS meal found."
+                meal_id = snacks["mealId"]
 
             log_timestamp = datetime.now(timezone.utc).strftime(
                 "%Y-%m-%dT%H:%M:%S.000Z"
@@ -363,5 +388,274 @@ def register_tools(app):
             return f"Error logging food: {e} | Response: {body}"
         except Exception as e:
             return f"Error logging food: {str(e)}"
+
+    @app.tool()
+    async def log_food(
+        meal_date: str,
+        meal_time: str,
+        name: str,
+        calories: float,
+        carbs: float,
+        protein: float,
+        fat: float,
+    ) -> str:
+        """Quick-add a food entry with macro values to the nutrition log
+
+        Logs food directly by name and macros without requiring a food ID.
+        Uses Garmin's Quick Add feature. The meal is determined automatically
+        by matching meal_time against each meal's startTime/endTime window;
+        falls back to SNACKS if no window matches.
+
+        Args:
+            meal_date: Date in YYYY-MM-DD format
+            name: Display name for the food entry
+            calories: Calories (kcal)
+            carbs: Carbohydrates in grams
+            protein: Protein in grams
+            fat: Fat in grams
+            meal_time: Time in HH:MM:SS format (account timezone)
+        """
+        try:
+            from datetime import datetime, timezone
+
+            meals_url = f"/nutrition-service/meals/{meal_date}"
+            meals_data = garmin_client.connectapi(meals_url)
+            meals = (meals_data or {}).get("meals", [])
+
+            # Match meal_time against startTime/endTime windows; fall back to SNACKS
+            meal_id = None
+            for m in meals:
+                start = m.get("startTime")
+                end = m.get("endTime")
+                if start and end and start <= meal_time <= end:
+                    meal_id = m["mealId"]
+                    break
+            if meal_id is None:
+                snacks = next((m for m in meals if m.get("mealName") == "SNACKS"), None)
+                if snacks is None:
+                    return f"Error logging food: could not match meal for time '{meal_time}' and no SNACKS meal found."
+                meal_id = snacks["mealId"]
+
+            now = datetime.now(timezone.utc)
+            log_timestamp = now.strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            payload = {
+                "mealDate": meal_date,
+                "quickAddItems": [
+                    {
+                        "name": name,
+                        "logId": None,
+                        "logTimestamp": log_timestamp,
+                        "logSource": "GCW",
+                        "logCategory": "QUICK_ADD",
+                        "mealTime": meal_time,
+                        "mealId": meal_id,
+                        "action": "ADD",
+                        "calories": _num_to_str(calories),
+                        "carbs": _num_to_str(carbs),
+                        "protein": _num_to_str(protein),
+                        "fat": _num_to_str(fat),
+                    }
+                ],
+            }
+            url = "/nutrition-service/food/logs/quickAdd"
+            resp = garmin_client.client.put(
+                "connectapi", url, json=payload, api=True
+            )
+            if resp.status_code == 204:
+                return "Food logged successfully."
+            return json.dumps(resp.json(), indent=2)
+        except GarminConnectConnectionError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error logging food: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error logging food: {str(e)}"
+
+    @app.tool()
+    async def delete_food_log(log_id: int) -> str:
+        """Delete a food log entry
+
+        Permanently removes a logged food item from the nutrition log.
+        Use get_nutrition_daily_food_log to find the logId of the entry
+        to delete.
+
+        Args:
+            log_id: Log entry ID to delete (from get_nutrition_daily_food_log)
+        """
+        try:
+            url = f"/nutrition-service/food/logs/{log_id}"
+            resp = garmin_client.client.delete("connectapi", url, api=True)
+            if resp.status_code in (200, 204):
+                return json.dumps({"status": "success", "log_id": log_id, "message": f"Food log entry {log_id} deleted successfully."}, indent=2)
+            return json.dumps({"status": "failed", "log_id": log_id, "http_status": resp.status_code, "message": f"Failed to delete food log: HTTP {resp.status_code}"}, indent=2)
+        except GarminConnectConnectionError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error deleting food log: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error deleting food log: {str(e)}"
+
+    @app.tool()
+    async def upsert_and_log(
+        meal_date: str,
+        meal_time: str,
+        food_name: str,
+        calories: float,
+        carbs: Optional[float] = None,
+        protein: Optional[float] = None,
+        fat: Optional[float] = None,
+        serving_unit: str = "G",
+        number_of_units: float = 100,
+        serving_qty: float = 1,
+    ) -> str:
+        """Find-or-create a custom food then log it in one step
+
+        Searches the user's custom food library for food_name. If found, logs
+        it immediately. If not found, creates it with the provided nutrition
+        data and then logs it. This avoids duplicate food entries and removes
+        the need for separate search → create → log round-trips.
+
+        Args:
+            meal_date: Date in YYYY-MM-DD format
+            meal_time: Time in HH:MM:SS format (account timezone); used to
+                determine the meal automatically
+            food_name: Name of the food to find or create
+            calories: Calories per serving
+            carbs: Carbohydrates in grams per serving
+            protein: Protein in grams per serving
+            fat: Total fat in grams per serving
+            serving_unit: Unit for serving size (e.g. "G", "ML", "OZ"). Default "G"
+            number_of_units: Serving size in the specified unit. Default 100
+            serving_qty: Number of servings to log (default 1)
+        """
+        try:
+            from datetime import datetime, timezone
+
+            # 1. Search for existing custom food
+            search_url = (
+                f"/nutrition-service/customFood"
+                f"?searchExpression={quote(food_name)}"
+                f"&start=0&limit=10&includeContent=true"
+            )
+            search_data = garmin_client.connectapi(search_url)
+            foods = search_data if isinstance(search_data, list) else []
+
+            food_id = None
+            serving_id = None
+            for f in foods:
+                meta = f.get("foodMetaData", f)
+                name_match = meta.get("foodName", "").lower() == food_name.lower()
+                if name_match:
+                    food_id = str(meta.get("foodId") or f.get("foodId", ""))
+                    contents = f.get("nutritionContents", [])
+                    if contents:
+                        serving_id = str(contents[0].get("servingId", ""))
+                    break
+
+            # 2. Create if not found
+            if not food_id or not serving_id:
+                nutrition = {
+                    "servingUnit": serving_unit,
+                    "numberOfUnits": _num_to_str(number_of_units),
+                    "calories": _num_to_str(calories),
+                }
+                optional_fields = {"carbs": carbs, "protein": protein, "fat": fat}
+                for key, value in optional_fields.items():
+                    if value is not None:
+                        nutrition[key] = _num_to_str(value)
+                create_payload = {
+                    "foodMetaData": {
+                        "foodName": food_name,
+                        "foodType": "GENERIC",
+                        "source": "GARMIN",
+                        "regionCode": "US",
+                        "languageCode": "en",
+                    },
+                    "nutritionContents": [nutrition],
+                }
+                create_resp = garmin_client.client.put(
+                    "connectapi", "/nutrition-service/customFood", json=create_payload, api=True
+                )
+                if create_resp.status_code not in (200, 201, 204):
+                    return f"Error creating custom food: HTTP {create_resp.status_code}"
+                if create_resp.status_code in (200, 201):
+                    created = create_resp.json()
+                    meta = created.get("foodMetaData", created)
+                    food_id = str(meta.get("foodId", ""))
+                    contents = created.get("nutritionContents", [])
+                    if contents:
+                        serving_id = str(contents[0].get("servingId", ""))
+                # 204: no body — look up by name
+                if not food_id or not serving_id:
+                    lookup_url = (
+                        f"/nutrition-service/customFood"
+                        f"?searchExpression={quote(food_name)}"
+                        f"&start=0&limit=10&includeContent=true"
+                    )
+                    lookup_data = garmin_client.connectapi(lookup_url)
+                    lookup_foods = lookup_data if isinstance(lookup_data, list) else []
+                    for f in lookup_foods:
+                        meta = f.get("foodMetaData", f)
+                        if meta.get("foodName", "").lower() == food_name.lower():
+                            food_id = str(meta.get("foodId") or f.get("foodId", ""))
+                            contents = f.get("nutritionContents", [])
+                            if contents:
+                                serving_id = str(contents[0].get("servingId", ""))
+                            break
+                if not food_id or not serving_id:
+                    return f"Error: could not retrieve foodId/servingId for '{food_name}' after creation."
+
+            # 3. Resolve meal_id from meal_time
+            meals_data = garmin_client.connectapi(f"/nutrition-service/meals/{meal_date}")
+            meals = (meals_data or {}).get("meals", [])
+            meal_id = None
+            for m in meals:
+                start = m.get("startTime")
+                end = m.get("endTime")
+                if start and end and start <= meal_time <= end:
+                    meal_id = m["mealId"]
+                    break
+            if meal_id is None:
+                snacks = next((m for m in meals if m.get("mealName") == "SNACKS"), None)
+                if snacks is None:
+                    return f"Error logging food: could not match meal for time '{meal_time}' and no SNACKS meal found."
+                meal_id = snacks["mealId"]
+
+            # 4. Log
+            log_timestamp = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+            log_payload = {
+                "mealDate": meal_date,
+                "foodLogItems": [
+                    {
+                        "logTimestamp": log_timestamp,
+                        "logSource": "GCW",
+                        "logCategory": "REGULAR_LOG",
+                        "mealTime": meal_time,
+                        "action": "ADD",
+                        "mealId": meal_id,
+                        "foodId": food_id,
+                        "servingId": serving_id,
+                        "source": "GARMIN",
+                        "regionCode": "US",
+                        "languageCode": "en",
+                        "servingQty": serving_qty,
+                    }
+                ],
+            }
+            log_resp = garmin_client.client.put(
+                "connectapi", "/nutrition-service/food/logs", json=log_payload, api=True
+            )
+            if log_resp.status_code == 204:
+                return "Food logged successfully."
+            return json.dumps(log_resp.json(), indent=2)
+        except GarminConnectConnectionError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error in upsert_and_log: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error in upsert_and_log: {str(e)}"
 
     return app

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -367,11 +367,22 @@ async def test_update_custom_food_error(app_with_nutrition, mock_garmin_client):
     assert "Error updating custom food" in result[0][0].text
 
 
+MOCK_MEALS = {
+    "meals": [
+        {"mealId": 20249, "mealName": "BREAKFAST", "startTime": "06:00:00", "endTime": "09:00:00"},
+        {"mealId": 20250, "mealName": "LUNCH", "startTime": "11:00:00", "endTime": "14:00:00"},
+        {"mealId": 20251, "mealName": "DINNER", "startTime": "18:00:00", "endTime": "21:00:00"},
+        {"mealId": 20252, "mealName": "SNACKS"},
+    ]
+}
+
+
 # log_food tests
 
 @pytest.mark.asyncio
 async def test_log_food(app_with_nutrition, mock_garmin_client):
-    """Test log_food logs a food item to a meal"""
+    """Test log_food resolves meal ID and quick-adds a food entry"""
+    mock_garmin_client.connectapi.return_value = MOCK_MEALS
     mock_resp = MagicMock()
     mock_resp.status_code = 200
     mock_resp.json.return_value = {"status": "ok"}
@@ -380,32 +391,40 @@ async def test_log_food(app_with_nutrition, mock_garmin_client):
         "log_food",
         {
             "meal_date": "2024-01-15",
-            "meal_time": "12:30:00",
-            "meal_id": 185360,
-            "food_id": "abc123",
-            "serving_id": "srv456",
-            "serving_qty": 3,
+            "meal_time": "12:30:00",  # within LUNCH window 11:00-14:00
+            "name": "Chicken Breast",
+            "calories": 200,
+            "carbs": 3,
+            "protein": 40,
+            "fat": 4,
         }
     )
     assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/meals/2024-01-15"
+    )
     call_args = mock_garmin_client.client.put.call_args
     assert call_args[0][0] == "connectapi"
-    assert call_args[0][1] == "/nutrition-service/food/logs"
+    assert call_args[0][1] == "/nutrition-service/food/logs/quickAdd"
     payload = call_args[1]["json"]
     assert payload["mealDate"] == "2024-01-15"
-    assert len(payload["foodLogItems"]) == 1
-    item = payload["foodLogItems"][0]
-    assert item["mealId"] == 185360
-    assert item["foodId"] == "abc123"
-    assert item["servingId"] == "srv456"
-    assert item["servingQty"] == 3
+    assert len(payload["quickAddItems"]) == 1
+    item = payload["quickAddItems"][0]
+    assert item["name"] == "Chicken Breast"
+    assert item["mealId"] == 20250  # LUNCH
+    assert item["calories"] == "200"
+    assert item["carbs"] == "3"
+    assert item["protein"] == "40"
+    assert item["fat"] == "4"
+    assert item["logCategory"] == "QUICK_ADD"
     assert item["action"] == "ADD"
-    assert item["mealTime"] == "12:30:00"
+    assert item["logId"] is None
 
 
 @pytest.mark.asyncio
-async def test_log_food_default_qty(app_with_nutrition, mock_garmin_client):
-    """Test log_food with default serving quantity of 1"""
+async def test_log_food_falls_back_to_snacks(app_with_nutrition, mock_garmin_client):
+    """Test log_food falls back to SNACKS when time doesn't match any window"""
+    mock_garmin_client.connectapi.return_value = MOCK_MEALS
     mock_resp = MagicMock()
     mock_resp.status_code = 204
     mock_garmin_client.client.put.return_value = mock_resp
@@ -413,29 +432,233 @@ async def test_log_food_default_qty(app_with_nutrition, mock_garmin_client):
         "log_food",
         {
             "meal_date": "2024-01-15",
-            "meal_time": "08:00:00",
-            "meal_id": 185360,
-            "food_id": "abc123",
-            "serving_id": "srv456",
+            "meal_time": "10:00:00",  # between BREAKFAST and LUNCH, no match → SNACKS
+            "name": "Oats",
+            "calories": 150,
+            "carbs": 27,
+            "protein": 5,
+            "fat": 3,
         }
     )
     assert "Food logged successfully" in result[0][0].text
     payload = mock_garmin_client.client.put.call_args[1]["json"]
-    assert payload["foodLogItems"][0]["servingQty"] == 1
+    assert payload["quickAddItems"][0]["mealId"] == 20252  # SNACKS
+    assert payload["quickAddItems"][0]["mealTime"] == "10:00:00"
 
 
 @pytest.mark.asyncio
 async def test_log_food_error(app_with_nutrition, mock_garmin_client):
-    """Test log_food handles errors"""
+    """Test log_food handles API errors"""
+    mock_garmin_client.connectapi.return_value = MOCK_MEALS
     mock_garmin_client.client.put.side_effect = Exception("API error")
     result = await app_with_nutrition.call_tool(
         "log_food",
         {
             "meal_date": "2024-01-15",
             "meal_time": "12:00:00",
-            "meal_id": 185360,
+            "name": "Test",
+            "calories": 100,
+            "carbs": 10,
+            "protein": 5,
+            "fat": 2,
+        }
+    )
+    assert "Error logging food" in result[0][0].text
+
+
+# log_custom_food tests
+
+@pytest.mark.asyncio
+async def test_log_custom_food(app_with_nutrition, mock_garmin_client):
+    """Test log_custom_food auto-resolves meal_id and logs using food_id/serving_id"""
+    mock_garmin_client.connectapi.return_value = MOCK_MEALS
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+    mock_resp.json.return_value = {"status": "ok"}
+    mock_garmin_client.client.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "log_custom_food",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:30:00",  # within LUNCH window 11:00-14:00
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "serving_qty": 3,
+        }
+    )
+    assert result is not None
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/meals/2024-01-15"
+    )
+    call_args = mock_garmin_client.client.put.call_args
+    assert call_args[0][0] == "connectapi"
+    assert call_args[0][1] == "/nutrition-service/food/logs"
+    payload = call_args[1]["json"]
+    assert payload["mealDate"] == "2024-01-15"
+    assert len(payload["foodLogItems"]) == 1
+    item = payload["foodLogItems"][0]
+    assert item["mealId"] == 20250  # LUNCH
+    assert item["foodId"] == "abc123"
+    assert item["servingId"] == "srv456"
+    assert item["servingQty"] == 3
+    assert item["logCategory"] == "REGULAR_LOG"
+    assert item["action"] == "ADD"
+    assert item["mealTime"] == "12:30:00"
+
+
+@pytest.mark.asyncio
+async def test_log_custom_food_falls_back_to_snacks(app_with_nutrition, mock_garmin_client):
+    """Test log_custom_food falls back to SNACKS when time doesn't match any window"""
+    mock_garmin_client.connectapi.return_value = MOCK_MEALS
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_garmin_client.client.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "log_custom_food",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "10:00:00",  # between BREAKFAST and LUNCH, no match → SNACKS
+            "food_id": "abc123",
+            "serving_id": "srv456",
+        }
+    )
+    assert "Food logged successfully" in result[0][0].text
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    assert payload["foodLogItems"][0]["mealId"] == 20252  # SNACKS
+    assert payload["foodLogItems"][0]["servingQty"] == 1
+
+
+@pytest.mark.asyncio
+async def test_log_custom_food_error(app_with_nutrition, mock_garmin_client):
+    """Test log_custom_food handles API errors"""
+    mock_garmin_client.connectapi.return_value = MOCK_MEALS
+    mock_garmin_client.client.put.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "log_custom_food",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:00:00",
             "food_id": "abc123",
             "serving_id": "srv456",
         }
     )
     assert "Error logging food" in result[0][0].text
+
+
+# delete_food_log tests
+
+@pytest.mark.asyncio
+async def test_delete_food_log(app_with_nutrition, mock_garmin_client):
+    """Test delete_food_log removes a food log entry"""
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_garmin_client.client.delete.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "delete_food_log",
+        {"log_id": 99001}
+    )
+    assert "success" in result[0][0].text
+    assert "99001" in result[0][0].text
+    mock_garmin_client.client.delete.assert_called_once_with(
+        "connectapi", "/nutrition-service/food/logs/99001", api=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_food_log_error(app_with_nutrition, mock_garmin_client):
+    """Test delete_food_log handles API errors"""
+    mock_garmin_client.client.delete.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "delete_food_log",
+        {"log_id": 99001}
+    )
+    assert "Error deleting food log" in result[0][0].text
+
+
+# upsert_and_log tests
+
+MOCK_CUSTOM_FOODS = [
+    {
+        "foodMetaData": {"foodId": "food001", "foodName": "Greek Yogurt"},
+        "nutritionContents": [{"servingId": "srv001", "calories": "100"}],
+    }
+]
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_log_existing_food(app_with_nutrition, mock_garmin_client):
+    """Test upsert_and_log finds existing food and logs it without creating"""
+    mock_garmin_client.connectapi.side_effect = [
+        MOCK_CUSTOM_FOODS,  # search
+        MOCK_MEALS,         # meal resolution
+    ]
+    mock_resp = MagicMock()
+    mock_resp.status_code = 204
+    mock_garmin_client.client.put.return_value = mock_resp
+    result = await app_with_nutrition.call_tool(
+        "upsert_and_log",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "08:30:00",  # within BREAKFAST window
+            "food_name": "Greek Yogurt",
+            "calories": 100,
+        }
+    )
+    assert "Food logged successfully" in result[0][0].text
+    # create_custom_food should NOT have been called
+    mock_garmin_client.client.put.assert_called_once()
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    item = payload["foodLogItems"][0]
+    assert item["foodId"] == "food001"
+    assert item["servingId"] == "srv001"
+    assert item["mealId"] == 20249  # BREAKFAST
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_log_creates_new_food(app_with_nutrition, mock_garmin_client):
+    """Test upsert_and_log creates food when not found then logs it"""
+    created_food = {
+        "foodMetaData": {"foodId": "food999", "foodName": "New Food"},
+        "nutritionContents": [{"servingId": "srv999"}],
+    }
+    mock_garmin_client.connectapi.side_effect = [
+        [],           # search returns empty
+        MOCK_MEALS,   # meal resolution
+    ]
+    create_resp = MagicMock()
+    create_resp.status_code = 201
+    create_resp.json.return_value = created_food
+    log_resp = MagicMock()
+    log_resp.status_code = 204
+    mock_garmin_client.client.put.side_effect = [create_resp, log_resp]
+    result = await app_with_nutrition.call_tool(
+        "upsert_and_log",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:00:00",
+            "food_name": "New Food",
+            "calories": 200,
+            "protein": 20,
+        }
+    )
+    assert "Food logged successfully" in result[0][0].text
+    assert mock_garmin_client.client.put.call_count == 2
+    log_payload = mock_garmin_client.client.put.call_args_list[1][1]["json"]
+    assert log_payload["foodLogItems"][0]["foodId"] == "food999"
+    assert log_payload["foodLogItems"][0]["servingId"] == "srv999"
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_log_error(app_with_nutrition, mock_garmin_client):
+    """Test upsert_and_log handles errors"""
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "upsert_and_log",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:00:00",
+            "food_name": "Test Food",
+            "calories": 100,
+        }
+    )
+    assert "Error in upsert_and_log" in result[0][0].text


### PR DESCRIPTION
Rebased from #76 (original by @fschmi) — resolved conflicts with #77 auth migration by updating garth API calls to garminconnect client API.

**Changes:**
- `log_food` repurposed as quick-add by macros (name, calories, carbs, protein, fat) — no food ID needed
- `log_custom_food` (renamed from old `log_food`) — auto-resolves meal_id from meal_time window
- New `delete_food_log(log_id)` tool
- New `upsert_and_log` — search-or-create-then-log in one call
- `get_custom_foods` URL-encodes search terms (bug fix)
- All API calls updated from `garth.put/delete` → `client.put/delete`

31/31 tests passing.

Closes #76