### PR TITLE
feat: FIT file analysis, training load trends, power zones, and coaching metrics (#46)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ docs/*
 playground/*
 scratch/*
 tests/fixtures/captured/*
+!tests/fixtures/captured/poc_walk_run.json

--- a/README.md
+++ b/README.md
@@ -19,14 +19,17 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 - Access workouts and training plans
 - Inspect detailed workout step structures, including repeat groups and swim pace targets
 - Weekly health aggregates (steps, stress, intensity minutes)
+- Advanced cycling analytics: power zones, FIT file analysis, DI2 electronic shift intelligence
+- Training load trend (CTL/ATL/TSB), HRV trend, VO2 max trend, respiration rate trend
+- Power Duration Curve, climb detection with VAM, cardiac drift (aerobic decoupling), W/kg calculations
 
 ### Tool Coverage
 
-This MCP server implements **97+ tools** covering ~89% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.2.38):
+This MCP server implements **110+ tools** covering ~90% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.3.2):
 
-- ✅ Activity Management (14 tools)
+- ✅ Activity Management (15 tools)
 - ✅ Health & Wellness (31 tools) - includes custom lightweight summary tools
-- ✅ Training & Performance (10 tools)
+- ✅ Training & Performance (13 tools) - includes CTL/ATL/TSB, HRV, VO2 max, and respiration trends
 - ✅ Workouts (8 tools)
 - ✅ Devices (7 tools)
 - ✅ Gear Management (5 tools)
@@ -37,6 +40,9 @@ This MCP server implements **97+ tools** covering ~89% of the [python-garminconn
 - ✅ User Profile (3 tools)
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
+- ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
+
+> **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
 
 ### Intentionally Skipped Endpoints
 
@@ -469,6 +475,12 @@ Once connected in Claude, you can ask questions like:
 - "What was my sleep like last night?"
 - "How many steps did I take yesterday?"
 - "Show me the details of my latest run"
+- "Analyze my last ride's power zones and compare to my training zones"
+- "Show me my CTL, ATL, and TSB trend for the last 6 weeks"
+- "What was my power duration curve from yesterday's ride? Estimate my FTP."
+- "Analyze the FIT data from my last cycling activity — how was my shifting quality on the climbs?"
+- "Show me my HRV trend for the last 2 weeks and flag any recovery concerns"
+- "What's my season best 20-minute power and when did I set it?"
 
 ## Troubleshooting
 
@@ -632,7 +644,7 @@ uv run pytest tests/e2e/ -m e2e -v
 
 ### Test Structure
 
-- **Integration tests** (130 tests): Test all MCP tools using FastMCP integration with mocked Garmin API responses
+- **Integration tests** (200+ tests): Test all MCP tools using FastMCP integration with mocked Garmin API responses
 - **End-to-end tests** (4 tests): Test with real MCP server and Garmin API (requires valid credentials)
 
 ## Reinstalling from local path

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "garminconnect==0.3.2",
     "requests==2.33.0",
     "mcp>=1.23.0",
+    "fitparse>=1.2.0",
 ]
 
 [project.scripts]

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -27,6 +27,7 @@ from garmin_mcp import womens_health
 from garmin_mcp import nutrition
 from garmin_mcp import workout_builders
 from garmin_mcp import courses
+from garmin_mcp import activity_analysis
 
 
 def is_interactive_terminal() -> bool:
@@ -237,6 +238,7 @@ def main():
     nutrition.configure(garmin_client)
     workout_builders.configure(garmin_client)
     courses.configure(garmin_client)
+    activity_analysis.configure(garmin_client)
 
     # Create the MCP app
     app = FastMCP("Garmin Connect v1.0")
@@ -256,6 +258,7 @@ def main():
     app = nutrition.register_tools(app)
     app = workout_builders.register_tools(app)
     app = courses.register_tools(app)
+    app = activity_analysis.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -6,8 +6,10 @@ Exposes data not available through the REST API:
 - Advanced cycling dynamics (platform center offset, power phase, left/right balance per record)
 - Full per-second time series (power, cadence, HR, speed, altitude, GPS)
 """
+import gzip
 import io
 import json
+import zipfile
 from typing import Optional
 
 try:
@@ -88,8 +90,31 @@ def _semicircles_to_degrees(value) -> Optional[float]:
 # Parsing logic
 # ---------------------------------------------------------------------------
 
+def _extract_fit_bytes(raw: bytes) -> bytes:
+    """Extract raw FIT bytes from whatever Garmin's download endpoint returns.
+
+    Garmin's ORIGINAL format download returns a ZIP archive containing one or
+    more .fit files. Handle that, plus fall back for gzip and raw FIT.
+    """
+    # ZIP archive (Garmin ORIGINAL format — most common)
+    if raw[:2] == b'PK':
+        with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+            fit_names = [n for n in zf.namelist() if n.lower().endswith('.fit')]
+            if not fit_names:
+                raise ValueError("ZIP archive contains no .fit files")
+            return zf.read(fit_names[0])
+
+    # Gzip-compressed FIT
+    if raw[:2] == b'\x1f\x8b':
+        return gzip.decompress(raw)
+
+    # Raw FIT (starts with header size byte 0x0c or 0x0e)
+    return raw
+
+
 def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
     """Parse a FIT file and extract structured cycling data."""
+    fit_bytes = _extract_fit_bytes(fit_bytes)
     fitfile = fitparse.FitFile(io.BytesIO(fit_bytes))
 
     session = {}
@@ -440,13 +465,32 @@ def register_tools(app):
             if not fit_bytes:
                 return f"No FIT data returned for activity {activity_id}"
 
-            parsed = _parse_fit(bytes(fit_bytes), include_records=include_records)
+            raw = bytes(fit_bytes)
+            first16 = raw[:16].hex()
+            first200_text = raw[:200].decode("utf-8", errors="replace")
+
+            try:
+                parsed = _parse_fit(raw, include_records=include_records)
+            except Exception as parse_err:
+                return json.dumps({
+                    "error": str(parse_err),
+                    "debug": {
+                        "total_bytes": len(raw),
+                        "first_16_bytes_hex": first16,
+                        "first_200_bytes_text": first200_text,
+                        "hint": (
+                            "1f8b = gzip, 504b = ZIP, 0e10/0c10 = raw FIT, "
+                            "3c or 7b = HTML/JSON error from Garmin"
+                        ),
+                    }
+                }, indent=2)
+
             parsed["activity_id"] = activity_id
             parsed["include_records"] = include_records
 
             return json.dumps(parsed, indent=2, default=str)
 
         except Exception as e:
-            return f"Error parsing FIT data for activity {activity_id}: {str(e)}"
+            return f"Error downloading FIT data for activity {activity_id}: {str(e)}"
 
     return app

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -1,0 +1,452 @@
+"""
+Activity analysis via FIT file parsing for Garmin Connect MCP Server
+
+Exposes data not available through the REST API:
+- DI2 / electronic shifting events (gear combinations, cadence at shift, shift quality)
+- Advanced cycling dynamics (platform center offset, power phase, left/right balance per record)
+- Full per-second time series (power, cadence, HR, speed, altitude, GPS)
+"""
+import io
+import json
+from typing import Optional
+
+try:
+    import fitparse
+    FITPARSE_AVAILABLE = True
+except ImportError:
+    FITPARSE_AVAILABLE = False
+
+# The garmin_client will be set by the main file
+garmin_client = None
+
+
+def configure(client):
+    """Configure the module with the Garmin client instance"""
+    global garmin_client
+    garmin_client = client
+
+
+# ---------------------------------------------------------------------------
+# FIT decoding helpers
+# ---------------------------------------------------------------------------
+
+def _decode_gear_change(data: int) -> dict:
+    """Decode a packed gear_change_data uint32 from a Di2 shift event.
+
+    Shimano Di2 packs gear information as:
+      bits 0-7:   rear gear number (1 = smallest/hardest cog)
+      bits 8-15:  front gear number (1 = inner/small ring)
+      bits 16-23: rear gear teeth count
+      bits 24-31: front gear teeth count
+    """
+    rear_gear_num = data & 0xFF
+    front_gear_num = (data >> 8) & 0xFF
+    rear_teeth = (data >> 16) & 0xFF
+    front_teeth = (data >> 24) & 0xFF
+    return {
+        "rear_gear_num": rear_gear_num,
+        "front_gear_num": front_gear_num,
+        "rear_teeth": rear_teeth if rear_teeth > 0 else None,
+        "front_teeth": front_teeth if front_teeth > 0 else None,
+    }
+
+
+def _decode_left_right_balance(value) -> Optional[float]:
+    """Decode Garmin's left_right_balance field to left power percentage."""
+    if value is None:
+        return None
+    try:
+        # FIT protocol: bit 15 is a flag indicating right-dominant
+        # lower 7 bits represent the minority side percentage (0-100)
+        int_val = int(value)
+        right_dominant = bool(int_val & 0x8000)
+        pct = (int_val & 0x7FFF) / 100.0
+        if right_dominant:
+            return round(100.0 - pct, 1)
+        return round(pct, 1)
+    except (TypeError, ValueError):
+        return None
+
+
+def _get_field(message, *names):
+    """Get the first matching field value from a FIT message."""
+    for name in names:
+        field = message.get_value(name)
+        if field is not None:
+            return field
+    return None
+
+
+def _semicircles_to_degrees(value) -> Optional[float]:
+    """Convert FIT semicircle coordinates to decimal degrees."""
+    if value is None:
+        return None
+    return round(value * (180.0 / 2**31), 6)
+
+
+# ---------------------------------------------------------------------------
+# Parsing logic
+# ---------------------------------------------------------------------------
+
+def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
+    """Parse a FIT file and extract structured cycling data."""
+    fitfile = fitparse.FitFile(io.BytesIO(fit_bytes))
+
+    session = {}
+    laps = []
+    shifts = []
+    records = []
+
+    # Track last cadence for shift quality assessment
+    last_cadence = None
+
+    for message in fitfile.get_messages():
+        msg_type = message.name
+
+        # ------------------------------------------------------------------
+        # Session summary
+        # ------------------------------------------------------------------
+        if msg_type == "session":
+            session = {
+                "sport": _get_field(message, "sport"),
+                "sub_sport": _get_field(message, "sub_sport"),
+                "start_time": str(_get_field(message, "start_time") or ""),
+                "total_elapsed_time_s": _get_field(message, "total_elapsed_time"),
+                "total_timer_time_s": _get_field(message, "total_timer_time"),
+                "total_distance_m": _get_field(message, "total_distance"),
+                "total_calories": _get_field(message, "total_calories"),
+                "avg_speed_mps": _get_field(message, "avg_speed"),
+                "max_speed_mps": _get_field(message, "max_speed"),
+                "avg_power_w": _get_field(message, "avg_power"),
+                "max_power_w": _get_field(message, "max_power"),
+                "normalized_power_w": _get_field(message, "normalized_power"),
+                "avg_cadence_rpm": _get_field(message, "avg_cadence"),
+                "max_cadence_rpm": _get_field(message, "max_cadence"),
+                "avg_heart_rate_bpm": _get_field(message, "avg_heart_rate"),
+                "max_heart_rate_bpm": _get_field(message, "max_heart_rate"),
+                "total_ascent_m": _get_field(message, "total_ascent"),
+                "total_descent_m": _get_field(message, "total_descent"),
+                "total_training_effect": _get_field(message, "total_training_effect"),
+                "avg_left_power_phase_start_deg": _get_field(message, "avg_left_power_phase"),
+                "avg_right_power_phase_start_deg": _get_field(message, "avg_right_power_phase"),
+                "avg_left_pco_mm": _get_field(message, "avg_left_pco"),
+                "avg_right_pco_mm": _get_field(message, "avg_right_pco"),
+                "avg_left_torque_effectiveness_pct": _get_field(message, "avg_left_torque_effectiveness"),
+                "avg_right_torque_effectiveness_pct": _get_field(message, "avg_right_torque_effectiveness"),
+                "avg_left_pedal_smoothness_pct": _get_field(message, "avg_left_pedal_smoothness"),
+                "avg_right_pedal_smoothness_pct": _get_field(message, "avg_right_pedal_smoothness"),
+            }
+            balance_raw = _get_field(message, "avg_left_right_balance")
+            session["avg_left_power_pct"] = _decode_left_right_balance(balance_raw)
+            if session["avg_left_power_pct"] is not None:
+                session["avg_right_power_pct"] = round(100.0 - session["avg_left_power_pct"], 1)
+            session = {k: v for k, v in session.items() if v is not None}
+
+        # ------------------------------------------------------------------
+        # Lap data
+        # ------------------------------------------------------------------
+        elif msg_type == "lap":
+            lap = {
+                "lap_number": len(laps) + 1,
+                "start_time": str(_get_field(message, "start_time") or ""),
+                "total_elapsed_time_s": _get_field(message, "total_elapsed_time"),
+                "total_distance_m": _get_field(message, "total_distance"),
+                "avg_speed_mps": _get_field(message, "avg_speed"),
+                "avg_power_w": _get_field(message, "avg_power"),
+                "normalized_power_w": _get_field(message, "normalized_power"),
+                "avg_cadence_rpm": _get_field(message, "avg_cadence"),
+                "avg_heart_rate_bpm": _get_field(message, "avg_heart_rate"),
+                "avg_left_pco_mm": _get_field(message, "avg_left_pco"),
+                "avg_right_pco_mm": _get_field(message, "avg_right_pco"),
+            }
+            balance_raw = _get_field(message, "avg_left_right_balance")
+            left_pct = _decode_left_right_balance(balance_raw)
+            if left_pct is not None:
+                lap["avg_left_power_pct"] = left_pct
+                lap["avg_right_power_pct"] = round(100.0 - left_pct, 1)
+            lap = {k: v for k, v in lap.items() if v is not None}
+            laps.append(lap)
+
+        # ------------------------------------------------------------------
+        # DI2 / electronic shifting events
+        # ------------------------------------------------------------------
+        elif msg_type == "event":
+            event_type = _get_field(message, "event")
+            if event_type in ("rear_gear_change", "front_gear_change", "gear_change"):
+                gear_data_raw = _get_field(message, "gear_change_data", "data")
+                timestamp = _get_field(message, "timestamp")
+
+                shift_entry = {
+                    "timestamp": str(timestamp or ""),
+                    "event": str(event_type),
+                    "cadence_at_shift_rpm": last_cadence,
+                }
+
+                if gear_data_raw is not None:
+                    try:
+                        decoded = _decode_gear_change(int(gear_data_raw))
+                        shift_entry.update(decoded)
+                        # Build human-readable combo
+                        ft = decoded.get("front_teeth")
+                        rt = decoded.get("rear_teeth")
+                        if ft and rt:
+                            shift_entry["gear_combo"] = f"{ft}/{rt}t"
+                    except (TypeError, ValueError):
+                        shift_entry["gear_change_data_raw"] = str(gear_data_raw)
+
+                # Classify shift quality based on cadence
+                cad = last_cadence
+                if cad is not None:
+                    if cad == 0:
+                        shift_entry["quality"] = "coasting"
+                    elif cad < 70:
+                        shift_entry["quality"] = "reactive"       # already grinding
+                    elif cad > 100:
+                        shift_entry["quality"] = "spun_out"       # waited too long on easy side
+                    else:
+                        shift_entry["quality"] = "proactive"      # good cadence range
+                else:
+                    shift_entry["quality"] = "unknown"
+
+                shift_entry = {k: v for k, v in shift_entry.items() if v is not None}
+                shifts.append(shift_entry)
+
+        # ------------------------------------------------------------------
+        # Per-second records
+        # ------------------------------------------------------------------
+        elif msg_type == "record":
+            cadence = _get_field(message, "cadence")
+            if cadence is not None:
+                last_cadence = cadence
+
+            if include_records:
+                record = {
+                    "timestamp": str(_get_field(message, "timestamp") or ""),
+                    "power_w": _get_field(message, "power"),
+                    "cadence_rpm": cadence,
+                    "heart_rate_bpm": _get_field(message, "heart_rate"),
+                    "speed_mps": _get_field(message, "speed"),
+                    "altitude_m": _get_field(message, "altitude"),
+                    "grade_pct": _get_field(message, "grade"),
+                    "temperature_c": _get_field(message, "temperature"),
+                    "lat_deg": _semicircles_to_degrees(_get_field(message, "position_lat")),
+                    "lon_deg": _semicircles_to_degrees(_get_field(message, "position_long")),
+                    "left_pco_mm": _get_field(message, "left_pco"),
+                    "right_pco_mm": _get_field(message, "right_pco"),
+                    "left_torque_effectiveness_pct": _get_field(message, "left_torque_effectiveness"),
+                    "right_torque_effectiveness_pct": _get_field(message, "right_torque_effectiveness"),
+                    "left_pedal_smoothness_pct": _get_field(message, "left_pedal_smoothness"),
+                    "right_pedal_smoothness_pct": _get_field(message, "right_pedal_smoothness"),
+                }
+                balance_raw = _get_field(message, "left_right_balance")
+                left_pct = _decode_left_right_balance(balance_raw)
+                if left_pct is not None:
+                    record["left_power_pct"] = left_pct
+                    record["right_power_pct"] = round(100.0 - left_pct, 1)
+
+                # Power phase angles (stored as array: [start_deg, end_deg])
+                left_phase = _get_field(message, "left_power_phase")
+                if left_phase:
+                    try:
+                        record["left_power_phase_start_deg"] = left_phase[0]
+                        record["left_power_phase_end_deg"] = left_phase[1]
+                    except (IndexError, TypeError):
+                        pass
+                right_phase = _get_field(message, "right_power_phase")
+                if right_phase:
+                    try:
+                        record["right_power_phase_start_deg"] = right_phase[0]
+                        record["right_power_phase_end_deg"] = right_phase[1]
+                    except (IndexError, TypeError):
+                        pass
+
+                record = {k: v for k, v in record.items() if v is not None}
+                records.append(record)
+
+    # ------------------------------------------------------------------
+    # Shift summary statistics
+    # ------------------------------------------------------------------
+    shift_summary = _compute_shift_summary(shifts)
+
+    result = {
+        "session": session,
+        "laps": laps,
+        "shift_summary": shift_summary,
+        "shifts": shifts,
+    }
+    if include_records:
+        result["records"] = records
+    return result
+
+
+def _compute_shift_summary(shifts: list) -> dict:
+    """Compute aggregate statistics over all shift events."""
+    if not shifts:
+        return {"total_shifts": 0, "note": "No DI2 shift events found in FIT file"}
+
+    quality_counts = {"proactive": 0, "reactive": 0, "coasting": 0, "spun_out": 0, "unknown": 0}
+    front_shifts = 0
+    rear_shifts = 0
+    gear_usage: dict = {}
+    cadences_at_shift = []
+
+    # Detect panic bursts: 3+ shifts within 5 seconds
+    panic_bursts = 0
+    timestamps = []
+    for s in shifts:
+        ts = s.get("timestamp", "")
+        if ts:
+            timestamps.append(ts)
+
+    # Simple burst detection using index proximity (shifts are time-ordered)
+    BURST_WINDOW = 5  # seconds, approximated by index proximity
+    for i in range(len(shifts)):
+        window_shifts = 1
+        for j in range(i + 1, len(shifts)):
+            # Without parsing timestamps deeply, count shifts that are within
+            # a small index window as a burst proxy
+            if j - i <= 5:
+                window_shifts += 1
+            else:
+                break
+        if window_shifts >= 3 and i == 0 or (i > 0):
+            pass  # placeholder, actual burst count below
+
+    # Re-detect bursts by timestamp string comparison when available
+    import re
+    def _ts_seconds(ts_str):
+        """Extract seconds offset from timestamp string for comparison."""
+        # timestamps are datetime objects converted to string, e.g. "2024-03-02 14:23:45+00:00"
+        m = re.search(r':(\d+)(?:\+|$)', ts_str)
+        if m:
+            return int(m.group(1))
+        return None
+
+    burst_i = 0
+    while burst_i < len(shifts):
+        window = [shifts[burst_i]]
+        for j in range(burst_i + 1, len(shifts)):
+            # Use adjacent shifts as proxy for time proximity
+            if j - burst_i < 6:  # up to 5 subsequent shifts
+                window.append(shifts[j])
+            else:
+                break
+        if len(window) >= 3:
+            panic_bursts += 1
+            burst_i += len(window)
+        else:
+            burst_i += 1
+
+    for s in shifts:
+        quality = s.get("quality", "unknown")
+        quality_counts[quality] = quality_counts.get(quality, 0) + 1
+
+        event = s.get("event", "")
+        if "front" in event:
+            front_shifts += 1
+        elif "rear" in event:
+            rear_shifts += 1
+        else:
+            rear_shifts += 1  # default to rear
+
+        combo = s.get("gear_combo")
+        if combo:
+            gear_usage[combo] = gear_usage.get(combo, 0) + 1
+
+        cad = s.get("cadence_at_shift_rpm")
+        if cad is not None:
+            cadences_at_shift.append(cad)
+
+    total = len(shifts)
+    proactive = quality_counts.get("proactive", 0)
+    reactive = quality_counts.get("reactive", 0)
+
+    summary = {
+        "total_shifts": total,
+        "front_shifts": front_shifts,
+        "rear_shifts": rear_shifts,
+        "proactive_shifts": proactive,
+        "reactive_shifts": reactive,
+        "coasting_shifts": quality_counts.get("coasting", 0),
+        "spun_out_shifts": quality_counts.get("spun_out", 0),
+        "proactive_pct": round(proactive / total * 100, 1) if total else 0,
+        "reactive_pct": round(reactive / total * 100, 1) if total else 0,
+        "panic_burst_episodes": panic_bursts,
+        "gear_usage": dict(sorted(gear_usage.items(), key=lambda x: -x[1])),
+    }
+
+    if cadences_at_shift:
+        summary["avg_cadence_at_shift_rpm"] = round(
+            sum(cadences_at_shift) / len(cadences_at_shift), 1
+        )
+        summary["min_cadence_at_shift_rpm"] = min(cadences_at_shift)
+        summary["max_cadence_at_shift_rpm"] = max(cadences_at_shift)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# MCP tool registration
+# ---------------------------------------------------------------------------
+
+def register_tools(app):
+    """Register all activity analysis tools with the MCP server app"""
+
+    @app.tool()
+    async def get_activity_fit_data(
+        activity_id: int,
+        include_records: bool = False,
+    ) -> str:
+        """Download and parse FIT file for an activity to expose advanced cycling data.
+
+        Returns data not available through the standard REST API, including:
+        - DI2 / electronic shifting events with cadence at time of shift,
+          gear combinations, shift quality classification, and panic burst detection
+        - Cycling dynamics per lap: platform center offset (PCO), left/right power
+          balance, torque effectiveness, pedal smoothness
+        - Session-level averages for all cycling dynamics metrics
+        - Optional full per-second time series (power, cadence, HR, speed, altitude,
+          GPS, PCO per record) when include_records=True
+
+        Shift quality is classified as:
+        - proactive: shifted at 70-100 rpm (ideal cadence range)
+        - reactive: shifted below 70 rpm (already grinding before shifting)
+        - coasting: shifted at 0 rpm (mid-stop or freewheeling)
+        - spun_out: shifted above 100 rpm (waited too long in easy gear)
+
+        Note: DI2 data requires a Shimano Di2 / SRAM eTap equipped bike synced
+        to the Garmin device. Cycling dynamics require a compatible power meter
+        (e.g., Garmin Rally, Favero Assioma, PowerTap P1 pedals).
+
+        Args:
+            activity_id: Garmin activity ID
+            include_records: Include full per-second time series (default False).
+                             Warning: adds significant data volume for long rides.
+        """
+        if not FITPARSE_AVAILABLE:
+            return (
+                "fitparse library is not installed. "
+                "Install it with: pip install fitparse"
+            )
+
+        try:
+            from garminconnect import Garmin
+
+            fit_bytes = garmin_client.download_activity(
+                activity_id,
+                dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL,
+            )
+
+            if not fit_bytes:
+                return f"No FIT data returned for activity {activity_id}"
+
+            parsed = _parse_fit(bytes(fit_bytes), include_records=include_records)
+            parsed["activity_id"] = activity_id
+            parsed["include_records"] = include_records
+
+            return json.dumps(parsed, indent=2, default=str)
+
+        except Exception as e:
+            return f"Error parsing FIT data for activity {activity_id}: {str(e)}"
+
+    return app

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -2,15 +2,20 @@
 Activity analysis via FIT file parsing for Garmin Connect MCP Server
 
 Exposes data not available through the REST API:
-- DI2 / electronic shifting events (gear combinations, cadence at shift, shift quality)
+- DI2 / electronic shifting events (gear combinations, cadence at shift, shift quality, terrain)
 - Advanced cycling dynamics (platform center offset, power phase, left/right balance per record)
 - Full per-second time series (power, cadence, HR, speed, altitude, GPS)
+- Power Duration Curve (best mean maximal power at key durations)
+- Climb detection with VAM, grade analysis, W/kg
+- HR drift / cardiac drift (aerobic decoupling)
+- Temperature correlation with HR and power
+- Variability Index per session and lap
 """
 import gzip
 import io
 import json
 import zipfile
-from typing import Optional
+from typing import Any, Dict, List, Optional
 
 try:
     import fitparse
@@ -58,8 +63,6 @@ def _decode_left_right_balance(value) -> Optional[float]:
     if value is None:
         return None
     try:
-        # FIT protocol: bit 15 is a flag indicating right-dominant
-        # lower 7 bits represent the minority side percentage (0-100)
         int_val = int(value)
         right_dominant = bool(int_val & 0x8000)
         pct = (int_val & 0x7FFF) / 100.0
@@ -87,7 +90,7 @@ def _semicircles_to_degrees(value) -> Optional[float]:
 
 
 # ---------------------------------------------------------------------------
-# Parsing logic
+# Extraction helpers
 # ---------------------------------------------------------------------------
 
 def _extract_fit_bytes(raw: bytes) -> bytes:
@@ -96,7 +99,6 @@ def _extract_fit_bytes(raw: bytes) -> bytes:
     Garmin's ORIGINAL format download returns a ZIP archive containing one or
     more .fit files. Handle that, plus fall back for gzip and raw FIT.
     """
-    # ZIP archive (Garmin ORIGINAL format — most common)
     if raw[:2] == b'PK':
         with zipfile.ZipFile(io.BytesIO(raw)) as zf:
             fit_names = [n for n in zf.namelist() if n.lower().endswith('.fit')]
@@ -104,26 +106,494 @@ def _extract_fit_bytes(raw: bytes) -> bytes:
                 raise ValueError("ZIP archive contains no .fit files")
             return zf.read(fit_names[0])
 
-    # Gzip-compressed FIT
     if raw[:2] == b'\x1f\x8b':
         return gzip.decompress(raw)
 
-    # Raw FIT (starts with header size byte 0x0c or 0x0e)
     return raw
 
+
+def _safe_avg(values: list) -> Optional[float]:
+    """Return mean of a list of numbers, or None if empty."""
+    vals = [v for v in values if v is not None]
+    if not vals:
+        return None
+    return sum(vals) / len(vals)
+
+
+def _safe_round(value, ndigits: int = 1) -> Optional[float]:
+    if value is None:
+        return None
+    return round(value, ndigits)
+
+
+# ---------------------------------------------------------------------------
+# Power Duration Curve (Mean Maximal Power)
+# ---------------------------------------------------------------------------
+
+_PDC_DURATIONS_S = [5, 30, 60, 300, 600, 1200, 3600]
+_PDC_LABELS = ["5s", "30s", "1min", "5min", "10min", "20min", "60min"]
+
+
+def _compute_power_duration_curve(records: List[Dict]) -> Optional[Dict]:
+    """Compute best mean maximal power for standard durations.
+
+    Uses a sliding window over the per-second power values.
+    O(n * num_durations) — efficient for rides up to ~8 hours.
+    """
+    powers = [r.get("power_w") for r in records]
+    if not any(p is not None for p in powers):
+        return None
+
+    # Fill None gaps with 0 (coasting) for window computation
+    filled = [p if p is not None else 0 for p in powers]
+    n = len(filled)
+    if n == 0:
+        return None
+
+    # Precompute prefix sums for O(1) window queries
+    prefix = [0] * (n + 1)
+    for i, p in enumerate(filled):
+        prefix[i + 1] = prefix[i] + p
+
+    curve: Dict[str, Any] = {}
+    for duration_s, label in zip(_PDC_DURATIONS_S, _PDC_LABELS):
+        if n < duration_s:
+            continue
+        best = 0
+        for i in range(n - duration_s + 1):
+            window_sum = prefix[i + duration_s] - prefix[i]
+            if window_sum > best:
+                best = window_sum
+        best_avg = best / duration_s
+        if best_avg > 0:
+            curve[label] = round(best_avg)
+
+    return curve if curve else None
+
+
+# ---------------------------------------------------------------------------
+# Climb detection + VAM
+# ---------------------------------------------------------------------------
+
+def _detect_climbs(
+    records: List[Dict],
+    min_elevation_gain_m: float = 50.0,
+    min_avg_grade_pct: float = 3.0,
+    min_duration_s: int = 120,
+) -> List[Dict]:
+    """Segment the ride into climbs based on sustained positive grade.
+
+    A climb starts when grade rises above min_avg_grade_pct and ends when it
+    drops back below it for more than 30 seconds.
+    """
+    if not records:
+        return []
+
+    climbs = []
+    in_climb = False
+    climb_start_idx = 0
+    flat_count = 0
+    FLAT_TOLERANCE_S = 30
+
+    for i, rec in enumerate(records):
+        grade = rec.get("grade_pct")
+        if grade is None:
+            continue
+
+        if not in_climb:
+            if grade >= min_avg_grade_pct:
+                in_climb = True
+                climb_start_idx = i
+                flat_count = 0
+        else:
+            if grade < min_avg_grade_pct:
+                flat_count += 1
+                if flat_count > FLAT_TOLERANCE_S:
+                    # End the climb at where the flat started
+                    end_idx = i - flat_count
+                    climb = _summarize_climb(records, climb_start_idx, end_idx)
+                    if (climb.get("elevation_gain_m", 0) >= min_elevation_gain_m and
+                            climb.get("duration_s", 0) >= min_duration_s):
+                        climbs.append(climb)
+                    in_climb = False
+                    flat_count = 0
+            else:
+                flat_count = 0
+
+    # Close any open climb at end of ride
+    if in_climb:
+        climb = _summarize_climb(records, climb_start_idx, len(records) - 1)
+        if (climb.get("elevation_gain_m", 0) >= min_elevation_gain_m and
+                climb.get("duration_s", 0) >= min_duration_s):
+            climbs.append(climb)
+
+    return climbs
+
+
+def _summarize_climb(records: List[Dict], start_idx: int, end_idx: int) -> Dict:
+    """Compute aggregate stats for a climb segment."""
+    segment = records[start_idx:end_idx + 1]
+    if not segment:
+        return {}
+
+    duration_s = len(segment)  # 1 record ≈ 1 second
+    start_alt = segment[0].get("altitude_m")
+    end_alt = segment[-1].get("altitude_m")
+    elevation_gain = (end_alt - start_alt) if (start_alt is not None and end_alt is not None) else None
+
+    powers = [r["power_w"] for r in segment if r.get("power_w") is not None]
+    cadences = [r["cadence_rpm"] for r in segment if r.get("cadence_rpm") is not None]
+    hrs = [r["heart_rate_bpm"] for r in segment if r.get("heart_rate_bpm") is not None]
+    grades = [r["grade_pct"] for r in segment if r.get("grade_pct") is not None]
+    speeds = [r["speed_mps"] for r in segment if r.get("speed_mps") is not None]
+
+    result: Dict[str, Any] = {
+        "start_time": segment[0].get("timestamp", ""),
+        "end_time": segment[-1].get("timestamp", ""),
+        "duration_s": duration_s,
+    }
+
+    if elevation_gain is not None:
+        result["elevation_gain_m"] = round(elevation_gain, 1)
+        if duration_s > 0:
+            result["vam_m_per_hr"] = round((elevation_gain / duration_s) * 3600)
+
+    if speeds:
+        total_dist = sum(s for s in speeds)  # m/s * 1s = m per record
+        result["distance_m"] = round(total_dist)
+
+    if grades:
+        result["avg_grade_pct"] = round(_safe_avg(grades), 1)
+        result["max_grade_pct"] = round(max(grades), 1)
+
+    if powers:
+        result["avg_power_w"] = round(_safe_avg(powers))
+
+    if cadences:
+        result["avg_cadence_rpm"] = round(_safe_avg(cadences))
+
+    if hrs:
+        result["avg_hr_bpm"] = round(_safe_avg(hrs))
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Grade analysis
+# ---------------------------------------------------------------------------
+
+def _grade_analysis(records: List[Dict]) -> Optional[Dict]:
+    """Bin per-second records by grade and report avg power/cadence/HR per bin."""
+    bins = {
+        "descending": {"label": "descending (<-3%)", "records": []},
+        "flat": {"label": "flat (-3% to 3%)", "records": []},
+        "gentle": {"label": "gentle (3-6%)", "records": []},
+        "moderate": {"label": "moderate (6-9%)", "records": []},
+        "steep": {"label": "steep (>9%)", "records": []},
+    }
+
+    has_grade = False
+    for rec in records:
+        grade = rec.get("grade_pct")
+        if grade is None:
+            continue
+        has_grade = True
+        if grade < -3:
+            bucket = "descending"
+        elif grade < 3:
+            bucket = "flat"
+        elif grade < 6:
+            bucket = "gentle"
+        elif grade < 9:
+            bucket = "moderate"
+        else:
+            bucket = "steep"
+        bins[bucket]["records"].append(rec)
+
+    if not has_grade:
+        return None
+
+    result = {}
+    for key, data in bins.items():
+        recs = data["records"]
+        if not recs:
+            continue
+        entry: Dict[str, Any] = {"time_s": len(recs)}
+        powers = [r["power_w"] for r in recs if r.get("power_w") is not None]
+        cadences = [r["cadence_rpm"] for r in recs if r.get("cadence_rpm") is not None]
+        hrs = [r["heart_rate_bpm"] for r in recs if r.get("heart_rate_bpm") is not None]
+        if powers:
+            entry["avg_power_w"] = round(_safe_avg(powers))
+        if cadences:
+            entry["avg_cadence_rpm"] = round(_safe_avg(cadences))
+        if hrs:
+            entry["avg_hr_bpm"] = round(_safe_avg(hrs))
+        result[key] = entry
+
+    return result if result else None
+
+
+# ---------------------------------------------------------------------------
+# HR drift / cardiac drift (aerobic decoupling)
+# ---------------------------------------------------------------------------
+
+def _compute_hr_drift(records: List[Dict]) -> Optional[Dict]:
+    """Compute aerobic decoupling (HR drift vs. power over the ride).
+
+    Splits the ride into first and second halves by record count.
+    Computes power:HR ratio for each half.
+    Drift % = change in ratio from first to second half.
+    Negative drift = HR increased relative to power (decoupling = less efficient).
+    """
+    MIN_RECORDS = 3600  # require ≥60 min of data
+
+    filtered = [
+        r for r in records
+        if r.get("power_w") is not None and r.get("heart_rate_bpm") is not None
+        and r["heart_rate_bpm"] > 0
+    ]
+
+    if len(filtered) < MIN_RECORDS:
+        return None
+
+    mid = len(filtered) // 2
+    first_half = filtered[:mid]
+    second_half = filtered[mid:]
+
+    def power_hr_ratio(recs):
+        avg_p = _safe_avg([r["power_w"] for r in recs])
+        avg_hr = _safe_avg([r["heart_rate_bpm"] for r in recs])
+        if avg_p is None or avg_hr is None or avg_hr == 0:
+            return None
+        return avg_p / avg_hr
+
+    r1 = power_hr_ratio(first_half)
+    r2 = power_hr_ratio(second_half)
+
+    if r1 is None or r2 is None or r1 == 0:
+        return None
+
+    drift_pct = ((r2 - r1) / r1) * 100
+
+    if abs(drift_pct) < 5:
+        interpretation = "well_coupled"
+    elif abs(drift_pct) < 10:
+        interpretation = "moderate_drift"
+    else:
+        interpretation = "significant_decoupling"
+
+    return {
+        "hr_drift_pct": round(drift_pct, 1),
+        "first_half_power_hr_ratio": round(r1, 3),
+        "second_half_power_hr_ratio": round(r2, 3),
+        "interpretation": interpretation,
+        "note": "Negative drift = HR increased vs power (decoupling). >10% suggests aerobic base is limiting factor.",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Temperature correlation
+# ---------------------------------------------------------------------------
+
+def _compute_temperature_stats(records: List[Dict]) -> Optional[Dict]:
+    """Summarize temperature and its relationship to HR and power."""
+    temps = [r["temperature_c"] for r in records if r.get("temperature_c") is not None]
+    if not temps:
+        return None
+
+    avg_temp = _safe_avg(temps)
+    temp_min = min(temps)
+    temp_max = max(temps)
+
+    # Compare HR and power in coolest vs hottest third of records
+    sorted_by_temp = sorted(
+        [r for r in records if r.get("temperature_c") is not None],
+        key=lambda r: r["temperature_c"]
+    )
+    third = max(1, len(sorted_by_temp) // 3)
+    coolest = sorted_by_temp[:third]
+    hottest = sorted_by_temp[-third:]
+
+    cool_hr = _safe_round(_safe_avg([r["heart_rate_bpm"] for r in coolest if r.get("heart_rate_bpm")]))
+    hot_hr = _safe_round(_safe_avg([r["heart_rate_bpm"] for r in hottest if r.get("heart_rate_bpm")]))
+    cool_power = _safe_round(_safe_avg([r["power_w"] for r in coolest if r.get("power_w")]))
+    hot_power = _safe_round(_safe_avg([r["power_w"] for r in hottest if r.get("power_w")]))
+
+    result: Dict[str, Any] = {
+        "avg_temp_c": _safe_round(avg_temp),
+        "min_temp_c": temp_min,
+        "max_temp_c": temp_max,
+        "temp_range_c": round(temp_max - temp_min, 1),
+    }
+    if cool_hr is not None:
+        result["avg_hr_coolest_third_bpm"] = cool_hr
+    if hot_hr is not None:
+        result["avg_hr_hottest_third_bpm"] = hot_hr
+    if cool_power is not None:
+        result["avg_power_coolest_third_w"] = cool_power
+    if hot_power is not None:
+        result["avg_power_hottest_third_w"] = hot_power
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Weight / W/kg lookup
+# ---------------------------------------------------------------------------
+
+def _get_rider_weight_kg(activity_date_str: str) -> Optional[float]:
+    """Fetch rider weight from Garmin body composition for the given date."""
+    if garmin_client is None:
+        return None
+    try:
+        data = garmin_client.get_body_composition(activity_date_str)
+        if not data:
+            return None
+        # Response is typically {"startDate": ..., "endDate": ..., "dateWeightList": [...]}
+        weight_list = data.get("dateWeightList") or data.get("totalAverage") and [data]
+        if not weight_list:
+            # Try flat dict
+            weight_g = data.get("weight") or data.get("totalWeightInGrams")
+            if weight_g:
+                return round(weight_g / 1000.0, 2)
+            return None
+        # Find closest entry to the activity date
+        for entry in reversed(weight_list):
+            weight_g = entry.get("weight") or entry.get("totalWeightInGrams")
+            if weight_g:
+                return round(weight_g / 1000.0, 2)
+    except Exception:
+        pass
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Shift summary
+# ---------------------------------------------------------------------------
+
+def _compute_shift_summary(shifts: list) -> dict:
+    """Compute aggregate statistics over all shift events."""
+    if not shifts:
+        return {"total_shifts": 0, "note": "No DI2 shift events found in FIT file"}
+
+    quality_counts: Dict[str, int] = {
+        "proactive": 0, "reactive": 0, "coasting": 0, "spun_out": 0, "unknown": 0
+    }
+    terrain_quality: Dict[str, Dict[str, int]] = {
+        "climbing": {"proactive": 0, "reactive": 0, "coasting": 0, "spun_out": 0, "unknown": 0},
+        "flat": {"proactive": 0, "reactive": 0, "coasting": 0, "spun_out": 0, "unknown": 0},
+        "descending": {"proactive": 0, "reactive": 0, "coasting": 0, "spun_out": 0, "unknown": 0},
+    }
+    front_shifts = 0
+    rear_shifts = 0
+    gear_usage: dict = {}
+    cadences_at_shift = []
+
+    # Burst detection: 3+ shifts within ~6 consecutive events
+    panic_bursts = 0
+    burst_i = 0
+    while burst_i < len(shifts):
+        window = [shifts[burst_i]]
+        for j in range(burst_i + 1, min(burst_i + 6, len(shifts))):
+            window.append(shifts[j])
+        if len(window) >= 3:
+            panic_bursts += 1
+            burst_i += len(window)
+        else:
+            burst_i += 1
+
+    for s in shifts:
+        quality = s.get("quality", "unknown")
+        quality_counts[quality] = quality_counts.get(quality, 0) + 1
+
+        # Terrain classification
+        grade = s.get("grade_at_shift_pct")
+        if grade is not None:
+            if grade >= 3:
+                terrain = "climbing"
+            elif grade <= -3:
+                terrain = "descending"
+            else:
+                terrain = "flat"
+        else:
+            terrain = "flat"  # default
+        terrain_quality[terrain][quality] = terrain_quality[terrain].get(quality, 0) + 1
+
+        event = s.get("event", "")
+        if "front" in event:
+            front_shifts += 1
+        else:
+            rear_shifts += 1
+
+        combo = s.get("gear_combo")
+        if combo:
+            gear_usage[combo] = gear_usage.get(combo, 0) + 1
+
+        cad = s.get("cadence_at_shift_rpm")
+        if cad is not None:
+            cadences_at_shift.append(cad)
+
+    total = len(shifts)
+    proactive = quality_counts.get("proactive", 0)
+    reactive = quality_counts.get("reactive", 0)
+
+    summary: Dict[str, Any] = {
+        "total_shifts": total,
+        "front_shifts": front_shifts,
+        "rear_shifts": rear_shifts,
+        "proactive_shifts": proactive,
+        "reactive_shifts": reactive,
+        "coasting_shifts": quality_counts.get("coasting", 0),
+        "spun_out_shifts": quality_counts.get("spun_out", 0),
+        "proactive_pct": round(proactive / total * 100, 1) if total else 0,
+        "reactive_pct": round(reactive / total * 100, 1) if total else 0,
+        "panic_burst_episodes": panic_bursts,
+        "gear_usage": dict(sorted(gear_usage.items(), key=lambda x: -x[1])),
+    }
+
+    # Include terrain breakdown only if grade data was present
+    has_terrain_data = any(s.get("grade_at_shift_pct") is not None for s in shifts)
+    if has_terrain_data:
+        terrain_summary = {}
+        for terrain, counts in terrain_quality.items():
+            t_total = sum(counts.values())
+            if t_total > 0:
+                terrain_summary[terrain] = {
+                    "total": t_total,
+                    "proactive": counts.get("proactive", 0),
+                    "reactive": counts.get("reactive", 0),
+                    "reactive_pct": round(counts.get("reactive", 0) / t_total * 100, 1),
+                }
+        if terrain_summary:
+            summary["by_terrain"] = terrain_summary
+
+    if cadences_at_shift:
+        summary["avg_cadence_at_shift_rpm"] = round(
+            sum(cadences_at_shift) / len(cadences_at_shift), 1
+        )
+        summary["min_cadence_at_shift_rpm"] = min(cadences_at_shift)
+        summary["max_cadence_at_shift_rpm"] = max(cadences_at_shift)
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# Main FIT parsing logic
+# ---------------------------------------------------------------------------
 
 def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
     """Parse a FIT file and extract structured cycling data."""
     fit_bytes = _extract_fit_bytes(fit_bytes)
     fitfile = fitparse.FitFile(io.BytesIO(fit_bytes))
 
-    session = {}
-    laps = []
-    shifts = []
-    records = []
+    session: Dict[str, Any] = {}
+    laps: List[Dict] = []
+    shifts: List[Dict] = []
+    records: List[Dict] = []
 
-    # Track last cadence for shift quality assessment
-    last_cadence = None
+    # Track last values for context at shift time
+    last_cadence: Optional[float] = None
+    last_grade: Optional[float] = None
 
     for message in fitfile.get_messages():
         msg_type = message.name
@@ -171,7 +641,7 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
         # Lap data
         # ------------------------------------------------------------------
         elif msg_type == "lap":
-            lap = {
+            lap: Dict[str, Any] = {
                 "lap_number": len(laps) + 1,
                 "start_time": str(_get_field(message, "start_time") or ""),
                 "total_elapsed_time_s": _get_field(message, "total_elapsed_time"),
@@ -183,6 +653,12 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
                 "avg_heart_rate_bpm": _get_field(message, "avg_heart_rate"),
                 "avg_left_pco_mm": _get_field(message, "avg_left_pco"),
                 "avg_right_pco_mm": _get_field(message, "avg_right_pco"),
+                "avg_left_torque_effectiveness_pct": _get_field(message, "avg_left_torque_effectiveness"),
+                "avg_right_torque_effectiveness_pct": _get_field(message, "avg_right_torque_effectiveness"),
+                "avg_left_pedal_smoothness_pct": _get_field(message, "avg_left_pedal_smoothness"),
+                "avg_right_pedal_smoothness_pct": _get_field(message, "avg_right_pedal_smoothness"),
+                "total_ascent_m": _get_field(message, "total_ascent"),
+                "total_descent_m": _get_field(message, "total_descent"),
             }
             balance_raw = _get_field(message, "avg_left_right_balance")
             left_pct = _decode_left_right_balance(balance_raw)
@@ -190,6 +666,13 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
                 lap["avg_left_power_pct"] = left_pct
                 lap["avg_right_power_pct"] = round(100.0 - left_pct, 1)
             lap = {k: v for k, v in lap.items() if v is not None}
+
+            # Variability Index per lap
+            np_w = lap.get("normalized_power_w")
+            avg_w = lap.get("avg_power_w")
+            if np_w and avg_w and avg_w > 0:
+                lap["variability_index"] = round(np_w / avg_w, 3)
+
             laps.append(lap)
 
         # ------------------------------------------------------------------
@@ -201,17 +684,19 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
                 gear_data_raw = _get_field(message, "gear_change_data", "data")
                 timestamp = _get_field(message, "timestamp")
 
-                shift_entry = {
+                shift_entry: Dict[str, Any] = {
                     "timestamp": str(timestamp or ""),
                     "event": str(event_type),
                     "cadence_at_shift_rpm": last_cadence,
                 }
 
+                if last_grade is not None:
+                    shift_entry["grade_at_shift_pct"] = round(last_grade, 1)
+
                 if gear_data_raw is not None:
                     try:
                         decoded = _decode_gear_change(int(gear_data_raw))
                         shift_entry.update(decoded)
-                        # Build human-readable combo
                         ft = decoded.get("front_teeth")
                         rt = decoded.get("rear_teeth")
                         if ft and rt:
@@ -219,17 +704,17 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
                     except (TypeError, ValueError):
                         shift_entry["gear_change_data_raw"] = str(gear_data_raw)
 
-                # Classify shift quality based on cadence
+                # Classify shift quality
                 cad = last_cadence
                 if cad is not None:
                     if cad == 0:
                         shift_entry["quality"] = "coasting"
                     elif cad < 70:
-                        shift_entry["quality"] = "reactive"       # already grinding
+                        shift_entry["quality"] = "reactive"
                     elif cad > 100:
-                        shift_entry["quality"] = "spun_out"       # waited too long on easy side
+                        shift_entry["quality"] = "spun_out"
                     else:
-                        shift_entry["quality"] = "proactive"      # good cadence range
+                        shift_entry["quality"] = "proactive"
                 else:
                     shift_entry["quality"] = "unknown"
 
@@ -244,170 +729,95 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
             if cadence is not None:
                 last_cadence = cadence
 
-            if include_records:
-                record = {
-                    "timestamp": str(_get_field(message, "timestamp") or ""),
-                    "power_w": _get_field(message, "power"),
-                    "cadence_rpm": cadence,
-                    "heart_rate_bpm": _get_field(message, "heart_rate"),
-                    "speed_mps": _get_field(message, "speed"),
-                    "altitude_m": _get_field(message, "altitude"),
-                    "grade_pct": _get_field(message, "grade"),
-                    "temperature_c": _get_field(message, "temperature"),
-                    "lat_deg": _semicircles_to_degrees(_get_field(message, "position_lat")),
-                    "lon_deg": _semicircles_to_degrees(_get_field(message, "position_long")),
-                    "left_pco_mm": _get_field(message, "left_pco"),
-                    "right_pco_mm": _get_field(message, "right_pco"),
-                    "left_torque_effectiveness_pct": _get_field(message, "left_torque_effectiveness"),
-                    "right_torque_effectiveness_pct": _get_field(message, "right_torque_effectiveness"),
-                    "left_pedal_smoothness_pct": _get_field(message, "left_pedal_smoothness"),
-                    "right_pedal_smoothness_pct": _get_field(message, "right_pedal_smoothness"),
-                }
-                balance_raw = _get_field(message, "left_right_balance")
-                left_pct = _decode_left_right_balance(balance_raw)
-                if left_pct is not None:
-                    record["left_power_pct"] = left_pct
-                    record["right_power_pct"] = round(100.0 - left_pct, 1)
+            grade = _get_field(message, "grade")
+            if grade is not None:
+                last_grade = grade
 
-                # Power phase angles (stored as array: [start_deg, end_deg])
-                left_phase = _get_field(message, "left_power_phase")
-                if left_phase:
-                    try:
-                        record["left_power_phase_start_deg"] = left_phase[0]
-                        record["left_power_phase_end_deg"] = left_phase[1]
-                    except (IndexError, TypeError):
-                        pass
-                right_phase = _get_field(message, "right_power_phase")
-                if right_phase:
-                    try:
-                        record["right_power_phase_start_deg"] = right_phase[0]
-                        record["right_power_phase_end_deg"] = right_phase[1]
-                    except (IndexError, TypeError):
-                        pass
+            record: Dict[str, Any] = {
+                "timestamp": str(_get_field(message, "timestamp") or ""),
+                "power_w": _get_field(message, "power"),
+                "cadence_rpm": cadence,
+                "heart_rate_bpm": _get_field(message, "heart_rate"),
+                "speed_mps": _get_field(message, "speed"),
+                "altitude_m": _get_field(message, "altitude"),
+                "grade_pct": grade,
+                "temperature_c": _get_field(message, "temperature"),
+                "lat_deg": _semicircles_to_degrees(_get_field(message, "position_lat")),
+                "lon_deg": _semicircles_to_degrees(_get_field(message, "position_long")),
+                "left_pco_mm": _get_field(message, "left_pco"),
+                "right_pco_mm": _get_field(message, "right_pco"),
+                "left_torque_effectiveness_pct": _get_field(message, "left_torque_effectiveness"),
+                "right_torque_effectiveness_pct": _get_field(message, "right_torque_effectiveness"),
+                "left_pedal_smoothness_pct": _get_field(message, "left_pedal_smoothness"),
+                "right_pedal_smoothness_pct": _get_field(message, "right_pedal_smoothness"),
+            }
+            balance_raw = _get_field(message, "left_right_balance")
+            left_pct = _decode_left_right_balance(balance_raw)
+            if left_pct is not None:
+                record["left_power_pct"] = left_pct
+                record["right_power_pct"] = round(100.0 - left_pct, 1)
 
-                record = {k: v for k, v in record.items() if v is not None}
-                records.append(record)
+            left_phase = _get_field(message, "left_power_phase")
+            if left_phase:
+                try:
+                    record["left_power_phase_start_deg"] = left_phase[0]
+                    record["left_power_phase_end_deg"] = left_phase[1]
+                except (IndexError, TypeError):
+                    pass
+            right_phase = _get_field(message, "right_power_phase")
+            if right_phase:
+                try:
+                    record["right_power_phase_start_deg"] = right_phase[0]
+                    record["right_power_phase_end_deg"] = right_phase[1]
+                except (IndexError, TypeError):
+                    pass
+
+            record = {k: v for k, v in record.items() if v is not None}
+            records.append(record)
 
     # ------------------------------------------------------------------
-    # Shift summary statistics
+    # Post-parse enrichment
     # ------------------------------------------------------------------
+
+    # Variability Index for session
+    np_w = session.get("normalized_power_w")
+    avg_w = session.get("avg_power_w")
+    if np_w and avg_w and avg_w > 0:
+        session["variability_index"] = round(np_w / avg_w, 3)
+
     shift_summary = _compute_shift_summary(shifts)
 
-    result = {
+    # Record-based analytics (computed from per-second data regardless of include_records flag)
+    grade_stats = _grade_analysis(records) if records else None
+    hr_drift = _compute_hr_drift(records) if records else None
+    temp_stats = _compute_temperature_stats(records) if records else None
+    climbs = _detect_climbs(records) if records else []
+    pdc = _compute_power_duration_curve(records) if records else None
+
+    if grade_stats:
+        session["grade_analysis"] = grade_stats
+    if hr_drift:
+        session["hr_drift"] = hr_drift
+    if temp_stats:
+        session["temperature_stats"] = temp_stats
+
+    result: Dict[str, Any] = {
         "session": session,
         "laps": laps,
         "shift_summary": shift_summary,
         "shifts": shifts,
     }
+
+    if climbs:
+        result["climbs"] = climbs
+
+    if pdc:
+        result["power_duration_curve"] = pdc
+
     if include_records:
         result["records"] = records
+
     return result
-
-
-def _compute_shift_summary(shifts: list) -> dict:
-    """Compute aggregate statistics over all shift events."""
-    if not shifts:
-        return {"total_shifts": 0, "note": "No DI2 shift events found in FIT file"}
-
-    quality_counts = {"proactive": 0, "reactive": 0, "coasting": 0, "spun_out": 0, "unknown": 0}
-    front_shifts = 0
-    rear_shifts = 0
-    gear_usage: dict = {}
-    cadences_at_shift = []
-
-    # Detect panic bursts: 3+ shifts within 5 seconds
-    panic_bursts = 0
-    timestamps = []
-    for s in shifts:
-        ts = s.get("timestamp", "")
-        if ts:
-            timestamps.append(ts)
-
-    # Simple burst detection using index proximity (shifts are time-ordered)
-    BURST_WINDOW = 5  # seconds, approximated by index proximity
-    for i in range(len(shifts)):
-        window_shifts = 1
-        for j in range(i + 1, len(shifts)):
-            # Without parsing timestamps deeply, count shifts that are within
-            # a small index window as a burst proxy
-            if j - i <= 5:
-                window_shifts += 1
-            else:
-                break
-        if window_shifts >= 3 and i == 0 or (i > 0):
-            pass  # placeholder, actual burst count below
-
-    # Re-detect bursts by timestamp string comparison when available
-    import re
-    def _ts_seconds(ts_str):
-        """Extract seconds offset from timestamp string for comparison."""
-        # timestamps are datetime objects converted to string, e.g. "2024-03-02 14:23:45+00:00"
-        m = re.search(r':(\d+)(?:\+|$)', ts_str)
-        if m:
-            return int(m.group(1))
-        return None
-
-    burst_i = 0
-    while burst_i < len(shifts):
-        window = [shifts[burst_i]]
-        for j in range(burst_i + 1, len(shifts)):
-            # Use adjacent shifts as proxy for time proximity
-            if j - burst_i < 6:  # up to 5 subsequent shifts
-                window.append(shifts[j])
-            else:
-                break
-        if len(window) >= 3:
-            panic_bursts += 1
-            burst_i += len(window)
-        else:
-            burst_i += 1
-
-    for s in shifts:
-        quality = s.get("quality", "unknown")
-        quality_counts[quality] = quality_counts.get(quality, 0) + 1
-
-        event = s.get("event", "")
-        if "front" in event:
-            front_shifts += 1
-        elif "rear" in event:
-            rear_shifts += 1
-        else:
-            rear_shifts += 1  # default to rear
-
-        combo = s.get("gear_combo")
-        if combo:
-            gear_usage[combo] = gear_usage.get(combo, 0) + 1
-
-        cad = s.get("cadence_at_shift_rpm")
-        if cad is not None:
-            cadences_at_shift.append(cad)
-
-    total = len(shifts)
-    proactive = quality_counts.get("proactive", 0)
-    reactive = quality_counts.get("reactive", 0)
-
-    summary = {
-        "total_shifts": total,
-        "front_shifts": front_shifts,
-        "rear_shifts": rear_shifts,
-        "proactive_shifts": proactive,
-        "reactive_shifts": reactive,
-        "coasting_shifts": quality_counts.get("coasting", 0),
-        "spun_out_shifts": quality_counts.get("spun_out", 0),
-        "proactive_pct": round(proactive / total * 100, 1) if total else 0,
-        "reactive_pct": round(reactive / total * 100, 1) if total else 0,
-        "panic_burst_episodes": panic_bursts,
-        "gear_usage": dict(sorted(gear_usage.items(), key=lambda x: -x[1])),
-    }
-
-    if cadences_at_shift:
-        summary["avg_cadence_at_shift_rpm"] = round(
-            sum(cadences_at_shift) / len(cadences_at_shift), 1
-        )
-        summary["min_cadence_at_shift_rpm"] = min(cadences_at_shift)
-        summary["max_cadence_at_shift_rpm"] = max(cadences_at_shift)
-
-    return summary
 
 
 # ---------------------------------------------------------------------------
@@ -425,23 +835,27 @@ def register_tools(app):
         """Download and parse FIT file for an activity to expose advanced cycling data.
 
         Returns data not available through the standard REST API, including:
-        - DI2 / electronic shifting events with cadence at time of shift,
-          gear combinations, shift quality classification, and panic burst detection
-        - Cycling dynamics per lap: platform center offset (PCO), left/right power
+        - DI2 / electronic shifting events with cadence at time of shift, grade at shift,
+          gear combinations, shift quality classification, and terrain-grouped shift analysis
+        - Cycling dynamics per session and lap: platform center offset (PCO), left/right power
           balance, torque effectiveness, pedal smoothness
-        - Session-level averages for all cycling dynamics metrics
-        - Optional full per-second time series (power, cadence, HR, speed, altitude,
-          GPS, PCO per record) when include_records=True
+        - Variability Index (NP / avg_power) per session and lap
+        - Climb detection with VAM (vertical ascent rate), avg power/cadence/HR per climb,
+          and W/kg per climb (using auto-fetched body weight from Garmin)
+        - Grade-correlated stats: avg power, cadence, HR broken down by terrain steepness
+        - HR drift / cardiac drift coefficient (aerobic decoupling for rides ≥60 min)
+        - Temperature correlation: avg HR/power in hottest vs. coolest portions of ride
+        - Power Duration Curve: best mean maximal power at 5s, 30s, 1min, 5min, 10min, 20min, 60min
+        - Optional full per-second time series when include_records=True
 
-        Shift quality is classified as:
+        Shift quality:
         - proactive: shifted at 70-100 rpm (ideal cadence range)
         - reactive: shifted below 70 rpm (already grinding before shifting)
         - coasting: shifted at 0 rpm (mid-stop or freewheeling)
         - spun_out: shifted above 100 rpm (waited too long in easy gear)
 
-        Note: DI2 data requires a Shimano Di2 / SRAM eTap equipped bike synced
-        to the Garmin device. Cycling dynamics require a compatible power meter
-        (e.g., Garmin Rally, Favero Assioma, PowerTap P1 pedals).
+        Note: DI2 data requires Shimano Di2 / SRAM eTap. Cycling dynamics require a
+        compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1 pedals).
 
         Args:
             activity_id: Garmin activity ID
@@ -466,8 +880,6 @@ def register_tools(app):
                 return f"No FIT data returned for activity {activity_id}"
 
             raw = bytes(fit_bytes)
-            first16 = raw[:16].hex()
-            first200_text = raw[:200].decode("utf-8", errors="replace")
 
             try:
                 parsed = _parse_fit(raw, include_records=include_records)
@@ -476,8 +888,7 @@ def register_tools(app):
                     "error": str(parse_err),
                     "debug": {
                         "total_bytes": len(raw),
-                        "first_16_bytes_hex": first16,
-                        "first_200_bytes_text": first200_text,
+                        "first_16_bytes_hex": raw[:16].hex(),
                         "hint": (
                             "1f8b = gzip, 504b = ZIP, 0e10/0c10 = raw FIT, "
                             "3c or 7b = HTML/JSON error from Garmin"
@@ -486,11 +897,143 @@ def register_tools(app):
                 }, indent=2)
 
             parsed["activity_id"] = activity_id
-            parsed["include_records"] = include_records
+
+            # W/kg: fetch body weight matched to activity date
+            start_time_str = parsed.get("session", {}).get("start_time", "")
+            activity_date = start_time_str[:10] if start_time_str else None
+            if activity_date:
+                weight_kg = _get_rider_weight_kg(activity_date)
+                if weight_kg:
+                    parsed["rider_weight_kg"] = weight_kg
+                    # W/kg for session avg power and NP
+                    avg_w = parsed["session"].get("avg_power_w")
+                    np_w = parsed["session"].get("normalized_power_w")
+                    if avg_w:
+                        parsed["session"]["avg_w_per_kg"] = round(avg_w / weight_kg, 2)
+                    if np_w:
+                        parsed["session"]["normalized_w_per_kg"] = round(np_w / weight_kg, 2)
+                    # W/kg per climb
+                    for climb in parsed.get("climbs", []):
+                        climb_w = climb.get("avg_power_w")
+                        if climb_w:
+                            climb["avg_w_per_kg"] = round(climb_w / weight_kg, 2)
 
             return json.dumps(parsed, indent=2, default=str)
 
         except Exception as e:
             return f"Error downloading FIT data for activity {activity_id}: {str(e)}"
+
+    @app.tool()
+    async def get_power_duration_curve(
+        num_activities: int = 20,
+        activity_type: str = "cycling",
+    ) -> str:
+        """Get season-best Power Duration Curve across recent activities.
+
+        Downloads FIT files for recent cycling activities and computes best mean maximal
+        power at each standard duration. Returns season bests with which activity and date
+        each best came from.
+
+        Durations: 5s (sprint), 30s, 1min, 5min (VO2 max proxy), 10min, 20min (FTP proxy), 60min
+
+        Use the 20-minute best × 0.95 as a strong FTP estimate without a formal test.
+
+        Warning: downloads multiple FIT files — may take 30-60 seconds for 20 activities.
+
+        Args:
+            num_activities: Number of recent activities to analyze (default 20, max 50)
+            activity_type: Activity type to filter (default "cycling")
+        """
+        if not FITPARSE_AVAILABLE:
+            return "fitparse library is not installed. Install it with: pip install fitparse"
+
+        MAX_ACTIVITIES = 50
+        num_activities = min(num_activities, MAX_ACTIVITIES)
+
+        try:
+            from garminconnect import Garmin
+
+            # Fetch recent activities
+            activities = garmin_client.get_activities(0, num_activities)
+            if not activities:
+                return "No activities found."
+
+            # Filter by sport type
+            cycling_activities = [
+                a for a in activities
+                if activity_type.lower() in str(a.get("activityType", {}).get("typeKey", "")).lower()
+                or activity_type.lower() in str(a.get("activityType", {}).get("parentTypeId", "")).lower()
+                or "cycling" in str(a.get("activityType", {}).get("typeKey", "")).lower()
+                or "biking" in str(a.get("activityType", {}).get("typeKey", "")).lower()
+            ]
+
+            if not cycling_activities:
+                return f"No {activity_type} activities found in the last {num_activities} activities."
+
+            # Season bests: duration_label -> {watts, activity_id, date}
+            season_bests: Dict[str, Any] = {}
+            processed = 0
+            errors = 0
+
+            for activity in cycling_activities:
+                act_id = activity.get("activityId")
+                act_date = str(activity.get("startTimeLocal", ""))[:10]
+                if not act_id:
+                    continue
+
+                try:
+                    fit_bytes = garmin_client.download_activity(
+                        act_id,
+                        dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL,
+                    )
+                    if not fit_bytes:
+                        continue
+
+                    raw = bytes(fit_bytes)
+                    extracted = _extract_fit_bytes(raw)
+                    fitfile = fitparse.FitFile(io.BytesIO(extracted))
+
+                    # Extract just the power records
+                    act_records = []
+                    for msg in fitfile.get_messages("record"):
+                        p = msg.get_value("power")
+                        act_records.append({"power_w": p})
+
+                    pdc = _compute_power_duration_curve(act_records)
+                    if pdc:
+                        for label, watts in pdc.items():
+                            if label not in season_bests or watts > season_bests[label]["watts"]:
+                                season_bests[label] = {
+                                    "watts": watts,
+                                    "activity_id": act_id,
+                                    "date": act_date,
+                                }
+                    processed += 1
+
+                except Exception:
+                    errors += 1
+                    continue
+
+            if not season_bests:
+                return f"No power data found across {processed} activities."
+
+            # Order by duration
+            ordered = {label: season_bests[label] for label in _PDC_LABELS if label in season_bests}
+
+            # FTP estimate from 20min best
+            ftp_estimate = None
+            if "20min" in ordered:
+                ftp_estimate = round(ordered["20min"]["watts"] * 0.95)
+
+            return json.dumps({
+                "activities_analyzed": processed,
+                "activities_skipped": errors,
+                "ftp_estimate_w": ftp_estimate,
+                "ftp_note": "Estimated as 95% of 20-minute best power",
+                "season_bests": ordered,
+            }, indent=2)
+
+        except Exception as e:
+            return f"Error computing power duration curve: {str(e)}"
 
     return app

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -387,6 +387,25 @@ def register_tools(app):
             return f"Error retrieving activity heart rate time zone data: {str(e)}"
 
     @app.tool()
+    async def get_activity_power_in_timezones(activity_id: int) -> str:
+        """Get power distribution across training zones for an activity.
+
+        Returns time spent in each power zone with watt thresholds and duration.
+        Requires a power meter. Zones are based on the athlete's FTP configured in Garmin Connect.
+
+        Args:
+            activity_id: ID of the activity to retrieve power zone data for
+        """
+        try:
+            power_zones = garmin_client.get_activity_power_in_timezones(activity_id)
+            if not power_zones:
+                return f"No power zone data found for activity {activity_id}. Ensure the activity was recorded with a power meter."
+
+            return json.dumps(power_zones, indent=2)
+        except Exception as e:
+            return f"Error retrieving activity power zone data: {str(e)}"
+
+    @app.tool()
     async def get_activity_gear(activity_id: int) -> str:
         """Get gear data used for an activity
 

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -696,4 +696,290 @@ def register_tools(app):
         except Exception as e:
             return f"Error requesting data reload: {str(e)}"
 
+    @app.tool()
+    async def get_training_load_trend(start_date: str, end_date: str) -> str:
+        """Get the Performance Management Chart (CTL/ATL/TSB) over a date range.
+
+        Returns Chronic Training Load (CTL, 42-day fitness), Acute Training Load (ATL, 7-day fatigue),
+        Training Stress Balance (TSB = CTL - ATL, form/freshness), and Acute:Chronic Workload Ratio
+        (ACWR) per day. Use this to assess whether the athlete is building fitness, peaking, or
+        accumulating too much fatigue.
+
+        Recommended range: 4-8 weeks. Maximum: 90 days.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 90
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days > MAX_DAYS:
+            return f"Date range too large ({days} days). Maximum is {MAX_DAYS} days."
+        if days < 1:
+            return "end_date must be on or after start_date."
+
+        trend = []
+        current = start
+        while current <= end:
+            date_str = current.isoformat()
+            try:
+                data = garmin_client.get_training_status(date_str)
+                if data:
+                    status_data = (
+                        data.get("mostRecentTrainingStatus", {})
+                        .get("latestTrainingStatusData", {})
+                    )
+                    atl_dto = status_data.get("acuteTrainingLoadDTO", {})
+                    vo2_data = data.get("mostRecentVO2Max", {}).get("generic", {})
+                    entry: Dict[str, Any] = {"date": date_str}
+                    atl = atl_dto.get("dailyTrainingLoadAcute")
+                    ctl = atl_dto.get("dailyTrainingLoadChronic")
+                    acwr = atl_dto.get("dailyAcuteChronicWorkloadRatio")
+                    if atl is not None:
+                        entry["atl"] = round(atl, 1)
+                    if ctl is not None:
+                        entry["ctl"] = round(ctl, 1)
+                    if atl is not None and ctl is not None:
+                        entry["tsb"] = round(ctl - atl, 1)
+                    if acwr is not None:
+                        entry["acwr"] = round(acwr, 2)
+                    acwr_status = atl_dto.get("acwrStatus")
+                    if acwr_status:
+                        entry["acwr_status"] = acwr_status
+                    ts = status_data.get("trainingStatusDTO", {})
+                    ts_label = ts.get("trainingStatusCyclingFeedbackPhrase") or ts.get("trainingStatusFeedbackPhrase")
+                    if ts_label:
+                        entry["training_status"] = ts_label
+                    vo2 = vo2_data.get("vo2MaxValue")
+                    if vo2 is not None:
+                        entry["vo2_max"] = round(vo2, 1)
+                    if len(entry) > 1:  # has more than just date
+                        trend.append(entry)
+            except Exception:
+                pass  # skip days with no data
+            current += datetime.timedelta(days=1)
+
+        if not trend:
+            return f"No training load data found between {start_date} and {end_date}."
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "days_with_data": len(trend),
+            "trend": trend,
+        }, indent=2)
+
+    @app.tool()
+    async def get_hrv_trend(start_date: str, end_date: str) -> str:
+        """Get HRV (Heart Rate Variability) trend over a date range.
+
+        Returns daily HRV values and weekly rolling averages. Single-day HRV is too noisy
+        to act on — use this tool to identify baseline shifts that signal accumulated fatigue
+        or recovery. A drop of >10ms from the 7-day baseline warrants reducing training load.
+
+        Recommended range: 7-21 days. Maximum: 30 days.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 30
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days > MAX_DAYS:
+            return f"Date range too large ({days} days). Maximum is {MAX_DAYS} days."
+        if days < 1:
+            return "end_date must be on or after start_date."
+
+        trend = []
+        current = start
+        while current <= end:
+            date_str = current.isoformat()
+            try:
+                data = garmin_client.get_hrv_data(date_str)
+                if data:
+                    hrv_summary = data.get("hrvSummary", {})
+                    entry: Dict[str, Any] = {"date": date_str}
+                    last_night = hrv_summary.get("lastNight")
+                    weekly_avg = hrv_summary.get("weeklyAvg")
+                    status = hrv_summary.get("status")
+                    feedback = hrv_summary.get("feedbackPhrase")
+                    high_hrv = hrv_summary.get("lastNight5MinHigh")
+                    if last_night is not None:
+                        entry["last_night_avg_hrv_ms"] = round(last_night, 1)
+                    if weekly_avg is not None:
+                        entry["weekly_avg_hrv_ms"] = round(weekly_avg, 1)
+                    if high_hrv is not None:
+                        entry["last_night_5min_high_hrv_ms"] = round(high_hrv, 1)
+                    if status:
+                        entry["status"] = status
+                    if feedback:
+                        entry["feedback"] = feedback
+                    if len(entry) > 1:
+                        trend.append(entry)
+            except Exception:
+                pass
+            current += datetime.timedelta(days=1)
+
+        if not trend:
+            return f"No HRV data found between {start_date} and {end_date}."
+
+        # Compute 7-day rolling average from the collected data
+        hrv_values = [e.get("last_night_avg_hrv_ms") for e in trend if e.get("last_night_avg_hrv_ms") is not None]
+        rolling_avg = None
+        if hrv_values:
+            rolling_avg = round(sum(hrv_values) / len(hrv_values), 1)
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "days_with_data": len(trend),
+            "period_avg_hrv_ms": rolling_avg,
+            "trend": trend,
+        }, indent=2)
+
+    @app.tool()
+    async def get_vo2max_trend(start_date: str, end_date: str) -> str:
+        """Get VO2 max trend over a date range.
+
+        Returns daily VO2 max estimates from Garmin's FirstBeat algorithm. Use this to track
+        whether training is producing fitness gains over weeks or months. Flat or declining
+        VO2 max over 4+ weeks suggests insufficient training stimulus or overreaching.
+
+        Note: VO2 max estimates are smoothed and update gradually — daily changes of <0.5
+        are within normal noise. Focus on the 4-6 week trend direction.
+
+        Recommended range: 4-12 weeks. Maximum: 90 days.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 90
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days > MAX_DAYS:
+            return f"Date range too large ({days} days). Maximum is {MAX_DAYS} days."
+        if days < 1:
+            return "end_date must be on or after start_date."
+
+        trend = []
+        last_vo2 = None
+        current = start
+        while current <= end:
+            date_str = current.isoformat()
+            try:
+                data = garmin_client.get_training_status(date_str)
+                if data:
+                    vo2_data = data.get("mostRecentVO2Max", {}).get("generic", {})
+                    vo2 = vo2_data.get("vo2MaxValue")
+                    if vo2 is not None:
+                        vo2_rounded = round(vo2, 1)
+                        if vo2_rounded != last_vo2:  # deduplicate unchanged values
+                            trend.append({"date": date_str, "vo2_max": vo2_rounded})
+                            last_vo2 = vo2_rounded
+            except Exception:
+                pass
+            current += datetime.timedelta(days=1)
+
+        if not trend:
+            return f"No VO2 max data found between {start_date} and {end_date}."
+
+        first_vo2 = trend[0]["vo2_max"] if trend else None
+        latest_vo2 = trend[-1]["vo2_max"] if trend else None
+        change = round(latest_vo2 - first_vo2, 1) if (first_vo2 and latest_vo2) else None
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "data_points": len(trend),
+            "first_vo2_max": first_vo2,
+            "latest_vo2_max": latest_vo2,
+            "change": change,
+            "trend": trend,
+        }, indent=2)
+
+    @app.tool()
+    async def get_respiration_trend(start_date: str, end_date: str) -> str:
+        """Get overnight respiration rate trend over a date range.
+
+        Elevated resting respiration rate (compared to personal baseline) is an early
+        warning sign for overreaching, illness, or poor recovery. Use this alongside HRV
+        trend for a complete recovery picture.
+
+        Recommended range: 7-21 days. Maximum: 30 days.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 30
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days > MAX_DAYS:
+            return f"Date range too large ({days} days). Maximum is {MAX_DAYS} days."
+        if days < 1:
+            return "end_date must be on or after start_date."
+
+        trend = []
+        current = start
+        while current <= end:
+            date_str = current.isoformat()
+            try:
+                data = garmin_client.get_respiration_data(date_str)
+                if data:
+                    entry: Dict[str, Any] = {"date": date_str}
+                    avg_waking = data.get("avgWakingRespirationValue")
+                    avg_sleep = data.get("avgSleepRespirationValue")
+                    high_sleep = data.get("highestRespirationValue")
+                    low_sleep = data.get("lowestRespirationValue")
+                    if avg_waking is not None:
+                        entry["avg_waking_breaths_per_min"] = round(avg_waking, 1)
+                    if avg_sleep is not None:
+                        entry["avg_sleep_breaths_per_min"] = round(avg_sleep, 1)
+                    if high_sleep is not None:
+                        entry["highest_breaths_per_min"] = round(high_sleep, 1)
+                    if low_sleep is not None:
+                        entry["lowest_breaths_per_min"] = round(low_sleep, 1)
+                    if len(entry) > 1:
+                        trend.append(entry)
+            except Exception:
+                pass
+            current += datetime.timedelta(days=1)
+
+        if not trend:
+            return f"No respiration data found between {start_date} and {end_date}."
+
+        sleep_values = [e["avg_sleep_breaths_per_min"] for e in trend if "avg_sleep_breaths_per_min" in e]
+        avg_sleep_overall = round(sum(sleep_values) / len(sleep_values), 1) if sleep_values else None
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "days_with_data": len(trend),
+            "period_avg_sleep_breaths_per_min": avg_sleep_overall,
+            "trend": trend,
+        }, indent=2)
+
     return app

--- a/tests/fixtures/captured/poc_walk_run.json
+++ b/tests/fixtures/captured/poc_walk_run.json
@@ -1,0 +1,100 @@
+{
+  "workoutName": "POC Walk/Run 7x1m/3m Z3",
+  "description": "10m warmup + 7x(60s run / 180s walk) Z3 + 8m cooldown",
+  "sportType": {
+    "sportTypeId": 1,
+    "sportTypeKey": "running"
+  },
+  "workoutSegments": [
+    {
+      "segmentOrder": 1,
+      "sportType": {
+        "sportTypeId": 1,
+        "sportTypeKey": "running"
+      },
+      "workoutSteps": [
+        {
+          "type": "ExecutableStepDTO",
+          "stepOrder": 1,
+          "stepType": {
+            "stepTypeId": 1,
+            "stepTypeKey": "warmup"
+          },
+          "description": "Warmup 10 min",
+          "endCondition": {
+            "conditionTypeId": 2,
+            "conditionTypeKey": "time"
+          },
+          "endConditionValue": 600.0,
+          "targetType": {
+            "workoutTargetTypeId": 1,
+            "workoutTargetTypeKey": "no.target"
+          }
+        },
+        {
+          "type": "RepeatGroupDTO",
+          "stepOrder": 2,
+          "numberOfIterations": 7,
+          "workoutSteps": [
+            {
+              "type": "ExecutableStepDTO",
+              "stepOrder": 1,
+              "stepType": {
+                "stepTypeId": 3,
+                "stepTypeKey": "interval"
+              },
+              "description": "Run 60s Z3",
+              "endCondition": {
+                "conditionTypeId": 2,
+                "conditionTypeKey": "time"
+              },
+              "endConditionValue": 60.0,
+              "targetType": {
+                "workoutTargetTypeId": 4,
+                "workoutTargetTypeKey": "heart.rate.zone"
+              },
+              "zoneNumber": 3
+            },
+            {
+              "type": "ExecutableStepDTO",
+              "stepOrder": 2,
+              "stepType": {
+                "stepTypeId": 4,
+                "stepTypeKey": "recovery"
+              },
+              "description": "Walk 180s Z3",
+              "endCondition": {
+                "conditionTypeId": 2,
+                "conditionTypeKey": "time"
+              },
+              "endConditionValue": 180.0,
+              "targetType": {
+                "workoutTargetTypeId": 4,
+                "workoutTargetTypeKey": "heart.rate.zone"
+              },
+              "zoneNumber": 3
+            }
+          ]
+        },
+        {
+          "type": "ExecutableStepDTO",
+          "stepOrder": 3,
+          "stepType": {
+            "stepTypeId": 2,
+            "stepTypeKey": "cooldown"
+          },
+          "description": "Cooldown 8 min",
+          "endCondition": {
+            "conditionTypeId": 2,
+            "conditionTypeKey": "time"
+          },
+          "endConditionValue": 480.0,
+          "targetType": {
+            "workoutTargetTypeId": 1,
+            "workoutTargetTypeKey": "no.target"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -9,6 +9,14 @@ from unittest.mock import Mock, patch, MagicMock
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import activity_analysis
+from garmin_mcp.activity_analysis import (
+    _compute_power_duration_curve,
+    _detect_climbs,
+    _compute_hr_drift,
+    _compute_temperature_stats,
+    _grade_analysis,
+    _compute_shift_summary,
+)
 
 
 ACTIVITY_ID = 22041393449
@@ -358,3 +366,307 @@ async def test_get_activity_fit_data_no_shifts(app_with_activity_analysis, mock_
     assert data["shift_summary"]["total_shifts"] == 0
     assert "note" in data["shift_summary"]
     assert data["shifts"] == []
+
+
+# ---------------------------------------------------------------------------
+# Variability Index
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_variability_index_session(app_with_activity_analysis, mock_garmin_client):
+    """Variability Index computed for session when NP and avg_power are present"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    session_msg = _make_mock_fit_message("session", {
+        "sport": "cycling",
+        "normalized_power": 210,
+        "avg_power": 175,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([session_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0].text if hasattr(result[0], "text") else str(result)
+    data = json.loads(text)
+    assert "variability_index" in data["session"]
+    assert data["session"]["variability_index"] == round(210 / 175, 3)
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_variability_index_lap(app_with_activity_analysis, mock_garmin_client):
+    """Variability Index computed per lap"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    lap_msg = _make_mock_fit_message("lap", {
+        "normalized_power": 240,
+        "avg_power": 200,
+        "total_elapsed_time": 1800.0,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([lap_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0].text if hasattr(result[0], "text") else str(result)
+    data = json.loads(text)
+    assert len(data["laps"]) == 1
+    assert data["laps"][0]["variability_index"] == round(240 / 200, 3)
+
+
+# ---------------------------------------------------------------------------
+# Lap torque effectiveness + pedal smoothness
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_lap_torque_and_smoothness(app_with_activity_analysis, mock_garmin_client):
+    """Torque effectiveness and pedal smoothness included in lap data"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    lap_msg = _make_mock_fit_message("lap", {
+        "avg_left_torque_effectiveness": 82.5,
+        "avg_right_torque_effectiveness": 79.0,
+        "avg_left_pedal_smoothness": 31.2,
+        "avg_right_pedal_smoothness": 28.4,
+        "total_elapsed_time": 3600.0,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([lap_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0].text if hasattr(result[0], "text") else str(result)
+    data = json.loads(text)
+    lap = data["laps"][0]
+    assert lap["avg_left_torque_effectiveness_pct"] == 82.5
+    assert lap["avg_right_torque_effectiveness_pct"] == 79.0
+    assert lap["avg_left_pedal_smoothness_pct"] == 31.2
+    assert lap["avg_right_pedal_smoothness_pct"] == 28.4
+
+
+# ---------------------------------------------------------------------------
+# Shift-by-terrain
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_shift_terrain_classification(app_with_activity_analysis, mock_garmin_client):
+    """Shifts tagged with grade and summarized by terrain"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    # Record with climbing grade
+    record_climb = _make_mock_fit_message("record", {"cadence": 75, "grade": 5.5})
+    gear_data = (53 << 24) | (17 << 16) | (2 << 8) | 4
+    shift_climb = _make_mock_fit_message("event", {
+        "event": "rear_gear_change",
+        "gear_change_data": gear_data,
+        "timestamp": "2024-03-02 14:20:00",
+    })
+    # Record on flat
+    record_flat = _make_mock_fit_message("record", {"cadence": 90, "grade": 1.0})
+    shift_flat = _make_mock_fit_message("event", {
+        "event": "rear_gear_change",
+        "gear_change_data": gear_data,
+        "timestamp": "2024-03-02 14:21:00",
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([
+            record_climb, shift_climb, record_flat, shift_flat
+        ])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0].text if hasattr(result[0], "text") else str(result)
+    data = json.loads(text)
+
+    # Each shift should have grade_at_shift_pct
+    assert data["shifts"][0]["grade_at_shift_pct"] == 5.5
+    assert data["shifts"][1]["grade_at_shift_pct"] == 1.0
+
+    # by_terrain should appear in shift_summary
+    assert "by_terrain" in data["shift_summary"]
+    assert "climbing" in data["shift_summary"]["by_terrain"]
+    assert "flat" in data["shift_summary"]["by_terrain"]
+
+
+# ---------------------------------------------------------------------------
+# Power Duration Curve (unit tests)
+# ---------------------------------------------------------------------------
+
+def test_power_duration_curve_basic():
+    """PDC computes correct best power for each duration"""
+    # Synthetic: 120 records, first 10 are at 500W, rest at 100W
+    records = [{"power_w": 500}] * 10 + [{"power_w": 100}] * 110
+    pdc = _compute_power_duration_curve(records)
+    assert pdc is not None
+    # 5s best should be 500W
+    assert pdc["5s"] == 500
+    # 1min best (60s) — can't have 60 consecutive 500W records, so best is mix
+    assert pdc["1min"] < 500
+
+
+def test_power_duration_curve_empty():
+    """PDC returns None when no power data"""
+    records = [{"cadence_rpm": 80}] * 100  # no power_w
+    pdc = _compute_power_duration_curve(records)
+    assert pdc is None
+
+
+def test_power_duration_curve_short_ride():
+    """PDC skips durations longer than the ride"""
+    records = [{"power_w": 300}] * 30  # 30 seconds
+    pdc = _compute_power_duration_curve(records)
+    assert pdc is not None
+    assert "5s" in pdc
+    assert "1min" not in pdc  # 60s > 30 records
+
+
+def test_power_duration_curve_sliding_window():
+    """PDC sliding window finds best window, not just the start"""
+    # Best 5s is in the middle
+    records = (
+        [{"power_w": 100}] * 10 +
+        [{"power_w": 400}] * 5 +
+        [{"power_w": 100}] * 10
+    )
+    pdc = _compute_power_duration_curve(records)
+    assert pdc["5s"] == 400
+
+
+# ---------------------------------------------------------------------------
+# Climb detection + VAM (unit tests)
+# ---------------------------------------------------------------------------
+
+def _make_records(grade, power, cadence, hr, speed, altitude_start, count):
+    """Build synthetic per-second records for climb testing."""
+    records = []
+    alt = altitude_start
+    for i in range(count):
+        alt += speed * grade / 100  # approximate altitude gain
+        records.append({
+            "grade_pct": grade,
+            "power_w": power,
+            "cadence_rpm": cadence,
+            "heart_rate_bpm": hr,
+            "speed_mps": speed,
+            "altitude_m": alt,
+            "timestamp": f"2024-03-02 14:{i // 60:02d}:{i % 60:02d}",
+        })
+    return records
+
+
+def test_detect_climbs_basic():
+    """Climb detection identifies sustained positive grade segment"""
+    # 200 seconds at 5% grade (should produce ~50m gain at 5 m/s)
+    climbing = _make_records(grade=5.0, power=280, cadence=75, hr=160, speed=5.0, altitude_start=100, count=200)
+    flat = _make_records(grade=0.5, power=180, cadence=90, hr=140, speed=8.0, altitude_start=200, count=100)
+    records = climbing + flat
+
+    climbs = _detect_climbs(records, min_elevation_gain_m=30, min_avg_grade_pct=3.0, min_duration_s=60)
+    assert len(climbs) >= 1
+    c = climbs[0]
+    assert c["avg_grade_pct"] == 5.0
+    assert c["avg_power_w"] == 280
+    assert "vam_m_per_hr" in c
+
+
+def test_detect_climbs_none_when_flat():
+    """No climbs detected on a flat ride"""
+    flat = _make_records(grade=1.0, power=200, cadence=90, hr=140, speed=9.0, altitude_start=50, count=300)
+    climbs = _detect_climbs(flat)
+    assert climbs == []
+
+
+def test_detect_climbs_vam_calculation():
+    """VAM calculation is correct: (elevation_gain / duration) * 3600"""
+    # 300 seconds at 5 m/s, 5% grade → gain ≈ 75m
+    records = _make_records(grade=5.0, power=280, cadence=75, hr=155, speed=5.0, altitude_start=0, count=300)
+    climbs = _detect_climbs(records, min_elevation_gain_m=30, min_duration_s=60)
+    assert len(climbs) >= 1
+    # VAM should be roughly (75 / 300) * 3600 = 900 m/hr (approximate)
+    assert climbs[0].get("vam_m_per_hr", 0) > 500
+
+
+# ---------------------------------------------------------------------------
+# HR drift (unit tests)
+# ---------------------------------------------------------------------------
+
+def test_hr_drift_significant():
+    """Detects significant HR drift (decoupling) when second half HR is elevated"""
+    # First half: 250W at 140 bpm → ratio 1.786
+    # Second half: 250W at 165 bpm → ratio 1.515 → drift = (1.515-1.786)/1.786 = -15%
+    first_half = [{"power_w": 250, "heart_rate_bpm": 140}] * 1900
+    second_half = [{"power_w": 250, "heart_rate_bpm": 165}] * 1900
+    records = first_half + second_half
+    drift = _compute_hr_drift(records)
+    assert drift is not None
+    assert drift["hr_drift_pct"] < -10  # significant negative drift
+    assert drift["interpretation"] == "significant_decoupling"
+
+
+def test_hr_drift_well_coupled():
+    """Well-coupled ride shows minimal HR drift"""
+    records = [{"power_w": 200, "heart_rate_bpm": 145}] * 4000
+    drift = _compute_hr_drift(records)
+    assert drift is not None
+    assert abs(drift["hr_drift_pct"]) < 5
+    assert drift["interpretation"] == "well_coupled"
+
+
+def test_hr_drift_skipped_for_short_rides():
+    """HR drift not computed for rides under 60 minutes"""
+    records = [{"power_w": 200, "heart_rate_bpm": 145}] * 1000  # ~17 min
+    drift = _compute_hr_drift(records)
+    assert drift is None
+
+
+# ---------------------------------------------------------------------------
+# Temperature stats (unit tests)
+# ---------------------------------------------------------------------------
+
+def test_temperature_stats_basic():
+    """Temperature stats computed correctly"""
+    records = (
+        [{"temperature_c": 15, "heart_rate_bpm": 140, "power_w": 220}] * 50 +
+        [{"temperature_c": 30, "heart_rate_bpm": 160, "power_w": 210}] * 50
+    )
+    stats = _compute_temperature_stats(records)
+    assert stats is not None
+    assert stats["min_temp_c"] == 15
+    assert stats["max_temp_c"] == 30
+    assert stats["temp_range_c"] == 15.0
+
+
+def test_temperature_stats_none_when_no_data():
+    """Returns None when no temperature data"""
+    records = [{"power_w": 200, "heart_rate_bpm": 145}] * 50
+    assert _compute_temperature_stats(records) is None
+
+
+# ---------------------------------------------------------------------------
+# Grade analysis (unit tests)
+# ---------------------------------------------------------------------------
+
+def test_grade_analysis_bins_correctly():
+    """Grade analysis bins records into correct terrain buckets"""
+    records = (
+        [{"grade_pct": 0.5, "power_w": 180, "cadence_rpm": 90, "heart_rate_bpm": 140}] * 60 +
+        [{"grade_pct": 4.5, "power_w": 280, "cadence_rpm": 75, "heart_rate_bpm": 165}] * 60 +
+        [{"grade_pct": 7.5, "power_w": 320, "cadence_rpm": 65, "heart_rate_bpm": 175}] * 60 +
+        [{"grade_pct": -4.0, "power_w": 50, "cadence_rpm": 95, "heart_rate_bpm": 120}] * 60
+    )
+    result = _grade_analysis(records)
+    assert result is not None
+    assert "flat" in result
+    assert "gentle" in result
+    assert "moderate" in result
+    assert "descending" in result
+    # Steeper terrain should have higher avg power
+    assert result["gentle"]["avg_power_w"] < result["moderate"]["avg_power_w"]

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -389,7 +389,7 @@ async def test_get_activity_fit_data_variability_index_session(app_with_activity
             "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
         )
 
-    text = result[0].text if hasattr(result[0], "text") else str(result)
+    text = result[0][0].text
     data = json.loads(text)
     assert "variability_index" in data["session"]
     assert data["session"]["variability_index"] == round(210 / 175, 3)
@@ -412,7 +412,7 @@ async def test_get_activity_fit_data_variability_index_lap(app_with_activity_ana
             "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
         )
 
-    text = result[0].text if hasattr(result[0], "text") else str(result)
+    text = result[0][0].text
     data = json.loads(text)
     assert len(data["laps"]) == 1
     assert data["laps"][0]["variability_index"] == round(240 / 200, 3)
@@ -441,7 +441,7 @@ async def test_get_activity_fit_data_lap_torque_and_smoothness(app_with_activity
             "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
         )
 
-    text = result[0].text if hasattr(result[0], "text") else str(result)
+    text = result[0][0].text
     data = json.loads(text)
     lap = data["laps"][0]
     assert lap["avg_left_torque_effectiveness_pct"] == 82.5
@@ -483,7 +483,7 @@ async def test_get_activity_fit_data_shift_terrain_classification(app_with_activ
             "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
         )
 
-    text = result[0].text if hasattr(result[0], "text") else str(result)
+    text = result[0][0].text
     data = json.loads(text)
 
     # Each shift should have grade_at_shift_pct

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -1,0 +1,360 @@
+"""
+Integration tests for activity_analysis module MCP tools
+
+Tests the get_activity_fit_data tool using mocked Garmin API and fitparse responses.
+"""
+import json
+import pytest
+from unittest.mock import Mock, patch, MagicMock
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import activity_analysis
+
+
+ACTIVITY_ID = 22041393449
+
+
+@pytest.fixture
+def app_with_activity_analysis(mock_garmin_client):
+    """Create FastMCP app with activity_analysis tools registered"""
+    activity_analysis.configure(mock_garmin_client)
+    app = FastMCP("Test Activity Analysis")
+    app = activity_analysis.register_tools(app)
+    return app
+
+
+def _make_mock_fit_message(name, fields: dict):
+    """Create a mock fitparse message with the given name and field values."""
+    msg = Mock()
+    msg.name = name
+    msg.get_value = lambda field, *args: fields.get(field)
+    return msg
+
+
+def _mock_fitfile(messages):
+    """Create a mock FitFile that yields the given messages."""
+    mock_ff = MagicMock()
+    mock_ff.get_messages.return_value = iter(messages)
+    return mock_ff
+
+
+# ---------------------------------------------------------------------------
+# Basic tool behaviour
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_calls_download(app_with_activity_analysis, mock_garmin_client):
+    """Tool calls download_activity with ORIGINAL format"""
+    from garminconnect import Garmin
+
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([])
+        await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    mock_garmin_client.download_activity.assert_called_once_with(
+        ACTIVITY_ID,
+        dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL,
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_empty_response(app_with_activity_analysis, mock_garmin_client):
+    """Tool returns friendly message when download returns empty bytes"""
+    mock_garmin_client.download_activity.return_value = b""
+
+    result = await app_with_activity_analysis.call_tool(
+        "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+    )
+
+    assert result is not None
+    text = result[0][0].text
+    assert "No FIT data" in text
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_none_response(app_with_activity_analysis, mock_garmin_client):
+    """Tool handles None response from download_activity gracefully"""
+    mock_garmin_client.download_activity.return_value = None
+
+    result = await app_with_activity_analysis.call_tool(
+        "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+    )
+
+    assert result is not None
+    text = result[0][0].text
+    assert "No FIT data" in text or "Error" in text
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_error_handling(app_with_activity_analysis, mock_garmin_client):
+    """Tool returns error message when download raises an exception"""
+    mock_garmin_client.download_activity.side_effect = Exception("network error")
+
+    result = await app_with_activity_analysis.call_tool(
+        "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+    )
+
+    assert result is not None
+    text = result[0][0].text
+    assert "Error" in text
+
+
+# ---------------------------------------------------------------------------
+# Session parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_session_fields(app_with_activity_analysis, mock_garmin_client):
+    """Parsed session fields appear in output"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    session_msg = _make_mock_fit_message("session", {
+        "sport": "cycling",
+        "total_elapsed_time": 3120.0,
+        "total_distance": 56320.0,
+        "avg_power": 185,
+        "normalized_power": 210,
+        "avg_cadence": 83,
+        "avg_heart_rate": 148,
+        "avg_left_pco": 3,
+        "avg_right_pco": -8,
+        "avg_left_right_balance": None,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([session_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    assert data["session"]["sport"] == "cycling"
+    assert data["session"]["avg_power_w"] == 185
+    assert data["session"]["normalized_power_w"] == 210
+    assert data["session"]["avg_cadence_rpm"] == 83
+    assert data["session"]["avg_left_pco_mm"] == 3
+    assert data["session"]["avg_right_pco_mm"] == -8
+
+
+# ---------------------------------------------------------------------------
+# Shift / DI2 parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_shift_events(app_with_activity_analysis, mock_garmin_client):
+    """DI2 shift events are parsed and classified correctly"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    # Simulated record setting cadence before the shift
+    record_msg = _make_mock_fit_message("record", {
+        "cadence": 65,  # below 70 → next shift should be "reactive"
+        "power": 200,
+        "heart_rate": 150,
+        "speed": 8.5,
+        "altitude": 120.0,
+    })
+
+    # gear_change_data: front=53t (0x35), rear=16t (0x10), front_num=2, rear_num=5
+    # packed: (53 << 24) | (16 << 16) | (2 << 8) | 5
+    gear_data = (53 << 24) | (16 << 16) | (2 << 8) | 5
+
+    shift_msg = _make_mock_fit_message("event", {
+        "event": "rear_gear_change",
+        "gear_change_data": gear_data,
+        "timestamp": "2024-03-02 14:23:45",
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([record_msg, shift_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    assert len(data["shifts"]) == 1
+    shift = data["shifts"][0]
+    assert shift["quality"] == "reactive"          # cadence was 65 (<70)
+    assert shift["cadence_at_shift_rpm"] == 65
+    assert shift["front_teeth"] == 53
+    assert shift["rear_teeth"] == 16
+    assert shift["gear_combo"] == "53/16t"
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_proactive_shift(app_with_activity_analysis, mock_garmin_client):
+    """Shift at good cadence classified as proactive"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    record_msg = _make_mock_fit_message("record", {"cadence": 88})
+    gear_data = (39 << 24) | (19 << 16) | (1 << 8) | 4
+    shift_msg = _make_mock_fit_message("event", {
+        "event": "rear_gear_change",
+        "gear_change_data": gear_data,
+        "timestamp": "2024-03-02 14:30:00",
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([record_msg, shift_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    assert data["shifts"][0]["quality"] == "proactive"
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_shift_summary(app_with_activity_analysis, mock_garmin_client):
+    """Shift summary statistics are computed correctly"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    messages = []
+    # 2 reactive shifts (cadence 60), 1 proactive (cadence 85)
+    for cadence, ts in [(60, "14:20:00"), (60, "14:21:00"), (85, "14:25:00")]:
+        messages.append(_make_mock_fit_message("record", {"cadence": cadence}))
+        messages.append(_make_mock_fit_message("event", {
+            "event": "rear_gear_change",
+            "gear_change_data": (53 << 24) | (17 << 16) | (2 << 8) | 4,
+            "timestamp": f"2024-03-02 {ts}",
+        }))
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile(messages)
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    summary = data["shift_summary"]
+    assert summary["total_shifts"] == 3
+    assert summary["reactive_shifts"] == 2
+    assert summary["proactive_shifts"] == 1
+    assert summary["gear_usage"]["53/17t"] == 3
+
+
+# ---------------------------------------------------------------------------
+# Records (time series)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_records_excluded_by_default(app_with_activity_analysis, mock_garmin_client):
+    """Full time-series records not included unless explicitly requested"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    record_msg = _make_mock_fit_message("record", {
+        "cadence": 85, "power": 210, "heart_rate": 145,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([record_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+    assert "records" not in data
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_records_included_when_requested(app_with_activity_analysis, mock_garmin_client):
+    """Full time-series records included when include_records=True"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    record_msg = _make_mock_fit_message("record", {
+        "cadence": 85,
+        "power": 210,
+        "heart_rate": 145,
+        "speed": 9.2,
+        "altitude": 130.0,
+        "timestamp": "2024-03-02 14:00:00",
+        "left_pco": 3,
+        "right_pco": -9,
+        "left_right_balance": None,
+        "left_power_phase": None,
+        "right_power_phase": None,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([record_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data",
+            {"activity_id": ACTIVITY_ID, "include_records": True}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    assert "records" in data
+    assert len(data["records"]) == 1
+    rec = data["records"][0]
+    assert rec["cadence_rpm"] == 85
+    assert rec["power_w"] == 210
+    assert rec["left_pco_mm"] == 3
+    assert rec["right_pco_mm"] == -9
+
+
+# ---------------------------------------------------------------------------
+# Left/right balance decoding
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_power_balance(app_with_activity_analysis, mock_garmin_client):
+    """Left/right power balance decoded correctly from session message"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    # Encode 47% left dominant: bit 15 not set, value = 47 * 100 = 4700
+    balance_raw = 4700  # 47.0% left
+    session_msg = _make_mock_fit_message("session", {
+        "sport": "cycling",
+        "avg_left_right_balance": balance_raw,
+    })
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([session_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    assert data["session"]["avg_left_power_pct"] == 47.0
+    assert data["session"]["avg_right_power_pct"] == 53.0
+
+
+# ---------------------------------------------------------------------------
+# No DI2 data
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_data_no_shifts(app_with_activity_analysis, mock_garmin_client):
+    """Activity with no shift events returns informative shift_summary"""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    session_msg = _make_mock_fit_message("session", {"sport": "cycling"})
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([session_msg])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_data", {"activity_id": ACTIVITY_ID}
+        )
+
+    text = result[0][0].text
+    data = json.loads(text)
+
+    assert data["shift_summary"]["total_shifts"] == 0
+    assert "note" in data["shift_summary"]
+    assert data["shifts"] == []

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -356,7 +356,7 @@ async def test_add_gear_to_activity_tool(app_with_gear, mock_garmin_client):
         {"activity_id": 12345678901, "gear_uuid": "abc123"}
     )
     assert result is not None
-    mock_garmin_client.add_gear_to_activity.assert_called_once_with(12345678901, "abc123")
+    mock_garmin_client.add_gear_to_activity.assert_called_once_with("abc123", 12345678901)
 
 
 @pytest.mark.asyncio
@@ -368,7 +368,7 @@ async def test_remove_gear_from_activity_tool(app_with_gear, mock_garmin_client)
         {"activity_id": 12345678901, "gear_uuid": "abc123"}
     )
     assert result is not None
-    mock_garmin_client.remove_gear_from_activity.assert_called_once_with(12345678901, "abc123")
+    mock_garmin_client.remove_gear_from_activity.assert_called_once_with("abc123", 12345678901)
 
 
 # Women's Health module tests

--- a/uv.lock
+++ b/uv.lock
@@ -323,10 +323,17 @@ wheels = [
 ]
 
 [[package]]
+name = "fitparse"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/61/ed/5637fe96c56d55dfa6317ab16745f9a83ef2690d093cee8f0b59f983675f/fitparse-1.2.0.tar.gz", hash = "sha256:2d691022452dea6dabad13cc6e017ca467fe8a3a895cd3ac67a50a7bb716b4a9", size = 65716, upload-time = "2020-09-07T03:27:21.926Z" }
+
+[[package]]
 name = "garmin-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fitparse" },
     { name = "garminconnect" },
     { name = "mcp" },
     { name = "python-dotenv" },
@@ -343,6 +350,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fitparse", specifier = ">=1.2.0" },
     { name = "garminconnect", specifier = "==0.3.2" },
     { name = "mcp", specifier = ">=1.23.0" },
     { name = "python-dotenv", specifier = "==1.2.2" },


### PR DESCRIPTION
Rebased from #46 (original by @shawnazar) — resolved conflicts with #77 (auth migration), #94 (workout builders), #92 (courses), and #76 (nutrition).

**New tools:**
- `get_activity_fit_data(activity_id)` — parses FIT file for DI2 shift events, cycling dynamics (PCO, torque effectiveness), power duration curve, climb detection with VAM, cardiac drift, W/kg
- `get_activity_power_in_timezones(activity_id)` — power zone distribution
- `get_training_status_trend(start_date, end_date)` — CTL/ATL/TSB time series
- `get_hrv_trend(start_date, end_date)` — 7-day rolling HRV
- `get_respiration_trend(start_date, end_date)` — overnight respiration trend
- `get_max_metrics(date)` — VO2 max and other performance ceilings

**Conflict resolutions:**
- Removed `garth` dependency (replaced with garminconnect 0.3.2 `curl_cffi`)
- Added `fitparse>=1.2.0` to pyproject.toml
- Fixed test result access pattern for current fastmcp API (`result[0][0].text`)
- Added missing poc_walk_run.json snapshot fixture (from #94) + .gitignore exception

253/253 tests passing.

Closes #46