### PR TITLE
fix: add elevationGain/elevationLoss to activity listing and detail tools

### DIFF
--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -52,6 +52,8 @@ def register_tools(app):
                     "avg_hr_bpm": a.get('averageHR'),
                     "max_hr_bpm": a.get('maxHR'),
                     "steps": a.get('steps'),
+                    "elevation_gain_meters": a.get('elevationGain'),
+                    "elevation_loss_meters": a.get('elevationLoss'),
                 }
                 # Remove None values
                 activity = {k: v for k, v in activity.items() if v is not None}
@@ -175,6 +177,12 @@ def register_tools(app):
                 # Intensity minutes
                 "moderate_intensity_minutes": summary.get('moderateIntensityMinutes'),
                 "vigorous_intensity_minutes": summary.get('vigorousIntensityMinutes'),
+
+                # Elevation
+                "elevation_gain_meters": summary.get('elevationGain'),
+                "elevation_loss_meters": summary.get('elevationLoss'),
+                "max_elevation_meters": summary.get('maxElevation'),
+                "min_elevation_meters": summary.get('minElevation'),
 
                 # Recovery
                 "recovery_hr_bpm": summary.get('recoveryHeartRate'),
@@ -497,6 +505,8 @@ def register_tools(app):
                     "avg_hr_bpm": a.get('averageHR'),
                     "max_hr_bpm": a.get('maxHR'),
                     "steps": a.get('steps'),
+                    "elevation_gain_meters": a.get('elevationGain'),
+                    "elevation_loss_meters": a.get('elevationLoss'),
                     "owner_display_name": a.get('ownerDisplayName'),
                 }
                 # Remove None values


### PR DESCRIPTION
Fixes #44.

Exposes elevation fields that were available in the raw Garmin API but stripped from the curated output:

- `get_activities` — adds `elevation_gain_meters`, `elevation_loss_meters`
- `get_activities_by_date` — adds `elevation_gain_meters`, `elevation_loss_meters`
- `get_activity` — adds `elevation_gain_meters`, `elevation_loss_meters`, `max_elevation_meters`, `min_elevation_meters`

Fields are omitted (as with all fields) when `None` (i.e. for activities that don't track elevation like indoor workouts).