### PR TITLE
fix: delete_workout dict.status_code, large activity IDs, schedule idempotency

### DIFF
--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -15,7 +15,7 @@ import gzip
 import io
 import json
 import zipfile
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 try:
     import fitparse
@@ -829,7 +829,7 @@ def register_tools(app):
 
     @app.tool()
     async def get_activity_fit_data(
-        activity_id: int,
+        activity_id: Union[int, str],
         include_records: bool = False,
     ) -> str:
         """Download and parse FIT file for an activity to expose advanced cycling data.
@@ -869,6 +869,7 @@ def register_tools(app):
             )
 
         try:
+            activity_id = int(activity_id)
             from garminconnect import Garmin
 
             fit_bytes = garmin_client.download_activity(

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -112,13 +112,14 @@ def register_tools(app):
             return f"Error retrieving activities for date: {str(e)}"
 
     @app.tool()
-    async def get_activity(activity_id: int) -> str:
+    async def get_activity(activity_id: Union[int, str]) -> str:
         """Get basic activity information
 
         Args:
             activity_id: ID of the activity to retrieve
         """
         try:
+            activity_id = int(activity_id)
             activity = garmin_client.get_activity(activity_id)
             if not activity:
                 return f"No activity found with ID {activity_id}"
@@ -206,7 +207,7 @@ def register_tools(app):
             return f"Error retrieving activity: {str(e)}"
 
     @app.tool()
-    async def set_activity_name(activity_id: int, activity_name: str) -> str:
+    async def set_activity_name(activity_id: Union[int, str], activity_name: str) -> str:
         """Set or update the name of an activity.
 
         Args:
@@ -214,6 +215,7 @@ def register_tools(app):
             activity_name: New activity name
         """
         try:
+            activity_id = int(activity_id)
             activity_name = activity_name.strip()
             if not activity_name:
                 return "Activity name cannot be empty"
@@ -233,13 +235,14 @@ def register_tools(app):
             return f"Error updating activity name: {str(e)}"
 
     @app.tool()
-    async def get_activity_splits(activity_id: int) -> str:
+    async def get_activity_splits(activity_id: Union[int, str]) -> str:
         """Get splits for an activity
 
         Args:
             activity_id: ID of the activity to retrieve splits for
         """
         try:
+            activity_id = int(activity_id)
             splits = garmin_client.get_activity_splits(activity_id)
             if not splits:
                 return f"No splits found for activity with ID {activity_id}"
@@ -314,13 +317,14 @@ def register_tools(app):
             return f"Error retrieving activity splits: {str(e)}"
 
     @app.tool()
-    async def get_activity_typed_splits(activity_id: int) -> str:
+    async def get_activity_typed_splits(activity_id: Union[int, str]) -> str:
         """Get typed splits for an activity
 
         Args:
             activity_id: ID of the activity to retrieve typed splits for
         """
         try:
+            activity_id = int(activity_id)
             typed_splits = garmin_client.get_activity_typed_splits(activity_id)
             if not typed_splits:
                 return f"No typed splits found for activity with ID {activity_id}"
@@ -330,13 +334,14 @@ def register_tools(app):
             return f"Error retrieving activity typed splits: {str(e)}"
 
     @app.tool()
-    async def get_activity_split_summaries(activity_id: int) -> str:
+    async def get_activity_split_summaries(activity_id: Union[int, str]) -> str:
         """Get split summaries for an activity
 
         Args:
             activity_id: ID of the activity to retrieve split summaries for
         """
         try:
+            activity_id = int(activity_id)
             split_summaries = garmin_client.get_activity_split_summaries(activity_id)
             if not split_summaries:
                 return f"No split summaries found for activity with ID {activity_id}"
@@ -346,13 +351,14 @@ def register_tools(app):
             return f"Error retrieving activity split summaries: {str(e)}"
 
     @app.tool()
-    async def get_activity_weather(activity_id: int) -> str:
+    async def get_activity_weather(activity_id: Union[int, str]) -> str:
         """Get weather data for an activity
 
         Args:
             activity_id: ID of the activity to retrieve weather data for
         """
         try:
+            activity_id = int(activity_id)
             weather = garmin_client.get_activity_weather(activity_id)
             if not weather:
                 return f"No weather data found for activity with ID {activity_id}"
@@ -379,13 +385,14 @@ def register_tools(app):
             return f"Error retrieving activity weather data: {str(e)}"
 
     @app.tool()
-    async def get_activity_hr_in_timezones(activity_id: int) -> str:
+    async def get_activity_hr_in_timezones(activity_id: Union[int, str]) -> str:
         """Get heart rate data in different time zones for an activity
 
         Args:
             activity_id: ID of the activity to retrieve heart rate time zone data for
         """
         try:
+            activity_id = int(activity_id)
             hr_zones = garmin_client.get_activity_hr_in_timezones(activity_id)
             if not hr_zones:
                 return f"No heart rate time zone data found for activity with ID {activity_id}"
@@ -395,7 +402,7 @@ def register_tools(app):
             return f"Error retrieving activity heart rate time zone data: {str(e)}"
 
     @app.tool()
-    async def get_activity_power_in_timezones(activity_id: int) -> str:
+    async def get_activity_power_in_timezones(activity_id: Union[int, str]) -> str:
         """Get power distribution across training zones for an activity.
 
         Returns time spent in each power zone with watt thresholds and duration.
@@ -405,6 +412,7 @@ def register_tools(app):
             activity_id: ID of the activity to retrieve power zone data for
         """
         try:
+            activity_id = int(activity_id)
             power_zones = garmin_client.get_activity_power_in_timezones(activity_id)
             if not power_zones:
                 return f"No power zone data found for activity {activity_id}. Ensure the activity was recorded with a power meter."
@@ -414,13 +422,14 @@ def register_tools(app):
             return f"Error retrieving activity power zone data: {str(e)}"
 
     @app.tool()
-    async def get_activity_gear(activity_id: int) -> str:
+    async def get_activity_gear(activity_id: Union[int, str]) -> str:
         """Get gear data used for an activity
 
         Args:
             activity_id: ID of the activity to retrieve gear data for
         """
         try:
+            activity_id = int(activity_id)
             gear = garmin_client.get_activity_gear(activity_id)
             if not gear:
                 return f"No gear data found for activity with ID {activity_id}"
@@ -430,13 +439,14 @@ def register_tools(app):
             return f"Error retrieving activity gear data: {str(e)}"
 
     @app.tool()
-    async def get_activity_exercise_sets(activity_id: int) -> str:
+    async def get_activity_exercise_sets(activity_id: Union[int, str]) -> str:
         """Get exercise sets for strength training activities
 
         Args:
             activity_id: ID of the activity to retrieve exercise sets for
         """
         try:
+            activity_id = int(activity_id)
             exercise_sets = garmin_client.get_activity_exercise_sets(activity_id)
             if not exercise_sets:
                 return f"No exercise sets found for activity with ID {activity_id}"

--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -356,16 +356,36 @@ def register_tools(app):
     async def schedule_week(week: List[Dict[str, Any]]) -> str:
         """Schedule a list of workouts for the week in a single call.
 
+        Idempotent: if a workout is already scheduled for that date, it is
+        reported as already scheduled and the POST is skipped (avoids
+        duplicating calendar entries).
+
         Args:
             week: List of dicts with keys: date (YYYY-MM-DD), workout_id (int)
         """
+        # Imported here (not at module top) to avoid any import-time ordering
+        # surprises between sibling modules. Both modules share the same
+        # garmin_client instance via configure() in __main__.
+        from garmin_mcp.workouts import _is_already_scheduled
+
         try:
             results = []
             for item in week:
                 calendar_date = item["date"]
                 workout_id = int(item["workout_id"])
+
+                if _is_already_scheduled(workout_id, calendar_date):
+                    results.append({
+                        "date": calendar_date,
+                        "workout_id": workout_id,
+                        "status": "already_scheduled",
+                        "idempotent": True,
+                    })
+                    continue
+
+                # garminconnect 0.3.2 dropped the .garth attribute; use .client.
                 url = f"workout-service/schedule/{workout_id}"
-                response = garmin_client.garth.post(
+                response = garmin_client.client.post(
                     "connectapi", url, json={"date": calendar_date}
                 )
                 if response.status_code == 200:

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -289,6 +289,37 @@ def _curate_scheduled_workout(scheduled: dict) -> dict:
     return {k: v for k, v in summary.items() if v is not None}
 
 
+def _is_already_scheduled(workout_id: int, calendar_date: str) -> bool:
+    """Return True if workout_id is already scheduled on calendar_date.
+
+    Used to make schedule_workout / schedule_workouts idempotent. The Garmin
+    schedule endpoint is not idempotent: a second POST creates a second
+    calendar entry on the same day. Querying first avoids the duplicate.
+    """
+    try:
+        query = {
+            "query": (
+                f'query{{workoutScheduleSummariesScalar('
+                f'startDate:"{calendar_date}", endDate:"{calendar_date}")}}'
+            )
+        }
+        result = garmin_client.query_garmin_graphql(query) or {}
+        existing = (
+            result.get("data", {}).get("workoutScheduleSummariesScalar", []) or []
+        )
+        for entry in existing:
+            if (
+                entry.get("workoutId") == workout_id
+                and entry.get("scheduleDate") == calendar_date
+            ):
+                return True
+    except Exception:
+        # If the pre-check itself fails, fall through to the normal POST
+        # path so we don't block a legitimate scheduling attempt.
+        return False
+    return False
+
+
 def register_tools(app):
     """Register all workout-related tools with the MCP server app"""
 
@@ -538,24 +569,22 @@ def register_tools(app):
             workout_id: ID of the workout to delete (get IDs from get_workouts)
         """
         try:
-            url = f"{garmin_client.garmin_workouts}/workout/{workout_id}"
-            response = garmin_client.client.delete("connectapi", url, api=True)
-
-            if response.status_code == 204 or response.status_code == 200:
-                return json.dumps({
-                    "status": "success",
-                    "workout_id": workout_id,
-                    "message": f"Workout {workout_id} deleted successfully"
-                }, indent=2)
-            else:
-                return json.dumps({
-                    "status": "failed",
-                    "workout_id": workout_id,
-                    "http_status": response.status_code,
-                    "message": f"Failed to delete workout: HTTP {response.status_code}"
-                }, indent=2)
+            # Use the high-level garminconnect method. In garminconnect 0.3.2,
+            # client.delete(..., api=True) returns resp.json() (a dict), not a
+            # Response, so checking response.status_code raises AttributeError.
+            # Delegate to the library and rely on exceptions to signal failure.
+            garmin_client.delete_workout(workout_id)
+            return json.dumps({
+                "status": "success",
+                "workout_id": workout_id,
+                "message": f"Workout {workout_id} deleted successfully"
+            }, indent=2)
         except Exception as e:
-            return f"Error deleting workout: {str(e)}"
+            return json.dumps({
+                "status": "failed",
+                "workout_id": workout_id,
+                "message": f"Failed to delete workout: {str(e)}"
+            }, indent=2)
 
     @app.tool()
     async def delete_workouts(workout_ids: list[int]) -> str:
@@ -569,22 +598,14 @@ def register_tools(app):
         results = []
         for workout_id in workout_ids:
             try:
-                url = f"{garmin_client.garmin_workouts}/workout/{workout_id}"
-                response = garmin_client.client.delete("connectapi", url, api=True)
-
-                if response.status_code in (200, 204):
-                    results.append({
-                        "status": "success",
-                        "workout_id": workout_id,
-                        "message": f"Workout {workout_id} deleted successfully"
-                    })
-                else:
-                    results.append({
-                        "status": "failed",
-                        "workout_id": workout_id,
-                        "http_status": response.status_code,
-                        "message": f"Failed to delete workout: HTTP {response.status_code}"
-                    })
+                # See note in delete_workout: high-level call avoids the
+                # garminconnect 0.3.2 dict-vs-Response trap.
+                garmin_client.delete_workout(workout_id)
+                results.append({
+                    "status": "success",
+                    "workout_id": workout_id,
+                    "message": f"Workout {workout_id} deleted successfully"
+                })
             except Exception as e:
                 results.append({
                     "status": "error",
@@ -705,11 +726,26 @@ def register_tools(app):
         This adds an existing workout from your Garmin workout library
         to your Garmin Connect calendar on the specified date.
 
+        Idempotent: if the workout is already scheduled for that date, this
+        is a no-op that reports success without creating a duplicate entry.
+
         Args:
             workout_id: ID of the workout to schedule (get IDs from get_workouts)
             calendar_date: Date to schedule the workout in YYYY-MM-DD format
         """
         try:
+            if _is_already_scheduled(workout_id, calendar_date):
+                return json.dumps({
+                    "status": "success",
+                    "workout_id": workout_id,
+                    "scheduled_date": calendar_date,
+                    "idempotent": True,
+                    "message": (
+                        f"Workout {workout_id} already scheduled for "
+                        f"{calendar_date} — no action taken"
+                    )
+                }, indent=2)
+
             url = f"workout-service/schedule/{workout_id}"
             response = garmin_client.client.post("connectapi", url, json={"date": calendar_date})
 
@@ -795,6 +831,22 @@ def register_tools(app):
                         continue
                     workout_id = upload_result['workoutId']
                     workout_name = upload_result.get('workoutName')
+
+                if _is_already_scheduled(workout_id, calendar_date):
+                    entry = {
+                        "status": "success",
+                        "workout_id": workout_id,
+                        "scheduled_date": calendar_date,
+                        "idempotent": True,
+                        "message": (
+                            f"Workout {workout_id} already scheduled for "
+                            f"{calendar_date} — no action taken"
+                        )
+                    }
+                    if workout_name:
+                        entry["workout_name"] = workout_name
+                    results.append(entry)
+                    continue
 
                 url = f"workout-service/schedule/{workout_id}"
                 response = garmin_client.client.post("connectapi", url, json={"date": calendar_date})

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -101,6 +101,27 @@ async def test_get_activity_tool(app_with_activity_management, mock_garmin_clien
 
 
 @pytest.mark.asyncio
+async def test_get_activity_accepts_string_id(app_with_activity_management, mock_garmin_client):
+    """Test get_activity accepts large IDs serialized as strings
+
+    Some MCP clients stringify large numeric IDs in tool call arguments
+    (Zod schema receives string instead of integer). The tool must coerce
+    to int internally so the underlying Garmin call still gets an integer.
+    Regression test for the 'Expected number, received string' bug.
+    """
+    mock_garmin_client.get_activity.return_value = MOCK_ACTIVITY_DETAILS
+
+    result = await app_with_activity_management.call_tool(
+        "get_activity",
+        {"activity_id": "22833209898"}  # string, not int
+    )
+
+    assert result is not None
+    # Library must have been called with an int, not a string
+    mock_garmin_client.get_activity.assert_called_once_with(22833209898)
+
+
+@pytest.mark.asyncio
 async def test_set_activity_name_tool(app_with_activity_management, mock_garmin_client):
     """Test set_activity_name tool updates activity name"""
     activity_id = 12345678901

--- a/tests/integration/test_workout_builders_tools.py
+++ b/tests/integration/test_workout_builders_tools.py
@@ -1,0 +1,140 @@
+"""
+Integration tests for high-level workout builder tools (workout_builders.py).
+"""
+import json
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from unittest.mock import MagicMock
+
+from garmin_mcp import workouts, workout_builders
+
+
+@pytest.fixture
+def app_with_builders(mock_garmin_client):
+    """FastMCP app with workout_builders registered.
+
+    Also configures `workouts` because workout_builders.schedule_week reuses
+    the `_is_already_scheduled` helper defined there, which reads from the
+    `garmin_client` module-level global in workouts.py. Both modules must
+    point at the same mock for the helper to see the right state.
+    """
+    # Default: pre-check finds no existing schedules so the POST path runs.
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {"workoutScheduleSummariesScalar": []}
+    }
+    workouts.configure(mock_garmin_client)
+    workout_builders.configure(mock_garmin_client)
+    app = FastMCP("Test Workout Builders")
+    app = workout_builders.register_tools(app)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_schedule_week_uses_client_post_not_garth(
+    app_with_builders, mock_garmin_client
+):
+    """schedule_week must route through garmin_client.client.post
+
+    Regression: garminconnect 0.3.2 removed the `.garth` attribute. The old
+    code called `garmin_client.garth.post(...)` which raises AttributeError.
+    This test pins the fix.
+    """
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_garmin_client.client.post.return_value = mock_response
+
+    result = await app_with_builders.call_tool(
+        "schedule_week",
+        {"week": [{"date": "2026-05-12", "workout_id": 1234567890}]},
+    )
+
+    assert result is not None
+    payload = json.loads(result[0][0].text)
+    assert payload["status"] == "complete"
+    assert payload["scheduled"][0]["status"] == "scheduled"
+    assert payload["scheduled"][0]["workout_id"] == 1234567890
+    # Must call .client.post, never .garth.*
+    mock_garmin_client.client.post.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_schedule_week_is_idempotent(
+    app_with_builders, mock_garmin_client
+):
+    """schedule_week skips the POST when the workout is already scheduled.
+
+    Matches the idempotency behaviour of schedule_workout / schedule_workouts.
+    """
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {
+            "workoutScheduleSummariesScalar": [
+                {
+                    "workoutId": 1234567890,
+                    "scheduleDate": "2026-05-12",
+                    "workoutName": "Easy Run",
+                }
+            ]
+        }
+    }
+
+    result = await app_with_builders.call_tool(
+        "schedule_week",
+        {"week": [{"date": "2026-05-12", "workout_id": 1234567890}]},
+    )
+
+    assert result is not None
+    payload = json.loads(result[0][0].text)
+    assert payload["status"] == "complete"
+    assert payload["scheduled"][0]["status"] == "already_scheduled"
+    assert payload["scheduled"][0]["idempotent"] is True
+    # Critically: no POST happened
+    mock_garmin_client.client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_week_partial_idempotency(
+    app_with_builders, mock_garmin_client
+):
+    """Mixed week: some entries already scheduled, others new.
+
+    Verifies the pre-check runs per-item, not once for the whole batch.
+    """
+    def graphql_side_effect(query):
+        # Return existing schedule only for 2026-05-12
+        if "2026-05-12" in query["query"]:
+            return {
+                "data": {
+                    "workoutScheduleSummariesScalar": [
+                        {
+                            "workoutId": 111,
+                            "scheduleDate": "2026-05-12",
+                            "workoutName": "Easy Run",
+                        }
+                    ]
+                }
+            }
+        return {"data": {"workoutScheduleSummariesScalar": []}}
+
+    mock_garmin_client.query_garmin_graphql.side_effect = graphql_side_effect
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_garmin_client.client.post.return_value = mock_response
+
+    result = await app_with_builders.call_tool(
+        "schedule_week",
+        {
+            "week": [
+                {"date": "2026-05-12", "workout_id": 111},  # already scheduled
+                {"date": "2026-05-14", "workout_id": 222},  # new
+            ]
+        },
+    )
+
+    payload = json.loads(result[0][0].text)
+    scheduled = payload["scheduled"]
+    assert scheduled[0]["status"] == "already_scheduled"
+    assert scheduled[1]["status"] == "scheduled"
+    # Only the new one triggered the POST
+    assert mock_garmin_client.client.post.call_count == 1

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -18,6 +18,11 @@ from tests.fixtures.garmin_responses import (
 @pytest.fixture
 def app_with_workouts(mock_garmin_client):
     """Create FastMCP app with workouts tools registered"""
+    # Default: pre-check used by schedule_* tools sees no existing schedule
+    # so the POST path runs as before. Individual tests override this.
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {"workoutScheduleSummariesScalar": []}
+    }
     workouts.configure(mock_garmin_client)
     app = FastMCP("Test Workouts")
     app = workouts.register_tools(app)
@@ -501,97 +506,64 @@ async def test_get_training_plan_workouts_tool(app_with_workouts, mock_garmin_cl
 
 # Delete workout tests
 @pytest.mark.asyncio
-async def test_delete_workout_success_204(app_with_workouts, mock_garmin_client):
-    """Test delete_workout tool with 204 response"""
+async def test_delete_workout_success(app_with_workouts, mock_garmin_client):
+    """Test delete_workout tool when the library call succeeds"""
     import json as json_module
-    from unittest.mock import MagicMock
 
-    # Setup mock for client.delete call
-    mock_response = MagicMock()
-    mock_response.status_code = 204
-    mock_garmin_client.client.delete.return_value = mock_response
+    # The MCP tool now delegates to garmin_client.delete_workout(id)
+    # (high-level method). Success is signalled by absence of exception.
+    mock_garmin_client.delete_workout.return_value = {}
 
-    # Call tool
     workout_id = 123456
     result = await app_with_workouts.call_tool(
         "delete_workout",
         {"workout_id": workout_id}
     )
 
-    # Verify
     assert result is not None
     result_data = json_module.loads(result[0][0].text)
     assert result_data["status"] == "success"
     assert result_data["workout_id"] == 123456
     assert "deleted successfully" in result_data["message"]
-
-
-@pytest.mark.asyncio
-async def test_delete_workout_success_200(app_with_workouts, mock_garmin_client):
-    """Test delete_workout tool with 200 response"""
-    import json as json_module
-    from unittest.mock import MagicMock
-
-    # Setup mock for client.delete call
-    mock_response = MagicMock()
-    mock_response.status_code = 200
-    mock_garmin_client.client.delete.return_value = mock_response
-
-    # Call tool
-    workout_id = 789012
-    result = await app_with_workouts.call_tool(
-        "delete_workout",
-        {"workout_id": workout_id}
-    )
-
-    # Verify
-    assert result is not None
-    result_data = json_module.loads(result[0][0].text)
-    assert result_data["status"] == "success"
-    assert result_data["workout_id"] == 789012
+    mock_garmin_client.delete_workout.assert_called_once_with(workout_id)
 
 
 @pytest.mark.asyncio
 async def test_delete_workout_failure(app_with_workouts, mock_garmin_client):
-    """Test delete_workout tool when deletion fails (non-200/204 status)"""
+    """Test delete_workout tool when the library raises (e.g. 404)"""
     import json as json_module
-    from unittest.mock import MagicMock
 
-    # Setup mock for client.delete call with error status
-    mock_response = MagicMock()
-    mock_response.status_code = 404
-    mock_garmin_client.client.delete.return_value = mock_response
+    mock_garmin_client.delete_workout.side_effect = Exception("API Error 404")
 
-    # Call tool
     workout_id = 999999
     result = await app_with_workouts.call_tool(
         "delete_workout",
         {"workout_id": workout_id}
     )
 
-    # Verify
     assert result is not None
     result_data = json_module.loads(result[0][0].text)
     assert result_data["status"] == "failed"
     assert result_data["workout_id"] == 999999
-    assert result_data["http_status"] == 404
+    assert "404" in result_data["message"]
 
 
 @pytest.mark.asyncio
 async def test_delete_workout_exception(app_with_workouts, mock_garmin_client):
-    """Test delete_workout tool when an exception is raised"""
-    # Setup mock to raise exception
-    mock_garmin_client.client.delete.side_effect = Exception("Network error")
+    """Test delete_workout tool with a network-level exception"""
+    import json as json_module
 
-    # Call tool
+    mock_garmin_client.delete_workout.side_effect = Exception("Network error")
+
     result = await app_with_workouts.call_tool(
         "delete_workout",
         {"workout_id": 123456}
     )
 
-    # Verify error is handled gracefully
     assert result is not None
-    assert "Error deleting workout" in result[0][0].text
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "failed"
+    assert "Network error" in result_data["message"]
 
 
 # Error handling tests
@@ -632,11 +604,8 @@ async def test_upload_workout_exception(app_with_workouts, mock_garmin_client):
 async def test_delete_workouts_single(app_with_workouts, mock_garmin_client):
     """Test delete_workouts with a single workout ID"""
     import json as json_module
-    from unittest.mock import MagicMock
 
-    mock_response = MagicMock()
-    mock_response.status_code = 204
-    mock_garmin_client.client.delete.return_value = mock_response
+    mock_garmin_client.delete_workout.return_value = {}
 
     result = await app_with_workouts.call_tool(
         "delete_workouts",
@@ -656,11 +625,8 @@ async def test_delete_workouts_single(app_with_workouts, mock_garmin_client):
 async def test_delete_workouts_multiple(app_with_workouts, mock_garmin_client):
     """Test delete_workouts with multiple workout IDs"""
     import json as json_module
-    from unittest.mock import MagicMock
 
-    mock_response = MagicMock()
-    mock_response.status_code = 204
-    mock_garmin_client.client.delete.return_value = mock_response
+    mock_garmin_client.delete_workout.return_value = {}
 
     result = await app_with_workouts.call_tool(
         "delete_workouts",
@@ -672,21 +638,18 @@ async def test_delete_workouts_multiple(app_with_workouts, mock_garmin_client):
     assert result_data["total"] == 3
     assert result_data["succeeded"] == 3
     assert result_data["failed"] == 0
-    assert mock_garmin_client.client.delete.call_count == 3
+    assert mock_garmin_client.delete_workout.call_count == 3
 
 
 @pytest.mark.asyncio
 async def test_delete_workouts_partial_failure(app_with_workouts, mock_garmin_client):
     """Test delete_workouts when some deletions fail"""
     import json as json_module
-    from unittest.mock import MagicMock
 
-    ok_response = MagicMock()
-    ok_response.status_code = 204
-    err_response = MagicMock()
-    err_response.status_code = 404
-
-    mock_garmin_client.client.delete.side_effect = [ok_response, err_response]
+    mock_garmin_client.delete_workout.side_effect = [
+        {},
+        Exception("API Error 404"),
+    ]
 
     result = await app_with_workouts.call_tool(
         "delete_workouts",
@@ -699,8 +662,8 @@ async def test_delete_workouts_partial_failure(app_with_workouts, mock_garmin_cl
     assert result_data["succeeded"] == 1
     assert result_data["failed"] == 1
     assert result_data["results"][0]["status"] == "success"
-    assert result_data["results"][1]["status"] == "failed"
-    assert result_data["results"][1]["http_status"] == 404
+    assert result_data["results"][1]["status"] == "error"
+    assert "404" in result_data["results"][1]["message"]
 
 
 @pytest.mark.asyncio
@@ -708,7 +671,7 @@ async def test_delete_workouts_exception(app_with_workouts, mock_garmin_client):
     """Test delete_workouts when an exception is raised"""
     import json as json_module
 
-    mock_garmin_client.client.delete.side_effect = Exception("Network error")
+    mock_garmin_client.delete_workout.side_effect = Exception("Network error")
 
     result = await app_with_workouts.call_tool(
         "delete_workouts",
@@ -929,6 +892,45 @@ async def test_schedule_workouts_exception(app_with_workouts, mock_garmin_client
     assert result_data["failed"] == 1
     assert result_data["results"][0]["status"] == "error"
     assert "Network error" in result_data["results"][0]["message"]
+
+
+@pytest.mark.asyncio
+async def test_schedule_workouts_idempotent(app_with_workouts, mock_garmin_client):
+    """Test schedule_workouts is a no-op when workout is already scheduled
+
+    The schedule endpoint on Garmin is NOT idempotent — a second POST creates
+    a duplicate calendar entry. The MCP tool pre-checks via GraphQL and skips
+    the POST when the same workout_id is already on that date.
+    """
+    import json as json_module
+
+    # GraphQL pre-check returns an existing schedule for this workout/date
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {
+            "workoutScheduleSummariesScalar": [
+                {
+                    "workoutId": 123456,
+                    "scheduleDate": "2024-01-15",
+                    "workoutName": "Easy Run",
+                }
+            ]
+        }
+    }
+
+    result = await app_with_workouts.call_tool(
+        "schedule_workouts",
+        {"schedules": [{"workout_id": 123456, "calendar_date": "2024-01-15"}]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 1
+    assert result_data["succeeded"] == 1
+    assert result_data["failed"] == 0
+    assert result_data["results"][0]["status"] == "success"
+    assert result_data["results"][0]["idempotent"] is True
+    # Critically: the schedule POST must NOT be called
+    mock_garmin_client.client.post.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Context

PR #102 switched `client.garth.delete` to `client.delete` but didn't notice that the new `Client.delete(api=True)` (introduced with the `garth → client` migration in `garminconnect 0.3.0`) returns `resp.json()` (a dict), not a `Response` object. So `response.status_code` still raises `AttributeError: 'dict' object has no attribute 'status_code'` for every `delete_workout` / `delete_workouts` call. The bug remained live after that PR.

This PR completes the fix and addresses three related issues.

## Changes

### 1. `delete_workout` / `delete_workouts`

Delegate to the high-level `garmin_client.delete_workout(id)` (already in the library) and rely on exceptions for failure signalling. Removes the dependency on the internal `garmin_workouts` attribute and on response-object-vs-dict ambiguity.

### 2. Large activity IDs: `Expected number, received string`

All `activity_id` parameters changed from `int` to `Union[int, str]` plus `int(activity_id)` at the function start. MCP clients sometimes serialize large IDs as strings (defensive precision handling); the strict `{"type": "integer"}` schema rejected them. Same pattern as `get_workout_by_id` already uses.

Tools updated: `get_activity`, `set_activity_name`, `get_activity_splits`, `get_activity_typed_splits`, `get_activity_split_summaries`, `get_activity_weather`, `get_activity_hr_in_timezones`, `get_activity_power_in_timezones`, `get_activity_gear`, `get_activity_exercise_sets`, `get_activity_fit_data`.

### 3. `schedule_workout` / `schedule_workouts` idempotency

Garmin's `POST /workout-service/schedule/{id}` is not idempotent: calling it twice creates two calendar entries on the same day. Added a pre-check via GraphQL (`workoutScheduleSummariesScalar`) that skips the POST when an entry for the same `workout_id`+date already exists. Returns `{"idempotent": true, "status": "success"}` in that case.

### 4. `schedule_week` (workout_builders.py): same `garth` regression + idempotency

While auditing the codebase for the `.garth` references PR #102 fixed in `workouts.py`, found that `workout_builders.schedule_week` still calls `garmin_client.garth.post(...)`. The `.garth` attribute was removed when `garminconnect` migrated to its own internal client wrapper in version 0.3.0 (the project pins `garminconnect==0.3.2`), so this tool was effectively broken for any user. Replaced with `.client.post` and reused the new `_is_already_scheduled` helper to apply the same idempotency behaviour as the other schedule tools.

Note: `src/garmin_mcp/courses.py` also still has 13 references to `garmin_client.garth.*` (in `get_courses`, `upload_course`, `delete_course`). Those are out of scope for this PR (different domain, larger blast radius) but should be tracked separately. Happy to follow up.

## Tests

- Updated 7 existing tests in `tests/integration/test_workouts_tools.py` to mock `garmin_client.delete_workout` instead of `client.delete`.
- Added `test_schedule_workouts_idempotent` covering the no-duplicate path.
- Added `test_get_activity_accepts_string_id` covering the string-ID coercion.
- Added `tests/integration/test_workout_builders_tools.py` with 3 tests for `schedule_week` (regression on `.garth` removal, idempotent path, mixed batch).

266 tests pass locally (unit + integration + e2e). 3 pre-existing errors in tests/test_garmin.py are unrelated to this PR: that file is a smoke script from commit b46708b that was never migrated to pytest fixtures (the test functions take client as a parameter, which pytest interprets as a missing fixture).