### PR TITLE
fix: improve Garmin tool defaults and calendar chunking

### DIFF
--- a/src/garmin_mcp/challenges.py
+++ b/src/garmin_mcp/challenges.py
@@ -540,14 +540,15 @@ def register_tools(app):
             return f"Error retrieving race predictions: {str(e)}"
 
     @app.tool()
-    async def get_inprogress_virtual_challenges(start: int = 0, limit: int = 20) -> str:
+    async def get_inprogress_virtual_challenges(start: int = 1, limit: int = 20) -> str:
         """Get in-progress virtual challenges/expeditions
 
         Returns virtual challenges (like walking expeditions on famous trails)
         that the user is currently participating in.
 
         Args:
-            start: Starting index for pagination (default 0)
+            start: Starting index for pagination (default 1, must be >= 1;
+                garminconnect 0.3.2 rejects 0 for this endpoint)
             limit: Maximum number of challenges to return (default 20, max 100)
         """
         try:

--- a/src/garmin_mcp/devices.py
+++ b/src/garmin_mcp/devices.py
@@ -92,16 +92,30 @@ def register_tools(app):
             return f"Error retrieving last used device: {str(e)}"
 
     @app.tool()
-    async def get_device_settings(device_id: Union[int, str]) -> str:
+    async def get_device_settings(device_id: Optional[Union[int, str]] = None) -> str:
         """Get settings for a specific Garmin device
 
         Returns device configuration including time/date format, units,
         activity tracking settings, and alarm information.
 
         Args:
-            device_id: Device ID (can be obtained from get_devices or get_device_last_used)
+            device_id: Device ID (optional; defaults to the most recently used
+                device when omitted; can be obtained from get_devices or
+                get_device_last_used)
         """
         try:
+            if device_id is None:
+                last_used = garmin_client.get_device_last_used()
+                if not last_used:
+                    return (
+                        "No default device found. Pass device_id explicitly or "
+                        "register a device with Garmin Connect."
+                    )
+
+                device_id = last_used.get("userDeviceId")
+                if not device_id:
+                    return "Default device has no userDeviceId. Pass device_id explicitly."
+
             settings = garmin_client.get_device_settings(device_id)
             if not settings:
                 return f"No settings found for device ID {device_id}."

--- a/src/garmin_mcp/womens_health.py
+++ b/src/garmin_mcp/womens_health.py
@@ -2,11 +2,38 @@
 Women's health functions for Garmin Connect MCP Server
 """
 import json
-import datetime
-from typing import Any, Dict, List, Optional, Union
+from datetime import date, timedelta
+from typing import Any, List
 
 # The garmin_client will be set by the main file
 garmin_client = None
+
+MENSTRUAL_CALENDAR_MAX_DAYS = 92
+
+
+def _stitch_menstrual_chunks(chunks: List[Any]) -> Any:
+    """Combine chunked menstrual calendar responses without changing shape."""
+    if len(chunks) == 1:
+        return chunks[0]
+
+    if all(isinstance(chunk, list) for chunk in chunks):
+        stitched = []
+        for chunk in chunks:
+            stitched.extend(chunk)
+        return stitched
+
+    if all(isinstance(chunk, dict) for chunk in chunks) and all(
+        isinstance(value, list)
+        for chunk in chunks
+        for value in chunk.values()
+    ):
+        stitched = {}
+        for chunk in chunks:
+            for key, value in chunk.items():
+                stitched.setdefault(key, []).extend(value)
+        return stitched
+
+    return chunks
 
 
 def configure(client):
@@ -47,16 +74,42 @@ def register_tools(app):
     @app.tool()
     async def get_menstrual_calendar_data(start_date: str, end_date: str) -> str:
         """Get menstrual calendar data between specified dates
+
+        Automatically chunks requests longer than 92 days, Garmin's
+        server-side limit, and stitches the responses together.
         
         Args:
             start_date: Start date in YYYY-MM-DD format
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            data = garmin_client.get_menstrual_calendar_data(start_date, end_date)
-            if not data:
-                return f"No menstrual calendar data found between {start_date} and {end_date}."
-            return json.dumps(data, indent=2)
+            start = date.fromisoformat(start_date)
+            end = date.fromisoformat(end_date)
+            if end < start:
+                return f"end_date {end_date} is before start_date {start_date}."
+
+            chunks = []
+            cursor = start
+            while cursor <= end:
+                window_end = min(
+                    cursor + timedelta(days=MENSTRUAL_CALENDAR_MAX_DAYS - 1),
+                    end,
+                )
+                data = garmin_client.get_menstrual_calendar_data(
+                    cursor.isoformat(),
+                    window_end.isoformat(),
+                )
+                if data:
+                    chunks.append(data)
+                cursor = window_end + timedelta(days=1)
+
+            if not chunks:
+                return (
+                    f"No menstrual calendar data found between {start_date} "
+                    f"and {end_date}."
+                )
+
+            return json.dumps(_stitch_menstrual_chunks(chunks), indent=2)
         except Exception as e:
             return f"Error retrieving menstrual calendar data: {str(e)}"
 

--- a/tests/integration/test_challenges_tools.py
+++ b/tests/integration/test_challenges_tools.py
@@ -288,7 +288,7 @@ async def test_get_inprogress_virtual_challenges_tool(app_with_challenges, mock_
 
     # Verify
     assert result is not None
-    mock_garmin_client.get_inprogress_virtual_challenges.assert_called_once_with(0, 20)
+    mock_garmin_client.get_inprogress_virtual_challenges.assert_called_once_with(1, 20)
 
 
 # Error handling tests

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -11,6 +11,8 @@ Tests tools from:
 - __init__ / main (1 tool - list_activities)
 Total: 25 tools
 """
+import json
+
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
@@ -78,6 +80,29 @@ async def test_get_device_settings_tool(app_with_devices, mock_garmin_client):
     )
     assert result is not None
     mock_garmin_client.get_device_settings.assert_called_once_with("abc123456789")
+
+
+@pytest.mark.asyncio
+async def test_get_device_settings_default_device(app_with_devices, mock_garmin_client):
+    """When device_id is omitted, falls back to get_device_last_used()."""
+    mock_garmin_client.get_device_last_used.return_value = {
+        "userDeviceId": "abc123456789"
+    }
+    mock_garmin_client.get_device_settings.return_value = MOCK_DEVICE_SETTINGS
+    result = await app_with_devices.call_tool("get_device_settings", {})
+    assert result is not None
+    mock_garmin_client.get_device_last_used.assert_called_once()
+    mock_garmin_client.get_device_settings.assert_called_once_with("abc123456789")
+
+
+@pytest.mark.asyncio
+async def test_get_device_settings_default_device_missing(app_with_devices, mock_garmin_client):
+    """When no last-used device exists, returns a clear error string."""
+    mock_garmin_client.get_device_last_used.return_value = None
+    result = await app_with_devices.call_tool("get_device_settings", {})
+    text = result[0][0].text
+    assert "No default device found" in text
+    mock_garmin_client.get_device_settings.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -414,3 +439,31 @@ async def test_get_menstrual_calendar_data_tool(app_with_womens_health, mock_gar
     )
     assert result is not None
     mock_garmin_client.get_menstrual_calendar_data.assert_called_once_with("2024-01-01", "2024-01-31")
+
+
+@pytest.mark.asyncio
+async def test_get_menstrual_calendar_data_chunking(app_with_womens_health, mock_garmin_client):
+    """Range >92 days is split into 92-day windows and stitched."""
+    second_chunk = {
+        **MOCK_MENSTRUAL_DATA,
+        "calendarDate": "2026-04-03",
+        "cycleDay": 1,
+    }
+    mock_garmin_client.get_menstrual_calendar_data.side_effect = [
+        [MOCK_MENSTRUAL_DATA],
+        [second_chunk],
+    ]
+
+    result = await app_with_womens_health.call_tool(
+        "get_menstrual_calendar_data",
+        {"start_date": "2026-01-01", "end_date": "2026-06-30"},
+    )
+
+    assert result is not None
+    assert mock_garmin_client.get_menstrual_calendar_data.call_count == 2
+    calls = mock_garmin_client.get_menstrual_calendar_data.call_args_list
+    assert calls[0].args == ("2026-01-01", "2026-04-02")
+    assert calls[1].args == ("2026-04-03", "2026-06-30")
+
+    data = json.loads(result[0][0].text)
+    assert data == [MOCK_MENSTRUAL_DATA, second_chunk]

--- a/tests/test_garmin.py
+++ b/tests/test_garmin.py
@@ -8,8 +8,11 @@ import datetime
 from pathlib import Path
 import json
 
+import pytest
 from dotenv import load_dotenv
 from garminconnect import Garmin
+
+pytestmark = pytest.mark.e2e
 
 # Load environment variables from .env file
 env_path = Path(__file__).parent / '.env'


### PR DESCRIPTION
## Summary

Three small tool fixes surfaced while driving Garmin MCP from an LLM agent:

- `get_inprogress_virtual_challenges` now defaults to `start=1`. `garminconnect` 0.3.2 validates this endpoint with `_validate_positive_integer`, so the previous no-arg MCP call failed before reaching Garmin.
- `get_device_settings` now accepts an omitted `device_id` and falls back to `get_device_last_used()["userDeviceId"]`, which matches the common "show me my watch settings" flow.
- `get_menstrual_calendar_data` now splits windows longer than Garmin's 92-day server-side limit into inclusive 92-day chunks and stitches the responses.
- `tests/test_garmin.py` is marked as `e2e` because it is a direct Garmin smoke script that needs real credentials/fixtures; this keeps `pytest -m "not e2e"` focused on mocked unit and integration tests.

## How this surfaced

LLM-driven usage tends to call no-arg/default tools and broad date windows. Before this change:

```python
get_inprogress_virtual_challenges()
# -> start must be a positive integer, got: 0

get_menstrual_calendar_data("2026-01-01", "2026-05-14")
# -> 400 Exceeded max date difference (92 days)
```

For device settings, an agent had to call `get_device_last_used`, parse the returned JSON, and then call `get_device_settings` with the extracted ID. The tool can do that safely itself when no explicit ID is passed.

## Tests

- Updated the virtual challenge integration test to expect the new default `(1, 20)`.
- Added integration coverage for `get_device_settings()` default-device fallback and missing default-device error handling.
- Added integration coverage for menstrual calendar chunking over a 181-day range (`92 + 89`) and stitched list responses.
- Verified `tests/test_garmin.py` is excluded from non-e2e runs after marking it as `e2e`.

Commands run:

```bash
uv run pytest tests/integration/test_challenges_tools.py tests/integration/test_other_modules_tools.py -v
uv run pytest -m "not e2e"
git diff --check
```

Final result: `255 passed, 13 deselected` for the non-e2e suite.

## Follow-up

A separate upstream `python-garminconnect` change may be worthwhile: `get_inprogress_virtual_challenges` could use the same non-negative `start` validation as the sibling challenge pagination methods. Until that ships in a release, this MCP default avoids the no-arg failure.