### PR TITLE
Add R-R interval / HRV parsing to FIT file analysis

### DIFF
--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -581,6 +581,43 @@ def _compute_shift_summary(shifts: list) -> dict:
 # Main FIT parsing logic
 # ---------------------------------------------------------------------------
 
+def _compute_hrv_metrics(rr_intervals_s: List[float]) -> Optional[Dict]:
+    """Compute standard time-domain HRV metrics from R-R intervals (seconds).
+
+    Returns RMSSD, SDNN, pNN50, mean R-R, and count. These are the standard
+    intra-workout HRV metrics used in sports science and HRV-guided training
+    platforms (HRV4Training, Elite HRV, Polar's recovery metrics, etc.).
+
+    Requires at least 10 R-R intervals to produce stable results.
+    """
+    if len(rr_intervals_s) < 10:
+        return None
+
+    rr_ms = [r * 1000.0 for r in rr_intervals_s]
+    diffs = [rr_ms[i + 1] - rr_ms[i] for i in range(len(rr_ms) - 1)]
+
+    # RMSSD: root mean square of successive differences
+    squared = [d * d for d in diffs]
+    rmssd = (sum(squared) / len(squared)) ** 0.5 if squared else 0.0
+
+    # SDNN: standard deviation of all N-N intervals
+    mean_rr = sum(rr_ms) / len(rr_ms)
+    sdnn = (sum((r - mean_rr) ** 2 for r in rr_ms) / (len(rr_ms) - 1)) ** 0.5 if len(rr_ms) > 1 else 0.0
+
+    # pNN50: percentage of pairs differing by more than 50 ms
+    nn50 = sum(1 for d in diffs if abs(d) > 50.0)
+    pnn50 = 100.0 * nn50 / len(diffs) if diffs else 0.0
+
+    return {
+        "rmssd_ms": round(rmssd, 1),
+        "sdnn_ms": round(sdnn, 1),
+        "pnn50_pct": round(pnn50, 2),
+        "mean_rr_ms": round(mean_rr, 1),
+        "mean_hr_bpm": round(60000.0 / mean_rr, 1) if mean_rr > 0 else None,
+        "rr_count": len(rr_ms),
+    }
+
+
 def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
     """Parse a FIT file and extract structured cycling data."""
     fit_bytes = _extract_fit_bytes(fit_bytes)
@@ -590,6 +627,11 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
     laps: List[Dict] = []
     shifts: List[Dict] = []
     records: List[Dict] = []
+    # R-R intervals from the FIT 'hrv' message type, paired with the timestamp
+    # of the most recent record message so we can bucket them per lap later.
+    # Requires "Log HRV" enabled on the watch AND a chest strap paired.
+    rr_pairs: List[tuple] = []  # (record_timestamp, rr_seconds)
+    last_record_ts = None
 
     # Track last values for context at shift time
     last_cadence: Optional[float] = None
@@ -733,6 +775,11 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
             if grade is not None:
                 last_grade = grade
 
+            # Track timestamp for HRV bucketing
+            ts = _get_field(message, "timestamp")
+            if ts is not None:
+                last_record_ts = ts
+
             record: Dict[str, Any] = {
                 "timestamp": str(_get_field(message, "timestamp") or ""),
                 "power_w": _get_field(message, "power"),
@@ -775,6 +822,21 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
             record = {k: v for k, v in record.items() if v is not None}
             records.append(record)
 
+        # ------------------------------------------------------------------
+        # HRV — R-R intervals (one or more per message in field 'time')
+        # ------------------------------------------------------------------
+        elif msg_type == "hrv":
+            rr_field = _get_field(message, "time")
+            if rr_field is None:
+                continue
+            if not isinstance(rr_field, (list, tuple)):
+                rr_field = [rr_field]
+            for rr in rr_field:
+                # Filter sentinel/invalid values. FIT spec uses ~65.535 s
+                # as "no R-R interval detected" filler in fixed-size arrays.
+                if rr is not None and 0.2 < rr < 3.0:
+                    rr_pairs.append((last_record_ts, float(rr)))
+
     # ------------------------------------------------------------------
     # Post-parse enrichment
     # ------------------------------------------------------------------
@@ -813,6 +875,65 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
 
     if pdc:
         result["power_duration_curve"] = pdc
+
+    # HRV (time-domain) — always include summary if R-R data exists.
+    # Raw R-R array only included when include_records=True (can be large).
+    # Also compute per-lap HRV by bucketing R-R intervals by timestamp.
+    if rr_pairs:
+        all_rr = [rr for (_, rr) in rr_pairs]
+        hrv_summary = _compute_hrv_metrics(all_rr)
+        if hrv_summary:
+            result["hrv"] = hrv_summary
+
+        # Per-lap HRV: walk laps in order, derive each lap's [start, end)
+        # window from start_time + total_elapsed_time_s, filter R-R pairs.
+        import datetime as _dt
+
+        def _parse_iso(s):
+            if not s:
+                return None
+            try:
+                # FIT timestamps may be "2026-05-15 02:27:08" or with tz
+                return _dt.datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                return None
+
+        for lap in laps:
+            lap_start = _parse_iso(lap.get("start_time"))
+            elapsed = lap.get("total_elapsed_time_s")
+            if lap_start is None or not elapsed:
+                continue
+            lap_end = lap_start + _dt.timedelta(seconds=float(elapsed))
+
+            # Filter R-R pairs whose record_ts falls within this lap.
+            # rr_pairs[i][0] is a datetime-like value from fitparse.
+            lap_rr = []
+            for ts, rr in rr_pairs:
+                ts_dt = ts if isinstance(ts, _dt.datetime) else _parse_iso(ts)
+                if ts_dt is None:
+                    continue
+                # Compare naively if either is tz-naive (FIT timestamps are UTC)
+                if lap_start.tzinfo and not ts_dt.tzinfo:
+                    ts_dt = ts_dt.replace(tzinfo=lap_start.tzinfo)
+                elif ts_dt.tzinfo and not lap_start.tzinfo:
+                    lap_start_cmp = lap_start.replace(tzinfo=ts_dt.tzinfo)
+                    lap_end_cmp = lap_end.replace(tzinfo=ts_dt.tzinfo)
+                    if lap_start_cmp <= ts_dt < lap_end_cmp:
+                        lap_rr.append(rr)
+                    continue
+                if lap_start <= ts_dt < lap_end:
+                    lap_rr.append(rr)
+
+            lap_hrv = _compute_hrv_metrics(lap_rr)
+            if lap_hrv:
+                lap["hrv"] = lap_hrv
+
+        if include_records:
+            # Raw stream — list of {timestamp, rr_seconds} for full transparency
+            result["rr_intervals_seconds"] = [
+                {"timestamp": str(ts) if ts else None, "rr_seconds": rr}
+                for (ts, rr) in rr_pairs
+            ]
 
     if include_records:
         result["records"] = records


### PR DESCRIPTION
### Summary

This PR adds support for the FIT `hrv` message type to `_parse_fit()` in `activity_analysis.py`. When a recorded activity contains R-R intervals (Garmin watch with the "Log HRV" data-recording setting enabled, paired with a chest strap), the parser now exposes:

- Whole-activity time-domain HRV metrics under a new top-level `hrv` key
- Per-lap HRV metrics nested inside each existing `lap` entry
- Optional raw R-R intervals (with timestamps) under `rr_intervals_seconds` when `include_records=True`

For activities without R-R data (most cycling, indoor workouts, watches with the setting off), the response is bit-for-bit identical to before — the new keys are simply absent.

### Why

`fitparse` already reads the `hrv` message type, but `_parse_fit()` doesn't emit it. As a result, the rich intra-workout HRV signal (RMSSD, SDNN, pNN50) that Garmin watches record when configured to do so is silently dropped before reaching the LLM client.

This is a meaningful gap because:

- Garmin Connect itself doesn't surface this data in its UI — third-party tools (Runalyze, Golden Cheetah, HRV4Training) are typically needed
- For an MCP that already provides FTP analysis, training-load trends, and HR drift, intra-workout HRV is a natural complement
- The README's "Usage Examples" section already mentions HRV-related queries Claude might run — this PR makes those answerable from FIT files rather than only from the nightly aggregates

### What the new fields look like

For a 43-minute run with chest strap and `Log HRV` enabled:

```json
{
  "session": { ... },
  "laps": [
    {
      "lap_number": 1,
      "avg_heart_rate_bpm": 134,
      "total_elapsed_time_s": 599,
      "hrv": {
        "rr_count": 1345,
        "rmssd_ms": 17.3,
        "sdnn_ms": 33.0,
        "pnn50_pct": 0.15,
        "mean_rr_ms": 445.8,
        "mean_hr_bpm": 134.6
      }
    },
    ...
  ],
  "hrv": {
    "rr_count": 5716,
    "rmssd_ms": 13.6,
    "sdnn_ms": 32.9,
    "pnn50_pct": 0.12,
    "mean_rr_ms": 451.5,
    "mean_hr_bpm": 132.9
  }
}
```

With `include_records=True`, also adds:

```json
{
  "rr_intervals_seconds": [
    {"timestamp": "2026-05-15 02:27:08", "rr_seconds": 0.685},
    {"timestamp": "2026-05-15 02:27:08", "rr_seconds": 0.680},
    ...
  ]
}
```

### Metrics computed

Standard time-domain HRV per Task Force of the European Society of Cardiology / North American Society of Pacing and Electrophysiology guidelines:

| Metric | Definition |
|---|---|
| `rmssd_ms` | Root mean square of successive R-R differences |
| `sdnn_ms` | Standard deviation of all N-N intervals |
| `pnn50_pct` | Percentage of pairs differing by >50ms |
| `mean_rr_ms` | Mean R-R interval (ms) |
| `mean_hr_bpm` | Derived avg HR from R-R (`60000 / mean_rr_ms`) |
| `rr_count` | Number of valid R-R intervals |

R-R values filtered to `0.2 s < rr < 3.0 s` to discard FIT sentinel values (the spec uses ~65.535s as the "no R-R" filler in fixed-size arrays). At least 10 R-R intervals required to produce stable metrics.

### Per-lap bucketing

Each `hrv` message in FIT format doesn't carry its own timestamp — it's emitted alongside the surrounding `record` messages. The parser tracks the most recent record timestamp (`last_record_ts`) and pairs each R-R interval with it. After parsing, lap-window filtering (`start_time` ≤ ts < `start_time + total_elapsed_time_s`) buckets the R-R values per lap and computes per-lap metrics.

This is correct in the common case and degrades gracefully: laps that lack timestamp data or fewer than 10 R-R intervals simply don't get an `hrv` block.

### Backward compatibility

- **Activities without R-R data**: response unchanged. No new keys appear.
- **Existing callers**: not affected. All new fields are additive; no existing field has been renamed, restructured, or removed.
- **Response size**: HRV summary block is ~150 bytes. Raw `rr_intervals_seconds` array (only with `include_records=True`) adds ~70 KB per hour of activity.

### Tests

I haven't added integration tests — happy to do so if the maintainer wants. The patch is straightforward enough that the existing FIT-file fixtures could be extended by appending synthetic `hrv` messages, OR a separate fixture FIT file with R-R data could be added under `tests/`.

### Personal context

I run on a Fenix 7 Pro with the HRM-Pro chest strap. This patch has been running locally for several weeks against real workouts; the per-lap HRV pattern matches Garmin Connect's own (non-MCP-exposed) HRV graphs and matches what HRV4Training computes from the same FIT files.

---