### PR TITLE
Add optional tool filtering via environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,29 @@ Some endpoints are not implemented due to performance or complexity consideratio
 
 If you need any of these endpoints, please [open an issue](https://github.com/Taxuspt/garmin_mcp/issues).
 
+## Tool Filtering
+
+This server registers 110+ tools by default, which can be a lot of context for
+an LLM to carry in every session. You can expose only the tools you need with
+two optional environment variables:
+
+| Env var | Effect |
+|---|---|
+| `GARMIN_ENABLED_TOOLS` | Comma-separated **allowlist** — if set, *only* these tools are registered. |
+| `GARMIN_DISABLED_TOOLS` | Comma-separated **denylist** — listed tools are skipped. Ignored if an allowlist is set. |
+
+Tool names are case-insensitive. With neither variable set, all tools register
+(unchanged default behaviour). Names that match no tool are ignored with a
+warning on stderr, which makes typos easy to spot.
+
+Example — expose only sleep, stress, and recent activities:
+
+```json
+"env": {
+  "GARMIN_ENABLED_TOOLS": "get_sleep_data,get_stress_summary,get_activities"
+}
+```
+
 ## High-level workout tools
 
 These builder tools let an LLM create and schedule workouts without writing raw Garmin JSON.

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -87,6 +87,69 @@ tokenstore_base64 = os.getenv("GARMINTOKENS_BASE64") or "~/.garminconnect_base64
 is_cn = os.getenv("GARMIN_IS_CN", "false").lower() in ("true", "1", "yes")
 
 
+# --- Tool filtering ---------------------------------------------------------
+# Optionally expose only a subset of tools, to reduce the context an LLM must
+# carry. No modules are removed; tools are simply not registered when filtered.
+#   GARMIN_ENABLED_TOOLS  - comma-separated allowlist; if set, ONLY these register
+#   GARMIN_DISABLED_TOOLS - comma-separated denylist; ignored if an allowlist is set
+# Tool names are case-insensitive. Unset = all tools register (default behaviour).
+def _parse_tool_set(value):
+    if not value:
+        return set()
+    return {name.strip().lower() for name in value.split(",") if name.strip()}
+
+
+enabled_tools = _parse_tool_set(os.getenv("GARMIN_ENABLED_TOOLS"))
+disabled_tools = _parse_tool_set(os.getenv("GARMIN_DISABLED_TOOLS"))
+
+
+class _ToolFilter:
+    """Wraps a FastMCP app to conditionally register tools by function name.
+
+    Modules register via ``@app.tool()``; we intercept that decorator and skip
+    registration for any tool not permitted by the env-var filter. All other
+    attribute access (``run``, ``resource``, ...) passes through to the app.
+    """
+
+    def __init__(self, app, enabled, disabled):
+        self._app = app
+        self._enabled = enabled
+        self._disabled = disabled
+        self._seen = set()  # tool names encountered, for typo detection
+
+    def _allowed(self, name):
+        name = name.lower()
+        if self._enabled:
+            return name in self._enabled
+        return name not in self._disabled
+
+    def tool(self, *args, **kwargs):
+        decorator = self._app.tool(*args, **kwargs)
+        # Prefer the explicit registered name if given (@app.tool(name="x")),
+        # so the env-var filter matches what the user actually configures.
+        explicit = kwargs.get("name") or (
+            args[0] if args and isinstance(args[0], str) else None
+        )
+
+        def wrapper(fn):
+            name = explicit or getattr(fn, "__name__", "")
+            self._seen.add(name.lower())
+            if self._allowed(name):
+                return decorator(fn)
+            return fn  # skip registration; tool never reaches the LLM
+
+        return wrapper
+
+    def unknown_filter_names(self):
+        """Configured names that never matched a real tool (likely typos)."""
+        configured = self._enabled or self._disabled
+        return sorted(configured - self._seen)
+
+    def __getattr__(self, item):
+        return getattr(self._app, item)
+# ---------------------------------------------------------------------------
+
+
 def init_api(email, password):
     """Initialize Garmin API with your credentials."""
     import io
@@ -240,8 +303,12 @@ def main():
     courses.configure(garmin_client)
     activity_analysis.configure(garmin_client)
 
-    # Create the MCP app
-    app = FastMCP("Garmin Connect v1.0")
+    # Create the MCP app, wrapped so the env-var filter can drop tools
+    app = _ToolFilter(FastMCP("Garmin Connect v1.0"), enabled_tools, disabled_tools)
+    if enabled_tools:
+        print(f"Tool filter: allowlist of {len(enabled_tools)} tool(s).", file=sys.stderr)
+    elif disabled_tools:
+        print(f"Tool filter: denylist of {len(disabled_tools)} tool(s).", file=sys.stderr)
 
     # Register tools from all modules
     app = activity_management.register_tools(app)
@@ -262,6 +329,14 @@ def main():
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)
+
+    # Warn about filter entries that matched no tool (most likely typos)
+    unknown = app.unknown_filter_names()
+    if unknown:
+        print(
+            f"Tool filter: warning — name(s) not found and ignored: {', '.join(unknown)}",
+            file=sys.stderr,
+        )
 
     # Run the MCP server
     app.run()

--- a/tests/unit/test_tool_filter.py
+++ b/tests/unit/test_tool_filter.py
@@ -1,0 +1,95 @@
+"""Unit tests for the env-var tool filter (_ToolFilter)."""
+
+from garmin_mcp import _ToolFilter
+
+
+class FakeApp:
+    """Minimal stand-in for FastMCP: records which tools get registered."""
+
+    def __init__(self):
+        self.registered = []
+
+    def tool(self, *args, **kwargs):
+        explicit = kwargs.get("name") or (
+            args[0] if args and isinstance(args[0], str) else None
+        )
+
+        def decorator(fn):
+            self.registered.append(explicit or fn.__name__)
+            return fn
+
+        return decorator
+
+    def run(self):
+        return "ran"
+
+
+def _register(filt, names):
+    """Register one no-op tool per name through the filter."""
+    for n in names:
+        def fn():
+            return None
+
+        fn.__name__ = n
+        filt.tool()(fn)
+
+
+def test_no_filter_registers_all():
+    app = FakeApp()
+    filt = _ToolFilter(app, set(), set())
+    _register(filt, ["get_a", "get_b"])
+    assert app.registered == ["get_a", "get_b"]
+
+
+def test_allowlist_only_registers_listed():
+    app = FakeApp()
+    filt = _ToolFilter(app, {"get_a"}, set())
+    _register(filt, ["get_a", "get_b"])
+    assert app.registered == ["get_a"]
+
+
+def test_denylist_skips_listed():
+    app = FakeApp()
+    filt = _ToolFilter(app, set(), {"get_b"})
+    _register(filt, ["get_a", "get_b"])
+    assert app.registered == ["get_a"]
+
+
+def test_allowlist_takes_precedence_over_denylist():
+    app = FakeApp()
+    filt = _ToolFilter(app, {"get_a"}, {"get_a"})
+    _register(filt, ["get_a", "get_b"])
+    assert app.registered == ["get_a"]
+
+
+def test_matching_is_case_insensitive():
+    app = FakeApp()
+    filt = _ToolFilter(app, {"get_a"}, set())
+    _register(filt, ["GET_A"])
+    assert app.registered == ["GET_A"]
+
+
+def test_unknown_filter_names_flags_typos():
+    app = FakeApp()
+    filt = _ToolFilter(app, {"get_a", "get_typo"}, set())
+    _register(filt, ["get_a"])
+    assert filt.unknown_filter_names() == ["get_typo"]
+
+
+def test_explicit_name_kwarg_used_for_matching():
+    app = FakeApp()
+    filt = _ToolFilter(app, {"real_name"}, set())
+
+    def fn():
+        return None
+
+    fn.__name__ = "internal_fn"
+    filt.tool(name="real_name")(fn)
+    assert app.registered == ["real_name"]
+    assert filt.unknown_filter_names() == []
+
+
+def test_passthrough_to_wrapped_app():
+    app = FakeApp()
+    filt = _ToolFilter(app, set(), set())
+    assert filt.run() == "ran"


### PR DESCRIPTION
## Summary

The server registers 110+ tools, which is a lot of context for an LLM to carry in every session — particularly for users who only need a slice of the API (e.g. health/wellness data, without workout-building or cycling analytics).

This adds two **optional** environment variables to expose only the tools you want:

| Env var | Effect |
|---|---|
| `GARMIN_ENABLED_TOOLS` | Comma-separated allowlist — if set, *only* these tools register. |
| `GARMIN_DISABLED_TOOLS` | Comma-separated denylist — skipped tools. Ignored if an allowlist is set. |

Tool names are case-insensitive. **With neither variable set, all tools register — behaviour is identical to today.**

## Design

A small `_ToolFilter` proxy wraps the `FastMCP` app and intercepts the `@app.tool()` decorator, skipping registration for filtered-out tools. Nothing is deleted — every module still `configure()`s and `register_tools()` exactly as before. Skipped tools remain importable as plain functions (so a tool that internally calls a sibling is unaffected), and all other app methods (`run`, `resource`, …) pass through unchanged.

Filter entries that match no tool are reported on stderr, so allowlist typos are easy to catch.

## Example

Expose only sleep, stress, and recent activities:

```json
"env": {
  "GARMIN_ENABLED_TOOLS": "get_sleep_data,get_stress_summary,get_activities"
}
```

## Tests

Adds `tests/unit/test_tool_filter.py` covering allowlist, denylist, allow-over-deny precedence, case-insensitivity, typo detection, explicit-`name=` matching, and attribute passthrough.

## Notes

- Fully backwards compatible and opt-in — no change to default behaviour.
- Documented under a new "Tool Filtering" section in the README.
