### PR TITLE
fix: sanitize RepeatGroupDTO endCondition before upload to prevent API corruption

### DIFF
--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -40,11 +40,47 @@ def _fix_hr_zone_step(step: dict) -> None:
         _fix_hr_zone_step(nested)
 
 
+def _fix_repeat_group_step(step: dict) -> None:
+    """Ensure RepeatGroupDTO steps have a valid endCondition and numberOfIterations.
+
+    The Garmin API silently corrupts a RepeatGroupDTO when conditionTypeId is
+    missing from its endCondition — it falls back to an unrelated condition type
+    (observed: "heart.rate") and drops numberOfIterations entirely.
+
+    This function:
+    - Adds conditionTypeId: 7 ("iterations") when conditionTypeKey is "iterations"
+      but conditionTypeId is absent.
+    - Backfills numberOfIterations from endConditionValue when the former is missing.
+    - Recurses into nested workoutSteps so nested repeat groups are also fixed.
+    """
+    if step.get('type') != 'RepeatGroupDTO':
+        for nested in step.get('workoutSteps', []):
+            _fix_repeat_group_step(nested)
+        return
+
+    end_condition = step.get('endCondition')
+    if isinstance(end_condition, dict):
+        if (
+            end_condition.get('conditionTypeKey') == 'iterations'
+            and 'conditionTypeId' not in end_condition
+        ):
+            end_condition['conditionTypeId'] = 7
+
+    if 'numberOfIterations' not in step:
+        value = step.get('endConditionValue')
+        if value is not None:
+            step['numberOfIterations'] = int(value)
+
+    for nested in step.get('workoutSteps', []):
+        _fix_repeat_group_step(nested)
+
+
 def _fix_hr_zone_steps(workout_data: dict) -> None:
     """Walk all workout steps and fix HR zone target mistakes."""
     for segment in workout_data.get('workoutSegments', []):
         for step in segment.get('workoutSteps', []):
             _fix_hr_zone_step(step)
+            _fix_repeat_group_step(step)
 
 
 def _curate_workout_summary(workout: dict) -> dict:
@@ -414,7 +450,10 @@ def register_tools(app):
 
         IMPORTANT: Step types must use Garmin's DTO format:
         - Use "ExecutableStepDTO" for regular steps (warmup, interval, cooldown, recovery)
-        - Use "RepeatGroupDTO" for repeat/interval groups with numberOfIterations
+        - Use "RepeatGroupDTO" for repeat/interval groups with numberOfIterations.
+          Always include endCondition with conditionTypeId 7 and conditionTypeKey
+          "iterations"; omitting conditionTypeId causes the API to silently corrupt
+          the repeat count.
 
         IMPORTANT: Heart rate targets come in two forms:
         - Named zone (e.g. Zone 2): set targetType to "heart.rate.zone" and use "zoneNumber" (1-5).
@@ -520,7 +559,10 @@ def register_tools(app):
 
         IMPORTANT: Step types must use Garmin's DTO format:
         - Use "ExecutableStepDTO" for regular steps (warmup, interval, cooldown, recovery)
-        - Use "RepeatGroupDTO" for repeat/interval groups with numberOfIterations
+        - Use "RepeatGroupDTO" for repeat/interval groups with numberOfIterations.
+          Always include endCondition with conditionTypeId 7 and conditionTypeKey
+          "iterations"; omitting conditionTypeId causes the API to silently corrupt
+          the repeat count.
 
         IMPORTANT: For heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
 

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -8,6 +8,7 @@ from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import workouts
+from garmin_mcp.workouts import _fix_repeat_group_step
 from tests.fixtures.garmin_responses import (
     MOCK_WORKOUTS,
     MOCK_WORKOUT_DETAILS,
@@ -1036,3 +1037,77 @@ async def test_schedule_workouts_inline_upload_no_id_returned(app_with_workouts,
     assert result_data["failed"] == 1
     assert result_data["results"][0]["status"] == "failed"
     mock_garmin_client.client.post.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _fix_repeat_group_step (unit tests)
+# ---------------------------------------------------------------------------
+
+def test_fix_repeat_group_adds_missing_condition_type_id():
+    """Adds conditionTypeId:7 when conditionTypeKey is 'iterations' but id is absent."""
+    step = {
+        "type": "RepeatGroupDTO",
+        "numberOfIterations": 5,
+        "endCondition": {"conditionTypeKey": "iterations"},
+        "endConditionValue": 5,
+        "workoutSteps": [],
+    }
+    _fix_repeat_group_step(step)
+    assert step["endCondition"]["conditionTypeId"] == 7
+    assert step["endCondition"]["conditionTypeKey"] == "iterations"
+
+
+def test_fix_repeat_group_leaves_existing_condition_type_id_unchanged():
+    """Does not overwrite conditionTypeId when already present."""
+    step = {
+        "type": "RepeatGroupDTO",
+        "numberOfIterations": 3,
+        "endCondition": {"conditionTypeId": 7, "conditionTypeKey": "iterations"},
+        "endConditionValue": 3,
+        "workoutSteps": [],
+    }
+    _fix_repeat_group_step(step)
+    assert step["endCondition"]["conditionTypeId"] == 7
+
+
+def test_fix_repeat_group_backfills_number_of_iterations_from_end_condition_value():
+    """numberOfIterations is set from endConditionValue when missing."""
+    step = {
+        "type": "RepeatGroupDTO",
+        "endCondition": {"conditionTypeId": 7, "conditionTypeKey": "iterations"},
+        "endConditionValue": 4,
+        "workoutSteps": [],
+    }
+    _fix_repeat_group_step(step)
+    assert step["numberOfIterations"] == 4
+
+
+def test_fix_repeat_group_does_not_modify_non_repeat_steps():
+    """Steps that are not RepeatGroupDTO are not modified."""
+    step = {
+        "type": "ExecutableStepDTO",
+        "endCondition": {"conditionTypeKey": "time"},
+        "endConditionValue": 300.0,
+    }
+    _fix_repeat_group_step(step)
+    assert "conditionTypeId" not in step["endCondition"]
+
+
+def test_fix_repeat_group_recurses_into_nested_repeat_groups():
+    """Nested RepeatGroupDTOs inside another are also fixed."""
+    inner = {
+        "type": "RepeatGroupDTO",
+        "numberOfIterations": 2,
+        "endCondition": {"conditionTypeKey": "iterations"},
+        "endConditionValue": 2,
+        "workoutSteps": [],
+    }
+    outer = {
+        "type": "RepeatGroupDTO",
+        "numberOfIterations": 3,
+        "endCondition": {"conditionTypeId": 7, "conditionTypeKey": "iterations"},
+        "endConditionValue": 3,
+        "workoutSteps": [inner],
+    }
+    _fix_repeat_group_step(outer)
+    assert inner["endCondition"]["conditionTypeId"] == 7


### PR DESCRIPTION
## Summary

The Garmin API silently corrupts a `RepeatGroupDTO` when `conditionTypeId` is missing from its `endCondition` — it replaces the condition type with an unrelated value (observed: `"heart.rate"`) and drops `numberOfIterations` entirely.

Adds `_fix_repeat_group_step()`, called alongside `_fix_hr_zone_step()` in the pre-upload pass, which:
- Adds `conditionTypeId: 7` when `conditionTypeKey` is `"iterations"` but the id is absent
- Backfills `numberOfIterations` from `endConditionValue` when the former is missing
- Recurses into nested `workoutSteps` for nested repeat groups

Also updates `upload_workout` / `upload_workouts` docstrings to document the correct `RepeatGroupDTO` `endCondition` structure.

Fixes #112

## Test plan

- [ ] 5 new unit tests for `_fix_repeat_group_step` all pass
- [ ] `uv run pytest -m "not e2e"` — 282 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)