### PR TITLE
Add remote Garmin login, DXT auth, and smart analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ __pycache__/
 dist/
 build/
 *.egg
+.dxt-build/
+*.dxt
 
 # Virtual environments
 .env

--- a/Dockerfile.remote
+++ b/Dockerfile.remote
@@ -1,0 +1,36 @@
+# Dockerfile for Garmin MCP remote server (OAuth2 + streamable HTTP)
+FROM python:3.12-slim
+
+WORKDIR /app
+
+# Install uv for faster dependency management
+COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
+
+# Set environment variables
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    UV_SYSTEM_PYTHON=1
+
+# Copy dependency files and README first for better layer caching
+COPY pyproject.toml README.md ./
+
+# Copy the application source code
+COPY src/ ./src/
+
+# Install dependencies
+RUN uv pip install -e .
+
+# Create data directories
+RUN mkdir -p /data/garmin_sessions
+
+# Expose the HTTP port
+EXPOSE 8000
+
+# Data volume for SQLite DB and Garmin session tokens
+VOLUME /data
+
+# Health check - verify the server is responding
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD python -c "import httpx; r = httpx.get('http://localhost:8000/mcp'); assert r.status_code in (200, 401)"
+
+ENTRYPOINT ["garmin-mcp-remote"]

--- a/README.md
+++ b/README.md
@@ -16,21 +16,28 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 - Manage gear and equipment
 - Access workouts and training plans
 - Weekly health aggregates (steps, stress, intensity minutes)
+- Smart historical analytics: personal baselines, anomalies, lagged correlations,
+  and weekly health review summaries
+- Custom health reports that can be grouped, saved locally, and rerun
+- Built-in auth tools to check saved tokens and log in with OTP only when Garmin
+  asks for it
 
 ### Tool Coverage
 
 This MCP server implements **95+ tools** covering ~88% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.2.38):
 
-- ✅ Activity Management (14 tools)
-- ✅ Health & Wellness (30 tools) - includes custom lightweight summary tools
-- ✅ Training & Performance (9 tools)
-- ✅ Workouts (8 tools)
-- ✅ Devices (7 tools)
-- ✅ Gear Management (5 tools)
-- ✅ Weight Tracking (5 tools)
-- ✅ Challenges & Badges (10 tools)
-- ✅ Women's Health (3 tools)
-- ✅ User Profile (3 tools)
+- Activity Management (14 tools)
+- Health & Wellness (30 tools) - includes custom lightweight summary tools
+- Training & Performance (9 tools)
+- Workouts (8 tools)
+- Devices (7 tools)
+- Gear Management (5 tools)
+- Weight Tracking (5 tools)
+- Challenges & Badges (10 tools)
+- Women's Health (3 tools)
+- User Profile (3 tools)
+- Smart Analytics (8 tools)
+- Authentication (2 tools)
 
 ### Intentionally Skipped Endpoints
 
@@ -48,7 +55,140 @@ Some endpoints are not implemented due to performance or complexity consideratio
 
 If you need any of these endpoints, please [open an issue](https://github.com/Taxuspt/garmin_mcp/issues).
 
+### Tool Reference
+
+Most Garmin data tools are direct wrappers around `python-garminconnect`.
+The tools below are extra server tools for authentication, analytics, and saved
+custom reports.
+
+#### Authentication Tools
+
+These tools are available even before Garmin login is complete. This lets the
+MCP server start cleanly in Claude Desktop, then finish login from Claude.
+
+| Tool | What it does | Main inputs | Typical result |
+| --- | --- | --- | --- |
+| `check_garmin_auth` | Checks whether saved Garmin tokens exist and still work. | `token_path` | `authenticated`, token path, token status, and next step |
+| `login_to_garmin` | Logs in to Garmin Connect, handles OTP only when Garmin asks, saves tokens, and activates the running server. | `email`, `password`, `otp_code`, `token_path`, `token_base64_path`, `force_reauth` | `authenticated`, `missing_credentials`, `mfa_required`, or `failed` |
+
+Use `check_garmin_auth` first. If it says tokens are missing or invalid, run
+`login_to_garmin`. Accounts without OTP save tokens in one call. Accounts with
+OTP return `mfa_required`, then you run `login_to_garmin` again with the code.
+
+#### Smart Analytics Tools
+
+The analytics tools fetch a bounded Garmin history window and return compact
+derived results instead of full raw Garmin payloads. The default window is
+90 days and the hard cap is 180 days, so calls stay manageable for MCP clients.
+
+| Tool | What it does | Main inputs | Typical result |
+| --- | --- | --- | --- |
+| `get_health_baselines` | Compares current health metrics with personal rolling baselines. | `end_date`, `days`, `baseline_window` | Latest value, baseline, delta, and direction per metric |
+| `get_wellness_anomalies` | Finds unusual days using z-scores against recent history. | `end_date`, `days`, `baseline_window`, `z_threshold` | Count and list of unusual metric days |
+| `get_lagged_health_correlations` | Checks whether one metric tends to lead another by 1 to 14 days. | `end_date`, `days`, `max_lag_days` | Strongest delayed metric relationships |
+| `get_weekly_health_review` | Compares the last 7 days with the prior 7 days. | `end_date` | Weekly comparison, notable anomalies, and delayed relationships |
+| `list_health_report_metrics` | Lists supported metric keys, grouping options, and aggregation options. | None | Metrics, units, directions, groups, aggregations, and report store path |
+| `run_custom_health_report` | Runs an ad hoc or saved grouped health report. | `end_date`, `days`, `metrics`, `group_by`, `aggregation`, `saved_report_name`, `include_daily_rows` | Grouped rows, chart hint, and optional daily raw rows |
+| `save_custom_health_report` | Saves a reusable custom report definition locally. | `name`, `metrics`, `group_by`, `aggregation`, `days`, `end_date`, `description` | Saved report definition |
+| `list_saved_health_reports` | Lists locally saved custom report definitions. | None | Report store path, count, and saved reports |
+
+Custom reports support these report options:
+
+- Groups: `date`, `week`, `month`
+- Aggregations: `avg`, `sum`, `min`, `max`, `latest`
+- Default metrics: `steps`, `sleep_score`, `stress_avg`, `overnight_hrv`,
+  `training_readiness`, `recovery_pressure`
+- Raw rows: set `include_daily_rows` to `true` in `run_custom_health_report`
+
+Saved report definitions are stored in `~/.garmin_mcp_reports.json` by default.
+Set `GARMIN_REPORTS_PATH` if you want a different JSON file location.
+
 ## Setup
+
+### Desktop Extension (DXT)
+
+This branch includes a Desktop Extension manifest for Claude Desktop.
+
+Build it locally:
+
+```bash
+./scripts/build_dxt.sh
+```
+
+The built file is `garmin-mcp.dxt`.
+
+The DXT package includes the server source, `pyproject.toml`, and `uv.lock`.
+It runs from Claude Desktop's installed extension directory through
+`${__dirname}`, so it does not depend on this repository path after install.
+
+When installing the extension, use a persistent token directory. If Garmin sends
+you an email or phone verification code during first login, paste that code into
+the one-time MFA code field. After the first successful login, the server saves
+OAuth tokens in the token directory, and you can leave the MFA code blank.
+
+Claude Desktop's DXT manifest does not provide a custom pre-save login button.
+This extension handles that inside the MCP server instead. The server starts
+even when Garmin is not authenticated, so you can ask Claude to:
+
+1. Run `check_garmin_auth` to see whether saved tokens exist and still work.
+2. Run `login_to_garmin` with your email and password if tokens are missing.
+3. If Garmin asks for a code, run `login_to_garmin` again with the same email
+   and password plus `otp_code`.
+
+Accounts without OTP save tokens in the first login call. Accounts with OTP get
+an `mfa_required` response first, then save tokens after the OTP call. Use a
+persistent token directory such as `~/.garminconnect` if you want to reuse the
+same Garmin session across DXT rebuilds.
+
+On macOS, `login_to_garmin` can also ask for missing credentials through a local
+system dialog. This keeps the password out of chat and out of the MCP config.
+Set `GARMIN_DISABLE_LOCAL_PROMPTS=1` if you want to disable those dialogs and
+require credentials through tool arguments or environment variables only.
+
+### Authentication Flow
+
+The server can now start even when Garmin is not authenticated. This is useful
+for Claude Desktop because MCP servers run in the background and cannot always
+ask for terminal input.
+
+Use this flow for a new setup:
+
+1. Start the server or install the DXT.
+2. Run `check_garmin_auth`.
+3. If tokens are missing or invalid, run `login_to_garmin`.
+4. If Garmin asks for a code, enter the OTP when the tool asks for it.
+5. Run `check_garmin_auth` again to confirm the saved tokens work.
+
+The token directory must be persistent. The default is `~/.garminconnect`.
+Inside that directory, Garmin token files such as `oauth1_token.json` and
+`oauth2_token.json` are created after a successful login.
+
+Important behavior:
+
+- An empty token directory is normal before the first login.
+- A missing `oauth1_token.json` file means tokens have not been saved yet.
+- The server should still stay online, so you can run the auth tools.
+- During email and password login, the server temporarily ignores
+  `GARMINTOKENS`. This avoids a Garmin library issue where an empty token
+  directory is loaded before the password login can start.
+
+Credential options:
+
+- Pass `email` and `password` directly to `login_to_garmin`.
+- Set `GARMIN_EMAIL` and `GARMIN_PASSWORD` in the MCP server environment.
+- Use `GARMIN_EMAIL_FILE` and `GARMIN_PASSWORD_FILE` for file-based secrets.
+- On macOS, leave the password out of config and let the local hidden dialog ask
+  for it when `login_to_garmin` runs.
+
+Security notes:
+
+- Garmin credentials are only needed to create or refresh tokens.
+- Saved tokens are reused after login, so normal data tools do not need the
+  password.
+- Do not commit passwords, token files, `.env` files, or local Claude Desktop
+  config files.
+- If you want to remove access, delete the token directory and authenticate
+  again later.
 
 ### Quick Start for Claude Desktop
 
@@ -391,19 +531,34 @@ For other issues, check the Claude Desktop logs at:
 
 ### Garmin Connect Multi-Factor Authentication (MFA)
 
-#### Understanding MFA with MCP Servers
+MFA can be handled in two ways. You can use the MCP auth tools from Claude, or
+you can authenticate once in a terminal before starting Claude Desktop.
 
-MCP servers run as background processes without direct terminal access. If your Garmin account has MFA enabled, you must authenticate once using the pre-authentication tool before the server can run.
+#### Option 1: Use the MCP Auth Tools
 
-#### Recommended: Pre-Authentication Tool
+This is the best option when the server is already visible in Claude.
 
-The easiest way to handle MFA is using the dedicated authentication tool:
+1. Run `check_garmin_auth`.
+2. Run `login_to_garmin`.
+3. Enter your Garmin email and password when asked.
+4. If Garmin sends an OTP, enter that code when asked.
+5. After success, the tokens are saved and normal Garmin tools can run.
+
+On macOS, the tool can ask for the password and OTP in local system dialogs.
+This means you do not need to paste the password into chat. If the dialog does
+not appear, check behind the Claude window.
+
+#### Option 2: Pre-Authentication Tool
+
+You can also authenticate in a terminal with the dedicated authentication tool:
 
 ```bash
 garmin-mcp-auth
 ```
 
-This saves OAuth tokens to `~/.garminconnect` for future use. The server will automatically use these tokens when running in Claude Desktop or other MCP clients.
+This saves OAuth tokens to `~/.garminconnect` for future use. The server will
+automatically use these tokens when running in Claude Desktop or other MCP
+clients.
 
 **Additional Options:**
 
@@ -421,7 +576,7 @@ garmin-mcp-auth --force-reauth
 garmin-mcp-auth --token-path ~/.garmin_tokens
 ```
 
-#### Alternative: Manual First Run
+#### Option 3: Manual First Run
 
 You can also authenticate by running the server once interactively:
 
@@ -440,7 +595,8 @@ GARMIN_EMAIL_FILE=~/.garmin_email GARMIN_PASSWORD_FILE=~/.garmin_password \
 # Now add to Claude Desktop config without credentials
 ```
 
-After initial authentication, configure Claude Desktop **without** credentials (tokens are already saved):
+After initial authentication, configure Claude Desktop **without** credentials.
+The tokens are already saved:
 
 ```json
 {
@@ -461,17 +617,28 @@ After initial authentication, configure Claude Desktop **without** credentials (
 
 #### Using Docker with MFA
 
-If using Docker, follow the [Handling MFA with Docker](#handling-mfa-with-docker) section above for a streamlined experience with persistent token storage.
+If using Docker, follow the [Handling MFA with Docker](#handling-mfa-with-docker)
+section above for a simple setup with persistent token storage.
 
 #### Troubleshooting MFA
 
 **Error: "MFA authentication required but no interactive terminal available"**
 
 Solution:
-1. Open terminal
-2. Run: `garmin-mcp-auth`
-3. Enter credentials and MFA code
-4. Restart Claude Desktop
+1. Run `login_to_garmin` from Claude if the auth tools are available.
+2. Or open a terminal and run `garmin-mcp-auth`.
+3. Enter credentials and MFA code.
+4. Restart Claude Desktop.
+
+**Error: "Token files not found" or "oauth1_token.json" missing**
+
+This usually means the token directory exists, but no login has saved tokens
+yet. It does not always mean the directory itself is missing.
+
+Solution:
+1. Keep the token directory, for example `~/.garminconnect`.
+2. Run `login_to_garmin` or `garmin-mcp-auth`.
+3. After login, verify with `check_garmin_auth` or `garmin-mcp-auth --verify`.
 
 **Token Expired**
 
@@ -487,7 +654,7 @@ garmin-mcp-auth --verify
 
 ## Remote Mode (Multi-User, HTTP + OAuth2)
 
-Remote mode runs the MCP server over HTTP with OAuth2 authentication, enabling multi-user access. Each user authenticates directly with their **Garmin Connect credentials** during the OAuth2 flow — no pre-created accounts or manual account linking required.
+Remote mode runs the MCP server over HTTP with OAuth2 authentication, enabling multi-user access. Each user authenticates directly with their **Garmin Connect credentials** during the OAuth2 flow - no pre-created accounts or manual account linking required.
 
 ### How It Works
 
@@ -497,23 +664,23 @@ When a client (e.g., Claude) connects to the remote server:
 2. The user is redirected to a login page asking for their **Garmin Connect email and password**
 3. If 2FA is enabled on the Garmin account, a second page asks for the verification code
 4. On success, the Garmin session tokens are stored server-side and an OAuth2 access token is returned to the client
-5. The client uses this token to access all Garmin tools — no extra setup needed
+5. The client uses this token to access all Garmin tools - no extra setup needed
 
 ```
-Client → 401 → OAuth2 discovery
-  → /authorize → redirect to /login?state=...
-  → User enters Garmin email + password
-  → POST /login/callback
-      ├─ No 2FA → create user + session → redirect with auth code
-      └─ 2FA required → redirect to /login/mfa?state=...
-           → User enters verification code
-           → POST /login/mfa/callback → create user + session → redirect with auth code
-  → Client exchanges code for tokens → access granted
+Client -> 401 -> OAuth2 discovery
+  -> /authorize -> redirect to /login?state=...
+  -> User enters Garmin email + password
+  -> POST /login/callback
+      +-- No 2FA -> create user + session -> redirect with auth code
+      +-- 2FA required -> redirect to /login/mfa?state=...
+           -> User enters verification code
+           -> POST /login/mfa/callback -> create user + session -> redirect with auth code
+  -> Client exchanges code for tokens -> access granted
 ```
 
 ### Security
 
-- Garmin credentials are **never stored** — only garth OAuth tokens are persisted on disk
+- Garmin credentials are **never stored** - only garth OAuth tokens are persisted on disk
 - The 2FA client state is held in memory only, with a 5-minute TTL and single-use (`pop`)
 - Users are identified by their Garmin email (upserted on login)
 
@@ -556,7 +723,7 @@ npx @modelcontextprotocol/inspector http://localhost:8000/mcp
 
 ## Testing
 
-This project includes comprehensive tests for all 81 MCP tools. **All 96 tests are currently passing (100%)**.
+This project includes comprehensive tests for the MCP tools. **All 175 tests are currently passing (100%)**.
 
 ### Running Tests
 
@@ -576,5 +743,7 @@ uv run pytest tests/e2e/ -m e2e -v
 
 ### Test Structure
 
-- **Integration tests** (96 tests): Test all MCP tools using FastMCP integration with mocked Garmin API responses
+- **Unit tests** (52 tests): Test auth helpers, token path handling, and CLI auth behavior
+- **Integration tests** (122 tests): Test MCP tools using FastMCP integration with mocked Garmin API responses
+- **Debug smoke test** (1 test): Confirms the MCP app can be reached directly
 - **End-to-end tests** (4 tests): Test with real MCP server and Garmin API (requires valid credentials)

--- a/docker-compose.remote.yml
+++ b/docker-compose.remote.yml
@@ -1,0 +1,22 @@
+services:
+  garmin-mcp:
+    build:
+      context: .
+      dockerfile: Dockerfile.remote
+    container_name: garmin-mcp-remote
+    ports:
+      - "8000:8000"
+    environment:
+      - GARMIN_MCP_SERVER_URL=${GARMIN_MCP_SERVER_URL:-http://localhost:8000}
+      - GARMIN_MCP_PORT=8000
+      - GARMIN_MCP_HOST=0.0.0.0
+      - GARMIN_MCP_PATH=/mcp
+      - DB_PATH=/data/garmin_mcp.db
+      - SESSION_STORAGE_PATH=/data/garmin_sessions
+    volumes:
+      - garmin-data:/data
+    restart: unless-stopped
+
+volumes:
+  garmin-data:
+    driver: local

--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -1,0 +1,165 @@
+{
+  "dxt_version": "0.1",
+  "name": "garmin-mcp",
+  "display_name": "Garmin Connect",
+  "version": "0.1.1",
+  "description": "Connect Claude to Garmin Connect fitness data, smart baselines, anomalies, lagged correlations, and weekly health reviews.",
+  "long_description": "This MCP server bridges Claude to your personal Garmin Connect data via the garminconnect Python library.\n\n**Capabilities:**\n- Activities: list, detail, splits, laps, heart-rate zones, weather\n- Health: steps, sleep, stress, body battery, HRV, SpO2, respiration\n- Smart analytics: personal baselines, anomaly detection, lagged correlations, weekly review\n- Custom reports: grouped historical reports that can be saved locally and rerun\n- Training: readiness, load trends (CTL/ATL/TSB), VO2 max trend, power zones\n- Workouts: upload, schedule, download, bulk operations\n- Body: weight, body composition, weigh-ins\n- Gear, badges, challenges, nutrition logging\n- Auth tools: check saved tokens, start Garmin login, request OTP only when Garmin asks, and save tokens\n\n**First-time setup:** Choose a persistent token directory. You can leave credentials blank and ask Claude to run check_garmin_auth, then login_to_garmin. Accounts without OTP save tokens in one call. If Garmin emails you a verification code, Claude will get an mfa_required response and you can run login_to_garmin again with the OTP code.",
+  "author": {
+    "name": "Alexandre Domingues",
+    "url": "https://github.com/Taxuspt/garmin_mcp"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Taxuspt/garmin_mcp"
+  },
+  "homepage": "https://github.com/Taxuspt/garmin_mcp",
+  "license": "MIT",
+  "keywords": [
+    "garmin",
+    "fitness",
+    "health",
+    "running",
+    "cycling",
+    "training",
+    "garmin-connect"
+  ],
+  "server": {
+    "type": "python",
+    "entry_point": "src/garmin_mcp/__main__.py",
+    "mcp_config": {
+      "command": "uv",
+      "args": [
+        "--directory",
+        "${__dirname}",
+        "run",
+        "garmin-mcp"
+      ],
+      "env": {
+        "GARMINTOKENS": "${user_config.token_path}",
+        "GARMIN_EMAIL": "${user_config.garmin_email}",
+        "GARMIN_PASSWORD": "${user_config.garmin_password}",
+        "GARMIN_MFA_CODE": "${user_config.garmin_mfa_code}",
+        "GARMIN_REPORTS_PATH": "${user_config.reports_path}"
+      }
+    }
+  },
+  "user_config": {
+    "token_path": {
+      "type": "directory",
+      "title": "Token storage directory",
+      "description": "Directory where your Garmin OAuth tokens are stored. Use a persistent folder, then run the login_to_garmin tool or garmin-mcp-auth to save tokens.",
+      "required": false,
+      "default": "${HOME}/.garminconnect"
+    },
+    "garmin_email": {
+      "type": "string",
+      "title": "Garmin email (optional)",
+      "description": "Your Garmin Connect email address. Leave blank if you have already run garmin-mcp-auth.",
+      "required": false,
+      "sensitive": false
+    },
+    "garmin_password": {
+      "type": "string",
+      "title": "Garmin password (optional)",
+      "description": "Your Garmin Connect password. Leave blank if you have already run garmin-mcp-auth.",
+      "required": false,
+      "sensitive": true
+    },
+    "garmin_mfa_code": {
+      "type": "string",
+      "title": "One-time Garmin MFA code (optional)",
+      "description": "Paste the code Garmin emailed or sent to you when first logging in. Leave blank once tokens exist.",
+      "required": false,
+      "sensitive": true
+    },
+    "reports_path": {
+      "type": "file",
+      "title": "Saved reports file",
+      "description": "Local JSON file where custom health report definitions are saved.",
+      "required": false,
+      "default": "${HOME}/.garmin_mcp_reports.json"
+    }
+  },
+  "tools": [
+    {
+      "name": "check_garmin_auth",
+      "description": "Check whether saved Garmin tokens exist and still work"
+    },
+    {
+      "name": "login_to_garmin",
+      "description": "Log in to Garmin, request OTP only when Garmin asks for it, and save reusable tokens"
+    },
+    {
+      "name": "get_activities",
+      "description": "List recent activities with pagination"
+    },
+    {
+      "name": "get_activity",
+      "description": "Get detailed information about a single activity"
+    },
+    {
+      "name": "get_stats",
+      "description": "Get daily health statistics (steps, HR, stress, body battery, sleep)"
+    },
+    {
+      "name": "get_sleep_data",
+      "description": "Get detailed sleep data including stages and score"
+    },
+    {
+      "name": "get_training_readiness",
+      "description": "Get training readiness score and contributing factors"
+    },
+    {
+      "name": "get_hrv_data",
+      "description": "Get heart rate variability data"
+    },
+    {
+      "name": "upload_workout",
+      "description": "Upload a structured workout to Garmin Connect"
+    },
+    {
+      "name": "get_body_composition",
+      "description": "Get body composition measurements"
+    },
+    {
+      "name": "get_health_baselines",
+      "description": "Compare recent Garmin health metrics against personal rolling baselines"
+    },
+    {
+      "name": "get_wellness_anomalies",
+      "description": "Find unusual Garmin health days compared with recent personal baselines"
+    },
+    {
+      "name": "get_lagged_health_correlations",
+      "description": "Find delayed relationships between training, sleep, stress, HRV, readiness, and recovery"
+    },
+    {
+      "name": "get_weekly_health_review",
+      "description": "Summarize the last week against the prior week with anomalies and lagged relationships"
+    },
+    {
+      "name": "list_health_report_metrics",
+      "description": "List metric keys, groupings, and aggregations available for custom health reports"
+    },
+    {
+      "name": "run_custom_health_report",
+      "description": "Run an ad hoc or saved grouped historical health report"
+    },
+    {
+      "name": "save_custom_health_report",
+      "description": "Save a reusable custom health report definition locally"
+    },
+    {
+      "name": "list_saved_health_reports",
+      "description": "List locally saved custom health reports"
+    }
+  ],
+  "compatibility": {
+    "claude_desktop": ">=0.10.0",
+    "platforms": ["darwin", "win32", "linux"],
+    "runtimes": {
+      "python": ">=3.10"
+    }
+  }
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,13 +12,16 @@ dependencies = [
     "python-dotenv==1.0.1",
     "garminconnect==0.2.38",
     "requests==2.32.3",
-    "mcp==1.3.0",
+    "mcp>=1.26.0",
     "garth>=0.5.17,<0.6.0",
+    "aiosqlite>=0.20.0",
+    "httpx>=0.27.0",
 ]
 
 [project.scripts]
 garmin-mcp = "garmin_mcp:main"
 garmin-mcp-auth = "garmin_mcp.auth_cli:main"
+garmin-mcp-remote = "garmin_mcp.remote:main"
 
 [tool.uv]
 dev-dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "garmin-mcp"
-version = "0.1.0"
+version = "0.1.1"
 description = "MCP server to access Garmin data"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/build_dxt.sh
+++ b/scripts/build_dxt.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+OUTPUT="$REPO_ROOT/garmin-mcp.dxt"
+BUILD_DIR="$REPO_ROOT/.dxt-build/garmin-mcp"
+
+rm -rf "$BUILD_DIR"
+mkdir -p "$BUILD_DIR"
+
+cp "$REPO_ROOT/dxt/manifest.json" "$BUILD_DIR/manifest.json"
+cp "$REPO_ROOT/pyproject.toml" "$BUILD_DIR/pyproject.toml"
+cp "$REPO_ROOT/uv.lock" "$BUILD_DIR/uv.lock"
+cp "$REPO_ROOT/README.md" "$BUILD_DIR/README.md"
+cp -R "$REPO_ROOT/src" "$BUILD_DIR/src"
+find "$BUILD_DIR" -type d -name "__pycache__" -prune -exec rm -rf {} +
+find "$BUILD_DIR" -type f \( -name "*.pyc" -o -name "*.pyo" \) -delete
+
+cd "$REPO_ROOT"
+npx --yes @anthropic-ai/dxt validate "$BUILD_DIR/manifest.json"
+npx --yes @anthropic-ai/dxt pack "$BUILD_DIR" "$OUTPUT"

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -24,6 +24,7 @@ from garmin_mcp import workouts
 from garmin_mcp import workout_templates
 from garmin_mcp import data_management
 from garmin_mcp import womens_health
+from garmin_mcp.client_resolver import set_global_client
 
 
 def is_interactive_terminal() -> bool:
@@ -209,6 +210,9 @@ def main():
         return
 
     print("Garmin Connect client initialized successfully.", file=sys.stderr)
+
+    # Set global client for client_resolver (used by tool functions)
+    set_global_client(garmin_client)
 
     # Configure all modules with the Garmin client
     activity_management.configure(garmin_client)

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -24,7 +24,16 @@ from garmin_mcp import workouts
 from garmin_mcp import workout_templates
 from garmin_mcp import data_management
 from garmin_mcp import womens_health
+from garmin_mcp import analytics
+from garmin_mcp import auth_tools
 from garmin_mcp.client_resolver import set_global_client
+from garmin_mcp.token_utils import (
+    ensure_token_directory,
+    get_token_base64_path,
+    get_token_path,
+    resolve_path,
+    without_token_env,
+)
 
 
 def is_interactive_terminal() -> bool:
@@ -42,10 +51,15 @@ def get_mfa() -> str:
     Raises:
         RuntimeError: If running in non-interactive environment
     """
+    mfa_code = os.getenv("GARMIN_MFA_CODE") or os.getenv("GARMIN_OTP")
+    if mfa_code:
+        return mfa_code.strip()
+
     if not is_interactive_terminal():
         print(
             "\nERROR: MFA code required but no interactive terminal available.\n"
-            "Please run 'garmin-mcp-auth' in your terminal first.\n"
+            "Please run 'garmin-mcp-auth' in your terminal first, or set GARMIN_MFA_CODE "
+            "to the one-time code Garmin sent you.\n"
             "See: https://github.com/Taxuspt/garmin_mcp#mfa-setup\n",
             file=sys.stderr,
         )
@@ -79,8 +93,8 @@ elif password_file:
     with open(password_file, "r") as password_file:
         password = password_file.read().rstrip()
 
-tokenstore = os.getenv("GARMINTOKENS") or "~/.garminconnect"
-tokenstore_base64 = os.getenv("GARMINTOKENS_BASE64") or "~/.garminconnect_base64"
+tokenstore = resolve_path(get_token_path())
+tokenstore_base64 = resolve_path(get_token_base64_path(), "~/.garminconnect_base64")
 
 
 def init_api(email, password):
@@ -120,9 +134,8 @@ def init_api(email, password):
             print(
                 "ERROR: OAuth tokens not found and no interactive terminal available.\n"
                 "Please authenticate first:\n"
-                "  1. Run: garmin-mcp-auth\n"
-                "  2. Enter your credentials and MFA code\n"
-                "  3. Restart your MCP client\n"
+                "  - In Claude, run login_to_garmin and provide an OTP only if Garmin asks.\n"
+                "  - Or run garmin-mcp-auth in a terminal before starting this server.\n"
                 f"Tokens will be saved to: {tokenstore}\n",
                 file=sys.stderr,
             )
@@ -137,8 +150,10 @@ def init_api(email, password):
             garmin = Garmin(
                 email=email, password=password, is_cn=False, prompt_mfa=get_mfa
             )
-            garmin.login()
+            with without_token_env():
+                garmin.login()
             # Save Oauth1 and Oauth2 token files to directory for next login
+            ensure_token_directory(tokenstore)
             garmin.garth.dump(tokenstore)
             print(
                 f"Oauth tokens stored in '{tokenstore}' directory for future use. (first method)\n",
@@ -146,7 +161,7 @@ def init_api(email, password):
             )
             # Encode Oauth1 and Oauth2 tokens to base64 string and safe to file for next login (alternative way)
             token_base64 = garmin.garth.dumps()
-            dir_path = os.path.expanduser(tokenstore_base64)
+            dir_path = resolve_path(tokenstore_base64, "~/.garminconnect_base64")
             with open(dir_path, "w") as token_file:
                 token_file.write(token_base64)
             print(
@@ -157,6 +172,7 @@ def init_api(email, password):
             FileNotFoundError,
             GarthHTTPError,
             GarminConnectAuthenticationError,
+            RuntimeError,
             requests.exceptions.HTTPError,
         ) as err:
             error_msg = str(err)
@@ -186,13 +202,16 @@ def init_api(email, password):
                     )
                 else:
                     print(f"Error: {error_msg.split(':')[0]}", file=sys.stderr)
+            elif isinstance(err, RuntimeError):
+                print(str(err).split(":")[0], file=sys.stderr)
             elif isinstance(err, requests.exceptions.HTTPError):
                 print("Network error. Please check your connection.", file=sys.stderr)
             else:
                 print(f"Error: {error_msg.split(':')[0]}", file=sys.stderr)
 
             print(
-                f"\nTip: Run 'garmin-mcp-auth' to authenticate interactively.",
+                "\nTip: Run the MCP tool 'login_to_garmin', or run "
+                "'garmin-mcp-auth' in a terminal.",
                 file=sys.stderr,
             )
             return None
@@ -200,21 +219,9 @@ def init_api(email, password):
     return garmin
 
 
-def main():
-    """Initialize the MCP server and register all tools"""
-
-    # Initialize Garmin client
-    garmin_client = init_api(email, password)
-    if not garmin_client:
-        print("Failed to initialize Garmin Connect client. Exiting.", file=sys.stderr)
-        return
-
-    print("Garmin Connect client initialized successfully.", file=sys.stderr)
-
-    # Set global client for client_resolver (used by tool functions)
+def activate_garmin_client(garmin_client):
+    """Make a Garmin client available to all stdio MCP tools."""
     set_global_client(garmin_client)
-
-    # Configure all modules with the Garmin client
     activity_management.configure(garmin_client)
     health_wellness.configure(garmin_client)
     user_profile.configure(garmin_client)
@@ -226,11 +233,39 @@ def main():
     workouts.configure(garmin_client)
     data_management.configure(garmin_client)
     womens_health.configure(garmin_client)
+    analytics.configure(garmin_client)
+
+
+def main():
+    """Initialize the MCP server and register all tools"""
+
+    auth_tools.configure(activate_garmin_client)
+
+    # Initialize Garmin client when tokens already exist. If they do not, keep
+    # the MCP server alive so check_garmin_auth/login_to_garmin can fix it.
+    try:
+        garmin_client = init_api(email, password)
+    except Exception as err:
+        print(
+            f"Garmin Connect auto-login skipped: {str(err).split(':')[0]}",
+            file=sys.stderr,
+        )
+        garmin_client = None
+    if garmin_client:
+        activate_garmin_client(garmin_client)
+        print("Garmin Connect client initialized successfully.", file=sys.stderr)
+    else:
+        print(
+            "Garmin Connect client not initialized. Auth tools are available; run "
+            "check_garmin_auth or login_to_garmin.",
+            file=sys.stderr,
+        )
 
     # Create the MCP app
     app = FastMCP("Garmin Connect v1.0")
 
     # Register tools from all modules
+    app = auth_tools.register_tools(app)
     app = activity_management.register_tools(app)
     app = health_wellness.register_tools(app)
     app = user_profile.register_tools(app)
@@ -242,6 +277,7 @@ def main():
     app = workouts.register_tools(app)
     app = data_management.register_tools(app)
     app = womens_health.register_tools(app)
+    app = analytics.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/__main__.py
+++ b/src/garmin_mcp/__main__.py
@@ -1,0 +1,3 @@
+from garmin_mcp import main
+
+main()

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -5,6 +5,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -19,7 +22,7 @@ def register_tools(app):
     """Register all activity management tools with the MCP server app"""
 
     @app.tool()
-    async def get_activities_by_date(start_date: str, end_date: str, activity_type: str = "") -> str:
+    async def get_activities_by_date(ctx: Context, start_date: str, end_date: str, activity_type: str = "") -> str:
         """Get activities data between specified dates, optionally filtered by activity type
 
         Args:
@@ -28,7 +31,7 @@ def register_tools(app):
             activity_type: Optional activity type filter (e.g., cycling, running, swimming)
         """
         try:
-            activities = garmin_client.get_activities_by_date(start_date, end_date, activity_type)
+            activities = get_client(ctx).get_activities_by_date(start_date, end_date, activity_type)
             if not activities:
                 return f"No activities found between {start_date} and {end_date}" + \
                        (f" for activity type '{activity_type}'" if activity_type else "")
@@ -62,14 +65,14 @@ def register_tools(app):
             return f"Error retrieving activities by date: {str(e)}"
 
     @app.tool()
-    async def get_activities_fordate(date: str) -> str:
+    async def get_activities_fordate(ctx: Context, date: str) -> str:
         """Get activities for a specific date
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            data = garmin_client.get_activities_fordate(date)
+            data = get_client(ctx).get_activities_fordate(date)
             if not data:
                 return f"No activities found for {date}"
 
@@ -110,14 +113,14 @@ def register_tools(app):
             return f"Error retrieving activities for date: {str(e)}"
 
     @app.tool()
-    async def get_activity(activity_id: int) -> str:
+    async def get_activity(ctx: Context, activity_id: int) -> str:
         """Get basic activity information
 
         Args:
             activity_id: ID of the activity to retrieve
         """
         try:
-            activity = garmin_client.get_activity(activity_id)
+            activity = get_client(ctx).get_activity(activity_id)
             if not activity:
                 return f"No activity found with ID {activity_id}"
 
@@ -198,14 +201,14 @@ def register_tools(app):
             return f"Error retrieving activity: {str(e)}"
 
     @app.tool()
-    async def get_activity_splits(activity_id: int) -> str:
+    async def get_activity_splits(ctx: Context, activity_id: int) -> str:
         """Get splits for an activity
 
         Args:
             activity_id: ID of the activity to retrieve splits for
         """
         try:
-            splits = garmin_client.get_activity_splits(activity_id)
+            splits = get_client(ctx).get_activity_splits(activity_id)
             if not splits:
                 return f"No splits found for activity with ID {activity_id}"
 
@@ -242,14 +245,14 @@ def register_tools(app):
             return f"Error retrieving activity splits: {str(e)}"
 
     @app.tool()
-    async def get_activity_typed_splits(activity_id: int) -> str:
+    async def get_activity_typed_splits(ctx: Context, activity_id: int) -> str:
         """Get typed splits for an activity
 
         Args:
             activity_id: ID of the activity to retrieve typed splits for
         """
         try:
-            typed_splits = garmin_client.get_activity_typed_splits(activity_id)
+            typed_splits = get_client(ctx).get_activity_typed_splits(activity_id)
             if not typed_splits:
                 return f"No typed splits found for activity with ID {activity_id}"
 
@@ -258,14 +261,14 @@ def register_tools(app):
             return f"Error retrieving activity typed splits: {str(e)}"
 
     @app.tool()
-    async def get_activity_split_summaries(activity_id: int) -> str:
+    async def get_activity_split_summaries(ctx: Context, activity_id: int) -> str:
         """Get split summaries for an activity
 
         Args:
             activity_id: ID of the activity to retrieve split summaries for
         """
         try:
-            split_summaries = garmin_client.get_activity_split_summaries(activity_id)
+            split_summaries = get_client(ctx).get_activity_split_summaries(activity_id)
             if not split_summaries:
                 return f"No split summaries found for activity with ID {activity_id}"
 
@@ -274,14 +277,14 @@ def register_tools(app):
             return f"Error retrieving activity split summaries: {str(e)}"
 
     @app.tool()
-    async def get_activity_weather(activity_id: int) -> str:
+    async def get_activity_weather(ctx: Context, activity_id: int) -> str:
         """Get weather data for an activity
 
         Args:
             activity_id: ID of the activity to retrieve weather data for
         """
         try:
-            weather = garmin_client.get_activity_weather(activity_id)
+            weather = get_client(ctx).get_activity_weather(activity_id)
             if not weather:
                 return f"No weather data found for activity with ID {activity_id}"
 
@@ -307,14 +310,14 @@ def register_tools(app):
             return f"Error retrieving activity weather data: {str(e)}"
 
     @app.tool()
-    async def get_activity_hr_in_timezones(activity_id: int) -> str:
+    async def get_activity_hr_in_timezones(ctx: Context, activity_id: int) -> str:
         """Get heart rate data in different time zones for an activity
 
         Args:
             activity_id: ID of the activity to retrieve heart rate time zone data for
         """
         try:
-            hr_zones = garmin_client.get_activity_hr_in_timezones(activity_id)
+            hr_zones = get_client(ctx).get_activity_hr_in_timezones(activity_id)
             if not hr_zones:
                 return f"No heart rate time zone data found for activity with ID {activity_id}"
 
@@ -323,14 +326,14 @@ def register_tools(app):
             return f"Error retrieving activity heart rate time zone data: {str(e)}"
 
     @app.tool()
-    async def get_activity_gear(activity_id: int) -> str:
+    async def get_activity_gear(ctx: Context, activity_id: int) -> str:
         """Get gear data used for an activity
 
         Args:
             activity_id: ID of the activity to retrieve gear data for
         """
         try:
-            gear = garmin_client.get_activity_gear(activity_id)
+            gear = get_client(ctx).get_activity_gear(activity_id)
             if not gear:
                 return f"No gear data found for activity with ID {activity_id}"
 
@@ -339,14 +342,14 @@ def register_tools(app):
             return f"Error retrieving activity gear data: {str(e)}"
 
     @app.tool()
-    async def get_activity_exercise_sets(activity_id: int) -> str:
+    async def get_activity_exercise_sets(ctx: Context, activity_id: int) -> str:
         """Get exercise sets for strength training activities
 
         Args:
             activity_id: ID of the activity to retrieve exercise sets for
         """
         try:
-            exercise_sets = garmin_client.get_activity_exercise_sets(activity_id)
+            exercise_sets = get_client(ctx).get_activity_exercise_sets(activity_id)
             if not exercise_sets:
                 return f"No exercise sets found for activity with ID {activity_id}"
 
@@ -355,13 +358,13 @@ def register_tools(app):
             return f"Error retrieving activity exercise sets: {str(e)}"
 
     @app.tool()
-    async def count_activities() -> str:
+    async def count_activities(ctx: Context) -> str:
         """Get total count of activities in the user's Garmin account
 
         Returns the total number of activities recorded.
         """
         try:
-            count = garmin_client.count_activities()
+            count = get_client(ctx).count_activities()
             if count is None:
                 return "Unable to retrieve activity count"
 
@@ -373,7 +376,7 @@ def register_tools(app):
             return f"Error counting activities: {str(e)}"
 
     @app.tool()
-    async def get_activities(start: int = 0, limit: int = 20) -> str:
+    async def get_activities(ctx: Context, start: int = 0, limit: int = 20) -> str:
         """Get activities with pagination support
 
         Retrieves a paginated list of activities. Use this for browsing through
@@ -387,7 +390,7 @@ def register_tools(app):
             # Cap limit at 100 for safety and performance
             limit = min(max(1, limit), 100)
 
-            activities = garmin_client.get_activities(start, limit)
+            activities = get_client(ctx).get_activities(start, limit)
             if not activities:
                 return f"No activities found at index {start}"
 
@@ -425,14 +428,14 @@ def register_tools(app):
             return f"Error retrieving activities: {str(e)}"
 
     @app.tool()
-    async def get_activity_types() -> str:
+    async def get_activity_types(ctx: Context) -> str:
         """Get all available activity types
 
         Returns a list of all activity types supported by Garmin Connect,
         useful for filtering activities by type.
         """
         try:
-            activity_types = garmin_client.get_activity_types()
+            activity_types = get_client(ctx).get_activity_types()
             if not activity_types:
                 return "No activity types found"
 

--- a/src/garmin_mcp/analytics.py
+++ b/src/garmin_mcp/analytics.py
@@ -1,0 +1,867 @@
+"""
+Historical analytics tools for Garmin Connect data.
+
+These tools turn daily Garmin records into compact intelligence: baselines,
+anomalies, lagged correlations, and weekly review notes. They intentionally
+bound date windows so MCP calls stay predictable and do not return raw history.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import math
+import os
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from mcp.server.fastmcp import Context
+
+from garmin_mcp.client_resolver import get_client
+
+
+garmin_client = None
+
+MAX_DAYS = 180
+DEFAULT_DAYS = 90
+DEFAULT_BASELINE_WINDOW = 28
+DEFAULT_REPORT_METRICS = "steps,sleep_score,stress_avg,overnight_hrv,training_readiness,recovery_pressure"
+REPORT_AGGREGATIONS = {"avg", "sum", "min", "max", "latest"}
+REPORT_GROUPS = {"date", "week", "month"}
+
+
+def configure(client):
+    """Configure the module with the Garmin client instance."""
+    global garmin_client
+    garmin_client = client
+
+
+def register_tools(app):
+    """Register historical analytics tools with the MCP server app."""
+
+    @app.tool()
+    async def get_health_baselines(
+        ctx: Context,
+        end_date: str | None = None,
+        days: int = DEFAULT_DAYS,
+        baseline_window: int = DEFAULT_BASELINE_WINDOW,
+    ) -> str:
+        """Compare current health metrics against personal rolling baselines.
+
+        Args:
+            end_date: Last date to include in YYYY-MM-DD format. Defaults to today.
+            days: Number of days to fetch, capped at 180.
+            baseline_window: Rolling baseline window in days, capped by fetched history.
+        """
+        try:
+            rows = _daily_rows(get_client(ctx), end_date=end_date, days=days)
+            if not rows:
+                return "No health data found for the requested window"
+            return json.dumps(
+                _baseline_payload(rows, baseline_window=baseline_window),
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error calculating health baselines: {str(e)}"
+
+    @app.tool()
+    async def get_wellness_anomalies(
+        ctx: Context,
+        end_date: str | None = None,
+        days: int = DEFAULT_DAYS,
+        baseline_window: int = DEFAULT_BASELINE_WINDOW,
+        z_threshold: float = 1.5,
+    ) -> str:
+        """Find unusual days compared with the user's own recent baseline.
+
+        Args:
+            end_date: Last date to include in YYYY-MM-DD format. Defaults to today.
+            days: Number of days to fetch, capped at 180.
+            baseline_window: Days before each row used as its comparison baseline.
+            z_threshold: Minimum absolute z-score to report.
+        """
+        try:
+            rows = _daily_rows(get_client(ctx), end_date=end_date, days=days)
+            anomalies = _anomalies(
+                rows,
+                baseline_window=baseline_window,
+                z_threshold=z_threshold,
+            )
+            return json.dumps(
+                {
+                    "window": _window(rows),
+                    "baseline_window_days": min(max(7, baseline_window), MAX_DAYS),
+                    "z_threshold": z_threshold,
+                    "count": len(anomalies),
+                    "anomalies": anomalies,
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error detecting wellness anomalies: {str(e)}"
+
+    @app.tool()
+    async def get_lagged_health_correlations(
+        ctx: Context,
+        end_date: str | None = None,
+        days: int = DEFAULT_DAYS,
+        max_lag_days: int = 7,
+    ) -> str:
+        """Find delayed relationships between health and training metrics.
+
+        A lag of 1 means the left metric on one day is compared with the right
+        metric on the following day. This is useful for effects such as hard
+        training today versus HRV, resting heart rate, or readiness tomorrow.
+
+        Args:
+            end_date: Last date to include in YYYY-MM-DD format. Defaults to today.
+            days: Number of days to fetch, capped at 180.
+            max_lag_days: Largest lag to test, capped at 14 days.
+        """
+        try:
+            rows = _daily_rows(get_client(ctx), end_date=end_date, days=days)
+            correlations = _lagged_correlations(rows, max_lag_days=max_lag_days)
+            return json.dumps(
+                {
+                    "window": _window(rows),
+                    "max_lag_days": min(max(1, max_lag_days), 14),
+                    "minimum_pairs": 8,
+                    "strongest": correlations[:12],
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error calculating lagged correlations: {str(e)}"
+
+    @app.tool()
+    async def get_weekly_health_review(ctx: Context, end_date: str | None = None) -> str:
+        """Create a compact weekly review from Garmin history.
+
+        The review compares the last 7 days against the prior 7 days, includes
+        unusual days, and highlights the strongest delayed metric relationships.
+
+        Args:
+            end_date: Last date of the week in YYYY-MM-DD format. Defaults to today.
+        """
+        try:
+            rows = _daily_rows(get_client(ctx), end_date=end_date, days=35)
+            if len(rows) < 7:
+                return "Not enough health data found for a weekly review"
+            review = _weekly_review(rows)
+            return json.dumps(review, indent=2)
+        except Exception as e:
+            return f"Error building weekly health review: {str(e)}"
+
+    @app.tool()
+    async def list_health_report_metrics(ctx: Context) -> str:
+        """List metrics and options supported by custom health reports."""
+        try:
+            return json.dumps(
+                {
+                    "metrics": {
+                        name: {
+                            "label": metadata["label"],
+                            "unit": metadata["unit"],
+                            "direction": metadata["direction"],
+                        }
+                        for name, metadata in ANALYTIC_METRICS.items()
+                    },
+                    "groups": sorted(REPORT_GROUPS),
+                    "aggregations": sorted(REPORT_AGGREGATIONS),
+                    "saved_report_store": str(_report_store_path()),
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error listing report metrics: {str(e)}"
+
+    @app.tool()
+    async def run_custom_health_report(
+        ctx: Context,
+        end_date: str | None = None,
+        days: int = DEFAULT_DAYS,
+        metrics: str = DEFAULT_REPORT_METRICS,
+        group_by: str = "week",
+        aggregation: str = "avg",
+        saved_report_name: str | None = None,
+        include_daily_rows: bool = False,
+    ) -> str:
+        """Run a custom historical health report.
+
+        Args:
+            end_date: Last date to include in YYYY-MM-DD format. Defaults to today.
+            days: Number of days to fetch, capped at 180.
+            metrics: Comma-separated metric keys. Use list_health_report_metrics.
+            group_by: One of date, week, or month.
+            aggregation: One of avg, sum, min, max, or latest.
+            saved_report_name: Optional saved report name to run instead of arguments.
+            include_daily_rows: Include compact daily rows used for the report.
+        """
+        try:
+            definition = _report_definition(
+                saved_report_name=saved_report_name,
+                metrics=metrics,
+                group_by=group_by,
+                aggregation=aggregation,
+                days=days,
+                end_date=end_date,
+            )
+            rows = _daily_rows(
+                get_client(ctx),
+                end_date=definition.get("end_date"),
+                days=int(definition["days"]),
+            )
+            report = _custom_report(rows, definition, include_daily_rows=include_daily_rows)
+            return json.dumps(report, indent=2)
+        except Exception as e:
+            return f"Error running custom health report: {str(e)}"
+
+    @app.tool()
+    async def save_custom_health_report(
+        ctx: Context,
+        name: str,
+        metrics: str = DEFAULT_REPORT_METRICS,
+        group_by: str = "week",
+        aggregation: str = "avg",
+        days: int = DEFAULT_DAYS,
+        end_date: str | None = None,
+        description: str | None = None,
+    ) -> str:
+        """Save a reusable custom health report definition locally.
+
+        Args:
+            name: Unique report name.
+            metrics: Comma-separated metric keys. Use list_health_report_metrics.
+            group_by: One of date, week, or month.
+            aggregation: One of avg, sum, min, max, or latest.
+            days: Number of days to fetch when the report is run.
+            end_date: Optional fixed report end date in YYYY-MM-DD format.
+            description: Optional human note for the report.
+        """
+        try:
+            definition = _report_definition(
+                saved_report_name=None,
+                metrics=metrics,
+                group_by=group_by,
+                aggregation=aggregation,
+                days=days,
+                end_date=end_date,
+            )
+            definition["name"] = _clean_report_name(name)
+            definition["description"] = description or ""
+            reports = _load_saved_reports()
+            reports[definition["name"]] = definition
+            _write_saved_reports(reports)
+            return json.dumps({"saved": True, "report": definition}, indent=2)
+        except Exception as e:
+            return f"Error saving custom health report: {str(e)}"
+
+    @app.tool()
+    async def list_saved_health_reports(ctx: Context) -> str:
+        """List locally saved custom health report definitions."""
+        try:
+            reports = _load_saved_reports()
+            return json.dumps(
+                {
+                    "store": str(_report_store_path()),
+                    "count": len(reports),
+                    "reports": sorted(reports.values(), key=lambda item: item["name"]),
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error listing saved health reports: {str(e)}"
+
+    return app
+
+
+def _daily_rows(client: Any, end_date: str | None, days: int) -> list[dict[str, Any]]:
+    safe_days = min(max(1, days), MAX_DAYS)
+    end = _parse_date(end_date) if end_date else dt.date.today()
+    start = end - dt.timedelta(days=safe_days - 1)
+    activities_by_date = _activity_totals(client, start, end)
+    rows: list[dict[str, Any]] = []
+
+    for offset in range(safe_days):
+        current = start + dt.timedelta(days=offset)
+        date_text = current.isoformat()
+        stats = _safe_call(lambda: client.get_stats(date_text), default={})
+        sleep = _safe_call(lambda: client.get_sleep_data(date_text), default={})
+        readiness = _safe_call(lambda: client.get_training_readiness(date_text), default=[])
+        activity = activities_by_date.get(date_text, {})
+        rows.append(_normalize_day(date_text, stats, sleep, readiness, activity))
+
+    return [row for row in rows if _has_signal(row)]
+
+
+def _activity_totals(client: Any, start: dt.date, end: dt.date) -> dict[str, dict[str, float]]:
+    activities = _safe_call(
+        lambda: client.get_activities_by_date(start.isoformat(), end.isoformat(), ""),
+        default=[],
+    )
+    output: dict[str, dict[str, float]] = {}
+    if not isinstance(activities, list):
+        return output
+    for activity in activities:
+        if not isinstance(activity, dict):
+            continue
+        raw_start = activity.get("startTimeLocal")
+        if not isinstance(raw_start, str) or len(raw_start) < 10:
+            continue
+        key = raw_start[:10]
+        bucket = output.setdefault(
+            key,
+            {
+                "activity_count": 0.0,
+                "activity_distance_meters": 0.0,
+                "activity_duration_seconds": 0.0,
+                "activity_calories": 0.0,
+            },
+        )
+        bucket["activity_count"] += 1
+        bucket["activity_distance_meters"] += _number(activity.get("distance")) or 0
+        bucket["activity_duration_seconds"] += _number(activity.get("duration")) or 0
+        bucket["activity_calories"] += _number(activity.get("calories")) or 0
+    return output
+
+
+def _normalize_day(
+    date_text: str,
+    stats: Any,
+    sleep: Any,
+    readiness: Any,
+    activity: dict[str, float],
+) -> dict[str, Any]:
+    stats = stats if isinstance(stats, dict) else {}
+    sleep = sleep if isinstance(sleep, dict) else {}
+    daily_sleep = sleep.get("dailySleepDTO") if isinstance(sleep.get("dailySleepDTO"), dict) else {}
+    readiness_entry = readiness[0] if isinstance(readiness, list) and readiness else {}
+    sleep_score = _sleep_score(sleep, daily_sleep)
+    readiness_score = _number(readiness_entry.get("score")) if isinstance(readiness_entry, dict) else None
+
+    row = {
+        "date": date_text,
+        "steps": _number(stats.get("totalSteps")),
+        "active_calories": _number(stats.get("activeKilocalories")),
+        "distance_meters": _number(stats.get("totalDistanceMeters")),
+        "resting_hr": _number(stats.get("restingHeartRate")),
+        "stress_avg": _number(stats.get("averageStressLevel")),
+        "stress_max": _number(stats.get("maxStressLevel")),
+        "body_battery_high": _number(stats.get("bodyBatteryHighestValue")),
+        "body_battery_low": _number(stats.get("bodyBatteryLowestValue")),
+        "body_battery_charged": _number(stats.get("bodyBatteryChargedValue")),
+        "body_battery_drained": _number(stats.get("bodyBatteryDrainedValue")),
+        "sleep_score": sleep_score,
+        "sleep_hours": _hours(daily_sleep.get("sleepTimeSeconds")),
+        "deep_sleep_hours": _hours(daily_sleep.get("deepSleepSeconds")),
+        "rem_sleep_hours": _hours(daily_sleep.get("remSleepSeconds")),
+        "sleep_stress": _number(daily_sleep.get("avgSleepStress")),
+        "overnight_hrv": _number(sleep.get("avgOvernightHrv")),
+        "training_readiness": readiness_score,
+        "activity_count": activity.get("activity_count"),
+        "activity_distance_meters": activity.get("activity_distance_meters"),
+        "activity_duration_hours": _hours(activity.get("activity_duration_seconds")),
+        "activity_calories": activity.get("activity_calories"),
+    }
+    row["recovery_pressure"] = _recovery_pressure(row)
+    return row
+
+
+def _baseline_payload(rows: list[dict[str, Any]], baseline_window: int) -> dict[str, Any]:
+    window = min(max(7, baseline_window), len(rows))
+    baseline_rows = rows[-window:]
+    prior_rows = rows[-(window * 2) : -window] if len(rows) >= window * 2 else []
+    latest = rows[-1]
+    metrics: dict[str, dict[str, Any]] = {}
+
+    for field, metadata in ANALYTIC_METRICS.items():
+        baseline_values = _values(baseline_rows, field)
+        latest_value = _number(latest.get(field))
+        prior_avg = _average(_values(prior_rows, field))
+        baseline_avg = _average(baseline_values)
+        baseline_std = _stddev(baseline_values)
+        metrics[field] = {
+            "label": metadata["label"],
+            "unit": metadata["unit"],
+            "latest": _round(latest_value),
+            "baseline_avg": _round(baseline_avg),
+            "prior_avg": _round(prior_avg),
+            "delta_from_baseline": _round(latest_value - baseline_avg)
+            if latest_value is not None and baseline_avg is not None
+            else None,
+            "z_score": _round((latest_value - baseline_avg) / baseline_std, 2)
+            if latest_value is not None and baseline_std
+            else None,
+            "direction": metadata["direction"],
+            "sample_days": len(baseline_values),
+        }
+
+    return {
+        "window": _window(rows),
+        "baseline_window_days": window,
+        "latest_date": latest["date"],
+        "metrics": metrics,
+    }
+
+
+def _anomalies(
+    rows: list[dict[str, Any]], baseline_window: int, z_threshold: float
+) -> list[dict[str, Any]]:
+    window = min(max(7, baseline_window), MAX_DAYS)
+    anomalies: list[dict[str, Any]] = []
+    for index, row in enumerate(rows):
+        history = rows[max(0, index - window) : index]
+        if len(history) < 7:
+            continue
+        for field, metadata in ANALYTIC_METRICS.items():
+            value = _number(row.get(field))
+            values = _values(history, field)
+            avg = _average(values)
+            std = _stddev(values)
+            if value is None or avg is None or not std:
+                continue
+            z_score = (value - avg) / std
+            if abs(z_score) < z_threshold:
+                continue
+            anomalies.append(
+                {
+                    "date": row["date"],
+                    "metric": field,
+                    "label": metadata["label"],
+                    "value": _round(value),
+                    "baseline_avg": _round(avg),
+                    "z_score": _round(z_score, 2),
+                    "severity": _severity(abs(z_score)),
+                    "interpretation": _interpret_anomaly(field, z_score),
+                }
+            )
+    return sorted(anomalies, key=lambda item: abs(float(item["z_score"])), reverse=True)[:25]
+
+
+def _lagged_correlations(rows: list[dict[str, Any]], max_lag_days: int) -> list[dict[str, Any]]:
+    safe_lag = min(max(1, max_lag_days), 14)
+    output: list[dict[str, Any]] = []
+    fields = list(ANALYTIC_METRICS)
+    for left in fields:
+        for right in fields:
+            if left == right:
+                continue
+            for lag in range(1, safe_lag + 1):
+                pairs: list[tuple[float, float]] = []
+                for index, row in enumerate(rows[:-lag]):
+                    left_value = _number(row.get(left))
+                    right_value = _number(rows[index + lag].get(right))
+                    if left_value is not None and right_value is not None:
+                        pairs.append((left_value, right_value))
+                correlation = _pearson(pairs)
+                if correlation is None:
+                    continue
+                output.append(
+                    {
+                        "left_metric": left,
+                        "left_label": ANALYTIC_METRICS[left]["label"],
+                        "right_metric": right,
+                        "right_label": ANALYTIC_METRICS[right]["label"],
+                        "lag_days": lag,
+                        "correlation": correlation,
+                        "pairs": len(pairs),
+                        "plain_english": (
+                            f"{ANALYTIC_METRICS[left]['label']} tends to move "
+                            f"{'with' if correlation > 0 else 'opposite to'} "
+                            f"{ANALYTIC_METRICS[right]['label']} {lag} day(s) later."
+                        ),
+                    }
+                )
+    return sorted(output, key=lambda item: abs(float(item["correlation"])), reverse=True)
+
+
+def _weekly_review(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    current = rows[-7:]
+    previous = rows[-14:-7] if len(rows) >= 14 else []
+    baseline = _baseline_payload(rows, baseline_window=28)
+    anomalies = _anomalies(rows[-35:], baseline_window=21, z_threshold=1.75)[:8]
+    correlations = _lagged_correlations(rows[-35:], max_lag_days=5)[:6]
+    comparisons: dict[str, dict[str, Any]] = {}
+    notes: list[str] = []
+
+    for field, metadata in ANALYTIC_METRICS.items():
+        current_avg = _average(_values(current, field))
+        previous_avg = _average(_values(previous, field))
+        delta = current_avg - previous_avg if current_avg is not None and previous_avg is not None else None
+        comparisons[field] = {
+            "label": metadata["label"],
+            "unit": metadata["unit"],
+            "current_7d_avg": _round(current_avg),
+            "previous_7d_avg": _round(previous_avg),
+            "delta": _round(delta),
+        }
+        if delta is not None and abs(delta) > _material_delta(field):
+            notes.append(_comparison_note(field, delta))
+
+    return {
+        "window": {"start": current[0]["date"], "end": current[-1]["date"], "days": len(current)},
+        "summary_notes": notes[:8],
+        "comparisons": comparisons,
+        "latest_baselines": baseline["metrics"],
+        "notable_anomalies": anomalies,
+        "lagged_relationships": correlations,
+    }
+
+
+def _report_definition(
+    saved_report_name: str | None,
+    metrics: str,
+    group_by: str,
+    aggregation: str,
+    days: int,
+    end_date: str | None,
+) -> dict[str, Any]:
+    if saved_report_name:
+        reports = _load_saved_reports()
+        name = _clean_report_name(saved_report_name)
+        if name not in reports:
+            raise ValueError(f"Saved report not found: {name}")
+        return reports[name]
+    return {
+        "name": "",
+        "description": "",
+        "metrics": _parse_metrics(metrics),
+        "group_by": _parse_group(group_by),
+        "aggregation": _parse_aggregation(aggregation),
+        "days": min(max(1, days), MAX_DAYS),
+        "end_date": end_date,
+    }
+
+
+def _custom_report(
+    rows: list[dict[str, Any]], definition: dict[str, Any], include_daily_rows: bool
+) -> dict[str, Any]:
+    metrics = _parse_metrics(",".join(definition["metrics"]))
+    group_by = _parse_group(str(definition["group_by"]))
+    aggregation = _parse_aggregation(str(definition["aggregation"]))
+    groups: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        groups.setdefault(_report_group_key(row["date"], group_by), []).append(row)
+
+    report_rows: list[dict[str, Any]] = []
+    for group, group_rows in sorted(groups.items()):
+        output: dict[str, Any] = {"group": group, "days": len(group_rows)}
+        for metric in metrics:
+            output[metric] = _aggregate(_values(group_rows, metric), aggregation)
+        report_rows.append(output)
+
+    result: dict[str, Any] = {
+        "definition": {
+            "name": definition.get("name") or None,
+            "description": definition.get("description") or "",
+            "metrics": metrics,
+            "group_by": group_by,
+            "aggregation": aggregation,
+            "days": int(definition["days"]),
+            "end_date": definition.get("end_date"),
+        },
+        "window": _window(rows),
+        "columns": ["group", "days", *metrics],
+        "rows": report_rows,
+        "chart_hint": {
+            "x": "group",
+            "series": [
+                {
+                    "metric": metric,
+                    "label": ANALYTIC_METRICS[metric]["label"],
+                    "unit": ANALYTIC_METRICS[metric]["unit"],
+                }
+                for metric in metrics
+            ],
+        },
+    }
+    if include_daily_rows:
+        result["daily_rows"] = [
+            {"date": row["date"], **{metric: row.get(metric) for metric in metrics}} for row in rows
+        ]
+    return result
+
+
+def _report_group_key(date_text: str, group_by: str) -> str:
+    current = _parse_date(date_text)
+    if group_by == "month":
+        return current.strftime("%Y-%m")
+    if group_by == "week":
+        year, week, _ = current.isocalendar()
+        return f"{year}-W{week:02d}"
+    return date_text
+
+
+def _aggregate(values: list[float], aggregation: str) -> float | None:
+    if not values:
+        return None
+    if aggregation == "sum":
+        return _round(sum(values))
+    if aggregation == "min":
+        return _round(min(values))
+    if aggregation == "max":
+        return _round(max(values))
+    if aggregation == "latest":
+        return _round(values[-1])
+    return _round(sum(values) / len(values))
+
+
+def _parse_metrics(metrics: str) -> list[str]:
+    parsed = [metric.strip() for metric in metrics.split(",") if metric.strip()]
+    if not parsed:
+        raise ValueError("At least one metric is required")
+    invalid = [metric for metric in parsed if metric not in ANALYTIC_METRICS]
+    if invalid:
+        raise ValueError(f"Unsupported metrics: {', '.join(invalid)}")
+    return list(dict.fromkeys(parsed))
+
+
+def _parse_group(group_by: str) -> str:
+    value = group_by.strip().lower()
+    if value not in REPORT_GROUPS:
+        raise ValueError(f"group_by must be one of: {', '.join(sorted(REPORT_GROUPS))}")
+    return value
+
+
+def _parse_aggregation(aggregation: str) -> str:
+    value = aggregation.strip().lower()
+    if value not in REPORT_AGGREGATIONS:
+        raise ValueError(
+            f"aggregation must be one of: {', '.join(sorted(REPORT_AGGREGATIONS))}"
+        )
+    return value
+
+
+def _clean_report_name(name: str) -> str:
+    cleaned = " ".join(name.split())
+    if not cleaned:
+        raise ValueError("Report name is required")
+    if len(cleaned) > 120:
+        raise ValueError("Report name must be 120 characters or less")
+    return cleaned
+
+
+def _report_store_path() -> Path:
+    configured = os.getenv("GARMIN_REPORTS_PATH")
+    if configured:
+        return Path(os.path.expanduser(configured))
+    return Path.home() / ".garmin_mcp_reports.json"
+
+
+def _load_saved_reports() -> dict[str, dict[str, Any]]:
+    path = _report_store_path()
+    if not path.exists():
+        return {}
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"Saved report store is invalid: {path}")
+    reports: dict[str, dict[str, Any]] = {}
+    for name, definition in data.items():
+        if not isinstance(name, str) or not isinstance(definition, dict):
+            continue
+        reports[name] = _validate_saved_definition(name, definition)
+    return reports
+
+
+def _write_saved_reports(reports: dict[str, dict[str, Any]]) -> None:
+    path = _report_store_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(reports, indent=2, sort_keys=True))
+
+
+def _validate_saved_definition(name: str, definition: dict[str, Any]) -> dict[str, Any]:
+    raw_metrics = definition.get("metrics") or []
+    metric_text = raw_metrics if isinstance(raw_metrics, str) else ",".join(raw_metrics)
+    validated = {
+        "name": _clean_report_name(str(definition.get("name") or name)),
+        "description": str(definition.get("description") or ""),
+        "metrics": _parse_metrics(metric_text),
+        "group_by": _parse_group(str(definition.get("group_by") or "week")),
+        "aggregation": _parse_aggregation(str(definition.get("aggregation") or "avg")),
+        "days": min(max(1, int(definition.get("days") or DEFAULT_DAYS)), MAX_DAYS),
+        "end_date": definition.get("end_date"),
+    }
+    return validated
+
+
+def _safe_call(fn: Callable[[], Any], default: Any) -> Any:
+    try:
+        result = fn()
+        return default if result is None else result
+    except Exception:
+        return default
+
+
+def _sleep_score(sleep: dict[str, Any], daily_sleep: dict[str, Any]) -> float | None:
+    direct = _number(daily_sleep.get("sleepScoreTotal")) or _number(daily_sleep.get("sleepScore"))
+    if direct is not None:
+        return direct
+    scores = daily_sleep.get("sleepScores")
+    if isinstance(scores, dict):
+        overall = scores.get("overall")
+        if isinstance(overall, dict):
+            return _number(overall.get("value"))
+    return _number(sleep.get("sleepScore"))
+
+
+def _recovery_pressure(row: dict[str, Any]) -> float | None:
+    drivers = [
+        _number(row.get("stress_avg")),
+        ((_number(row.get("resting_hr")) or 45) - 45) * 1.5
+        if row.get("resting_hr") is not None
+        else None,
+        (100 - (_number(row.get("body_battery_high")) or 100)) * 0.35
+        if row.get("body_battery_high") is not None
+        else None,
+        (_number(row.get("activity_duration_hours")) or 0) * 4
+        if row.get("activity_duration_hours") is not None
+        else None,
+        (45 - (_number(row.get("overnight_hrv")) or 45)) * 0.7
+        if row.get("overnight_hrv") is not None
+        else None,
+    ]
+    values = [float(value) for value in drivers if value is not None]
+    if not values:
+        return None
+    return _round(max(0, min(100, sum(values) / len(values))))
+
+
+def _pearson(pairs: list[tuple[float, float]]) -> float | None:
+    if len(pairs) < 8:
+        return None
+    xs = [x for x, _ in pairs]
+    ys = [y for _, y in pairs]
+    x_avg = sum(xs) / len(xs)
+    y_avg = sum(ys) / len(ys)
+    numerator = sum((x - x_avg) * (y - y_avg) for x, y in pairs)
+    x_den = math.sqrt(sum((x - x_avg) ** 2 for x in xs))
+    y_den = math.sqrt(sum((y - y_avg) ** 2 for y in ys))
+    if x_den == 0 or y_den == 0:
+        return None
+    return _round(numerator / (x_den * y_den), 3)
+
+
+def _parse_date(value: str) -> dt.date:
+    return dt.date.fromisoformat(value)
+
+
+def _window(rows: list[dict[str, Any]]) -> dict[str, Any]:
+    if not rows:
+        return {"start": None, "end": None, "days": 0}
+    return {"start": rows[0]["date"], "end": rows[-1]["date"], "days": len(rows)}
+
+
+def _has_signal(row: dict[str, Any]) -> bool:
+    return any(_number(row.get(field)) is not None for field in ANALYTIC_METRICS)
+
+
+def _values(rows: list[dict[str, Any]], field: str) -> list[float]:
+    return [value for value in (_number(row.get(field)) for row in rows) if value is not None]
+
+
+def _average(values: list[float]) -> float | None:
+    return sum(values) / len(values) if values else None
+
+
+def _stddev(values: list[float]) -> float | None:
+    if len(values) < 3:
+        return None
+    avg = sum(values) / len(values)
+    variance = sum((value - avg) ** 2 for value in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def _number(value: Any) -> float | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int | float):
+        return float(value)
+    return None
+
+
+def _hours(seconds: Any) -> float | None:
+    value = _number(seconds)
+    return _round(value / 3600) if value is not None else None
+
+
+def _round(value: float | None, digits: int = 2) -> float | None:
+    return round(value, digits) if value is not None and math.isfinite(value) else None
+
+
+def _severity(abs_z: float) -> str:
+    if abs_z >= 3:
+        return "high"
+    if abs_z >= 2:
+        return "medium"
+    return "low"
+
+
+def _interpret_anomaly(field: str, z_score: float) -> str:
+    metadata = ANALYTIC_METRICS[field]
+    if metadata["direction"] == "higher_is_better":
+        return "better than normal" if z_score > 0 else "worse than normal"
+    if metadata["direction"] == "lower_is_better":
+        return "worse than normal" if z_score > 0 else "better than normal"
+    return "higher than normal" if z_score > 0 else "lower than normal"
+
+
+def _material_delta(field: str) -> float:
+    return {
+        "steps": 1000,
+        "active_calories": 120,
+        "resting_hr": 2,
+        "stress_avg": 5,
+        "body_battery_high": 8,
+        "sleep_score": 6,
+        "sleep_hours": 0.4,
+        "overnight_hrv": 4,
+        "training_readiness": 6,
+        "activity_duration_hours": 0.3,
+        "recovery_pressure": 5,
+    }.get(field, 1)
+
+
+def _comparison_note(field: str, delta: float) -> str:
+    label = ANALYTIC_METRICS[field]["label"]
+    direction = "up" if delta > 0 else "down"
+    return f"{label} is {direction} by {_round(abs(delta))} versus the prior week."
+
+
+ANALYTIC_METRICS = {
+    "steps": {"label": "Steps", "unit": "steps", "direction": "higher_is_better"},
+    "active_calories": {
+        "label": "Active calories",
+        "unit": "kcal",
+        "direction": "neutral",
+    },
+    "resting_hr": {
+        "label": "Resting heart rate",
+        "unit": "bpm",
+        "direction": "lower_is_better",
+    },
+    "stress_avg": {"label": "Average stress", "unit": "", "direction": "lower_is_better"},
+    "body_battery_high": {
+        "label": "Body Battery high",
+        "unit": "",
+        "direction": "higher_is_better",
+    },
+    "sleep_score": {"label": "Sleep score", "unit": "", "direction": "higher_is_better"},
+    "sleep_hours": {"label": "Sleep duration", "unit": "h", "direction": "higher_is_better"},
+    "overnight_hrv": {"label": "Overnight HRV", "unit": "ms", "direction": "higher_is_better"},
+    "training_readiness": {
+        "label": "Training readiness",
+        "unit": "",
+        "direction": "higher_is_better",
+    },
+    "activity_duration_hours": {
+        "label": "Activity duration",
+        "unit": "h",
+        "direction": "neutral",
+    },
+    "recovery_pressure": {
+        "label": "Recovery pressure",
+        "unit": "",
+        "direction": "lower_is_better",
+    },
+}

--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -19,11 +19,16 @@ from garmin_mcp.token_utils import (
     token_exists,
     validate_tokens,
     get_token_info,
+    without_token_env,
 )
 
 
 def get_mfa() -> str:
     """Get MFA code from user input."""
+    mfa_code = os.getenv("GARMIN_MFA_CODE") or os.getenv("GARMIN_OTP")
+    if mfa_code:
+        return mfa_code.strip()
+
     print("\nGarmin Connect MFA required. Please check your email/phone for the code.")
     return input("Enter MFA code: ")
 
@@ -103,11 +108,11 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
             sys.stderr = old_stderr
 
         if is_valid:
-            print("✓ Existing tokens are valid. Authentication not needed.")
+            print("OK: Existing tokens are valid. Authentication not needed.")
             print(f"  Use --force-reauth to generate new tokens.")
             return True
         else:
-            print(f"✗ Existing tokens are invalid: {error_msg}")
+            print(f"ERROR: Existing tokens are invalid: {error_msg}")
             print("  Proceeding with re-authentication...\n")
 
     # Get credentials
@@ -123,29 +128,30 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
 
     try:
         garmin = Garmin(email=email, password=password, is_cn=False, prompt_mfa=get_mfa)
-        garmin.login()
+        with without_token_env():
+            garmin.login()
 
         # Save tokens to directory
         garmin.garth.dump(token_path)
-        print(f"\n✓ OAuth tokens saved to: {os.path.expanduser(token_path)}")
+        print(f"\nOK: OAuth tokens saved to: {os.path.expanduser(token_path)}")
 
         # Save tokens as base64
         token_base64 = garmin.garth.dumps()
         expanded_base64_path = os.path.expanduser(token_base64_path)
         with open(expanded_base64_path, "w") as token_file:
             token_file.write(token_base64)
-        print(f"✓ OAuth tokens (base64) saved to: {expanded_base64_path}")
+        print(f"OK: OAuth tokens (base64) saved to: {expanded_base64_path}")
 
         # Verify tokens work
         print("\nVerifying tokens...")
         try:
             # Try to get user's full name as a simple verification
             full_name = garmin.get_full_name()
-            print(f"✓ Authentication successful!")
+            print("OK: Authentication successful!")
             print(f"  Logged in as: {full_name}")
         except Exception:
             # Fallback: just confirm tokens were saved
-            print(f"✓ Authentication successful!")
+            print("OK: Authentication successful!")
             print(f"  OAuth tokens saved and ready to use.")
 
         print("\n" + "=" * 60)
@@ -161,7 +167,7 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
 
     except GarminConnectAuthenticationError as e:
         error_msg = str(e)
-        print(f"\n✗ Authentication failed", file=sys.stderr)
+        print("\nERROR: Authentication failed", file=sys.stderr)
 
         # Provide helpful hints based on error type
         if "MFA" in error_msg or "code" in error_msg.lower():
@@ -177,7 +183,7 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
 
     except GarthHTTPError as e:
         error_msg = str(e)
-        print(f"\n✗ Authentication error", file=sys.stderr)
+        print("\nERROR: Authentication error", file=sys.stderr)
 
         if "429" in error_msg:
             print("  Too many requests. Please wait a few minutes and try again.", file=sys.stderr)
@@ -191,7 +197,7 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
         return False
 
     except requests.exceptions.HTTPError as e:
-        print(f"\n✗ Network error", file=sys.stderr)
+        print("\nERROR: Network error", file=sys.stderr)
 
         if e.response is not None:
             if e.response.status_code == 429:
@@ -207,7 +213,7 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
 
     except Exception as e:
         error_msg = str(e)
-        print(f"\n✗ Unexpected error", file=sys.stderr)
+        print("\nERROR: Unexpected error", file=sys.stderr)
 
         # Only show detailed error in debug scenarios
         if "timeout" in error_msg.lower():
@@ -234,17 +240,17 @@ def verify_tokens(token_path: str) -> bool:
     info = get_token_info(token_path)
 
     if not info["exists"]:
-        print(f"✗ Tokens not found at: {info['expanded_path']}")
+        print(f"ERROR: Tokens not found at: {info['expanded_path']}")
         print("\nRun 'garmin-mcp-auth' without --verify to authenticate.")
         return False
 
     if info["valid"]:
-        print(f"✓ Tokens are valid!")
+        print("OK: Tokens are valid!")
         print(f"  Location: {info['expanded_path']}")
         print("\nYou can use the Garmin MCP server without re-authenticating.")
         return True
     else:
-        print(f"✗ Tokens are invalid: {info['error']}")
+        print(f"ERROR: Tokens are invalid: {info['error']}")
         print("\nRun 'garmin-mcp-auth --force-reauth' to re-authenticate.")
         return False
 

--- a/src/garmin_mcp/auth_tools.py
+++ b/src/garmin_mcp/auth_tools.py
@@ -1,0 +1,279 @@
+"""
+Interactive Garmin authentication tools for MCP clients.
+
+The server can start before Garmin tokens exist. These tools let the user check
+auth state, trigger Garmin login, enter an OTP only when Garmin asks for one,
+and save reusable tokens without restarting the MCP process.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import requests
+from garth.exc import GarthHTTPError
+from garminconnect import Garmin, GarminConnectAuthenticationError
+
+from garmin_mcp.token_utils import (
+    ensure_token_directory,
+    get_token_base64_path,
+    get_token_info,
+    get_token_path,
+    resolve_path,
+    without_token_env,
+)
+
+
+_activate_client: Callable[[Garmin], None] | None = None
+
+
+class MfaRequired(RuntimeError):
+    """Raised when Garmin asks for MFA and no code was supplied."""
+
+
+def configure(activate_client: Callable[[Garmin], None]) -> None:
+    """Set callback used to activate a successfully authenticated Garmin client."""
+    global _activate_client
+    _activate_client = activate_client
+
+
+def register_tools(app):
+    """Register authentication tools."""
+
+    @app.tool()
+    async def check_garmin_auth(token_path: str | None = None) -> str:
+        """Check whether Garmin tokens exist and still work.
+
+        Args:
+            token_path: Optional token directory. Defaults to GARMINTOKENS or ~/.garminconnect.
+        """
+        try:
+            path = token_path or get_token_path()
+            info = get_token_info(path)
+            return json.dumps(
+                {
+                    "authenticated": bool(info["exists"] and info["valid"]),
+                    "token_path": info["path"],
+                    "expanded_path": info["expanded_path"],
+                    "tokens_exist": info["exists"],
+                    "tokens_valid": info["valid"],
+                    "error": info["error"] or None,
+                    "next_step": _auth_next_step(bool(info["exists"]), bool(info["valid"])),
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return json.dumps(
+                {
+                    "authenticated": False,
+                    "error": str(e),
+                    "next_step": "Run login_to_garmin with email and password.",
+                },
+                indent=2,
+            )
+
+    @app.tool()
+    async def login_to_garmin(
+        email: str | None = None,
+        password: str | None = None,
+        otp_code: str | None = None,
+        token_path: str | None = None,
+        token_base64_path: str | None = None,
+        force_reauth: bool = False,
+    ) -> str:
+        """Log in to Garmin Connect and save reusable OAuth tokens.
+
+        Call once with email/password. If Garmin returns mfa_required, call it
+        again with the same email/password and otp_code from Garmin email/SMS.
+        Accounts without OTP authenticate and save tokens in one call.
+
+        Args:
+            email: Garmin Connect email. Defaults to GARMIN_EMAIL.
+            password: Garmin Connect password. Defaults to GARMIN_PASSWORD.
+            otp_code: One-time Garmin verification code, only needed when requested.
+            token_path: Token directory. Defaults to GARMINTOKENS or ~/.garminconnect.
+            token_base64_path: Optional base64 token file path.
+            force_reauth: Ignore existing valid tokens and login again.
+        """
+        path = resolve_path(token_path or get_token_path())
+        base64_path = resolve_path(
+            token_base64_path or get_token_base64_path(),
+            "~/.garminconnect_base64",
+        )
+        if not force_reauth:
+            info = get_token_info(path)
+            if info["exists"] and info["valid"]:
+                return json.dumps(
+                    {
+                        "status": "authenticated",
+                        "message": "Existing Garmin tokens are valid.",
+                        "token_path": info["expanded_path"],
+                    },
+                    indent=2,
+                )
+
+        login_email = (email or os.getenv("GARMIN_EMAIL") or "").strip()
+        if not login_email:
+            login_email = _prompt_local_input(
+                "Garmin Connect email",
+                "Enter your Garmin Connect email.",
+            )
+        login_password = password or os.getenv("GARMIN_PASSWORD") or ""
+        if not login_password:
+            login_password = _prompt_local_input(
+                "Garmin Connect password",
+                "Enter your Garmin Connect password. It will be used only for this login and will not be stored.",
+                hidden=True,
+            )
+        if not login_email or not login_password:
+            return json.dumps(
+                {
+                    "status": "missing_credentials",
+                    "message": "Email and password are required to start Garmin login.",
+                    "token_path": path,
+                },
+                indent=2,
+            )
+
+        try:
+            garmin = Garmin(
+                email=login_email,
+                password=login_password,
+                is_cn=False,
+                prompt_mfa=_mfa_prompt(otp_code),
+            )
+            with without_token_env():
+                garmin.login()
+            ensure_token_directory(path)
+            garmin.garth.dump(path)
+            expanded_base64_path = resolve_path(base64_path, "~/.garminconnect_base64")
+            Path(expanded_base64_path).parent.mkdir(parents=True, exist_ok=True)
+            with open(expanded_base64_path, "w") as token_file:
+                token_file.write(garmin.garth.dumps())
+            if _activate_client is not None:
+                _activate_client(garmin)
+            return json.dumps(
+                {
+                    "status": "authenticated",
+                    "message": "Garmin login succeeded and tokens were saved.",
+                    "email": login_email,
+                    "token_path": path,
+                    "token_base64_path": expanded_base64_path,
+                },
+                indent=2,
+            )
+        except MfaRequired:
+            return json.dumps(
+                {
+                    "status": "mfa_required",
+                    "message": "Garmin requested a one-time code. Check your email or phone, then call login_to_garmin again with otp_code.",
+                    "email": login_email,
+                    "token_path": path,
+                },
+                indent=2,
+            )
+        except (GarminConnectAuthenticationError, GarthHTTPError, requests.exceptions.HTTPError) as e:
+            return json.dumps(
+                {
+                    "status": "failed",
+                    "message": _clean_login_error(e),
+                    "email": login_email,
+                    "token_path": path,
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return json.dumps(
+                {
+                    "status": "failed",
+                    "message": str(e).split(":")[0],
+                    "email": login_email,
+                    "token_path": path,
+                },
+                indent=2,
+            )
+
+    return app
+
+
+def _mfa_prompt(otp_code: str | None) -> Callable[[], str]:
+    def prompt() -> str:
+        code = (otp_code or os.getenv("GARMIN_MFA_CODE") or os.getenv("GARMIN_OTP") or "").strip()
+        if not code:
+            code = _prompt_local_input(
+                "Garmin verification code",
+                "Enter the one-time code Garmin sent to your email or phone.",
+            )
+        if not code:
+            raise MfaRequired("Garmin MFA required")
+        return code
+
+    return prompt
+
+
+def _prompt_local_input(title: str, message: str, hidden: bool = False) -> str:
+    """Prompt for a local value on macOS without sending it through chat."""
+    if sys.platform != "darwin" or os.getenv("GARMIN_DISABLE_LOCAL_PROMPTS") == "1":
+        return ""
+
+    script = [
+        'on run argv',
+        'set dialogMessage to item 1 of argv',
+        'set dialogTitle to item 2 of argv',
+    ]
+    if hidden:
+        script.append(
+            'set dialogResult to display dialog dialogMessage default answer "" with title dialogTitle with hidden answer buttons {"Cancel", "OK"} default button "OK"'
+        )
+    else:
+        script.append(
+            'set dialogResult to display dialog dialogMessage default answer "" with title dialogTitle buttons {"Cancel", "OK"} default button "OK"'
+        )
+    script.extend(
+        [
+            'return text returned of dialogResult',
+            'end run',
+        ]
+    )
+
+    try:
+        result = subprocess.run(
+            ["osascript", *sum([["-e", line] for line in script], []), "--", message, title],
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=300,
+        )
+    except Exception:
+        return ""
+
+    if result.returncode != 0:
+        return ""
+    return result.stdout.strip()
+
+
+def _auth_next_step(exists: bool, valid: bool) -> str:
+    if exists and valid:
+        return "You can use Garmin tools now."
+    if exists:
+        return "Tokens exist but are invalid. Run login_to_garmin with force_reauth=true."
+    return "Run login_to_garmin with email and password."
+
+
+def _clean_login_error(error: Exception) -> str:
+    message = str(error)
+    if "MFA" in message or "code" in message.lower():
+        return "OTP code may be incorrect or expired."
+    if "401" in message or "403" in message or "password" in message.lower():
+        return "Invalid Garmin email or password."
+    if "429" in message:
+        return "Garmin rate limited the login attempt. Wait and try again."
+    if "500" in message or "503" in message:
+        return "Garmin Connect service is currently failing. Try again later."
+    return message.split(":")[0]

--- a/src/garmin_mcp/challenges.py
+++ b/src/garmin_mcp/challenges.py
@@ -6,6 +6,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -225,14 +228,14 @@ def register_tools(app):
     """Register all challenges-related tools with the MCP server app"""
 
     @app.tool()
-    async def get_goals(goal_type: str = "active") -> str:
+    async def get_goals(ctx: Context, goal_type: str = "active") -> str:
         """Get Garmin Connect goals (active, future, or past)
 
         Args:
             goal_type: Type of goals to retrieve. Options: "active", "future", or "past"
         """
         try:
-            goals = garmin_client.get_goals(goal_type)
+            goals = get_client(ctx).get_goals(goal_type)
             if not goals:
                 return f"No {goal_type} goals found."
             return json.dumps(goals, indent=2)
@@ -240,10 +243,10 @@ def register_tools(app):
             return f"Error retrieving {goal_type} goals: {str(e)}"
 
     @app.tool()
-    async def get_personal_record() -> str:
+    async def get_personal_record(ctx: Context) -> str:
         """Get personal records for user"""
         try:
-            records = garmin_client.get_personal_record()
+            records = get_client(ctx).get_personal_record()
             if not records:
                 return "No personal records found."
 
@@ -285,10 +288,10 @@ def register_tools(app):
             return f"Error retrieving personal records: {str(e)}"
 
     @app.tool()
-    async def get_earned_badges() -> str:
+    async def get_earned_badges(ctx: Context) -> str:
         """Get earned badges for user"""
         try:
-            badges = garmin_client.get_earned_badges()
+            badges = get_client(ctx).get_earned_badges()
             if not badges:
                 return "No earned badges found."
 
@@ -351,7 +354,7 @@ def register_tools(app):
             return f"Error retrieving earned badges: {str(e)}"
 
     @app.tool()
-    async def get_adhoc_challenges(start: int = 0, limit: int = 20) -> str:
+    async def get_adhoc_challenges(ctx: Context, start: int = 0, limit: int = 20) -> str:
         """Get user-created social/group challenges (e.g., step competitions with friends)
 
         Returns challenges created by users to compete with connections. These are
@@ -362,7 +365,7 @@ def register_tools(app):
             limit: Maximum number of challenges to return (default 20, max 100)
         """
         try:
-            challenges = garmin_client.get_adhoc_challenges(start, min(limit, 100))
+            challenges = get_client(ctx).get_adhoc_challenges(start, min(limit, 100))
             if not challenges:
                 return "No adhoc challenges found."
 
@@ -400,7 +403,7 @@ def register_tools(app):
             return f"Error retrieving adhoc challenges: {str(e)}"
 
     @app.tool()
-    async def get_available_badge_challenges(start: int = 1, limit: int = 20) -> str:
+    async def get_available_badge_challenges(ctx: Context, start: int = 1, limit: int = 20) -> str:
         """Get official Garmin badge challenges available to join
 
         Returns monthly/seasonal challenges from Garmin that the user can join.
@@ -411,7 +414,7 @@ def register_tools(app):
             limit: Maximum number of challenges to return (default 20, max 100)
         """
         try:
-            challenges = garmin_client.get_available_badge_challenges(start, min(limit, 100))
+            challenges = get_client(ctx).get_available_badge_challenges(start, min(limit, 100))
             if not challenges:
                 return "No available badge challenges found."
 
@@ -433,7 +436,7 @@ def register_tools(app):
             return f"Error retrieving available badge challenges: {str(e)}"
 
     @app.tool()
-    async def get_badge_challenges(start: int = 1, limit: int = 20) -> str:
+    async def get_badge_challenges(ctx: Context, start: int = 1, limit: int = 20) -> str:
         """Get all badge challenges the user has joined (completed and in-progress)
 
         Returns the user's history of badge challenges including progress,
@@ -444,7 +447,7 @@ def register_tools(app):
             limit: Maximum number of challenges to return (default 20, max 100)
         """
         try:
-            challenges = garmin_client.get_badge_challenges(start, min(limit, 100))
+            challenges = get_client(ctx).get_badge_challenges(start, min(limit, 100))
             if not challenges:
                 return "No badge challenges found."
 
@@ -466,7 +469,7 @@ def register_tools(app):
             return f"Error retrieving badge challenges: {str(e)}"
 
     @app.tool()
-    async def get_non_completed_badge_challenges(
+    async def get_non_completed_badge_challenges(ctx: Context, 
         start: int = 1, limit: int = 20
     ) -> str:
         """Get badge challenges currently in progress (not yet completed)
@@ -479,7 +482,7 @@ def register_tools(app):
             limit: Maximum number of challenges to return (default 20, max 100)
         """
         try:
-            challenges = garmin_client.get_non_completed_badge_challenges(
+            challenges = get_client(ctx).get_non_completed_badge_challenges(
                 start, min(limit, 100)
             )
             if not challenges:
@@ -501,14 +504,14 @@ def register_tools(app):
             return f"Error retrieving in-progress badge challenges: {str(e)}"
 
     @app.tool()
-    async def get_race_predictions() -> str:
+    async def get_race_predictions(ctx: Context) -> str:
         """Get predicted race times based on current fitness level
 
         Returns Garmin's predictions for 5K, 10K, half marathon, and marathon
         finish times based on the user's recent training data and VO2 max.
         """
         try:
-            predictions = garmin_client.get_race_predictions()
+            predictions = get_client(ctx).get_race_predictions()
             if not predictions:
                 return "No race predictions found."
 
@@ -540,7 +543,7 @@ def register_tools(app):
             return f"Error retrieving race predictions: {str(e)}"
 
     @app.tool()
-    async def get_inprogress_virtual_challenges(start: int = 0, limit: int = 20) -> str:
+    async def get_inprogress_virtual_challenges(ctx: Context, start: int = 0, limit: int = 20) -> str:
         """Get in-progress virtual challenges/expeditions
 
         Returns virtual challenges (like walking expeditions on famous trails)
@@ -551,7 +554,7 @@ def register_tools(app):
             limit: Maximum number of challenges to return (default 20, max 100)
         """
         try:
-            challenges = garmin_client.get_inprogress_virtual_challenges(
+            challenges = get_client(ctx).get_inprogress_virtual_challenges(
                 start, min(limit, 100)
             )
             if not challenges:

--- a/src/garmin_mcp/client_resolver.py
+++ b/src/garmin_mcp/client_resolver.py
@@ -1,0 +1,66 @@
+"""
+Client resolver for Garmin MCP server.
+
+Resolves the Garmin client based on context:
+- stdio mode: returns the global client (single-user)
+- remote mode: extracts user_id from OAuth access token, resolves via SessionManager
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Optional
+
+from garminconnect import Garmin
+
+if TYPE_CHECKING:
+    from mcp.server.fastmcp import Context
+
+# Global client for stdio mode
+_global_client: Optional[Garmin] = None
+
+# Session manager for remote mode (set by remote.py)
+_session_manager = None
+
+
+def set_global_client(client: Garmin) -> None:
+    """Set the global Garmin client for stdio mode."""
+    global _global_client
+    _global_client = client
+
+
+def set_session_manager(manager) -> None:
+    """Set the session manager for remote mode."""
+    global _session_manager
+    _session_manager = manager
+
+
+def get_client(ctx: Optional[Context] = None) -> Garmin:
+    """Resolve the Garmin client based on context.
+
+    In stdio mode (no ctx or no auth token): returns the global client.
+    In remote mode: extracts user_id from the OAuth access token and
+    returns the per-user Garmin client from SessionManager.
+    """
+    # Try remote mode: extract user_id from OAuth token
+    if ctx is not None and _session_manager is not None:
+        try:
+            from mcp.server.auth.middleware.auth_context import get_access_token
+
+            access_token = get_access_token()
+            if access_token is not None:
+                user_id = _session_manager.get_user_id_for_token(access_token.token)
+                if user_id:
+                    client = _session_manager.get_client(user_id)
+                    if client is not None:
+                        return client
+                    raise RuntimeError(
+                        "Garmin session expired or not available. Please re-authenticate."
+                    )
+        except ImportError:
+            pass
+
+    # Fallback to global client (stdio mode)
+    if _global_client is not None:
+        return _global_client
+
+    raise RuntimeError("Garmin client not available. Please authenticate first.")

--- a/src/garmin_mcp/config.py
+++ b/src/garmin_mcp/config.py
@@ -1,0 +1,35 @@
+"""
+Configuration for Garmin MCP remote server via environment variables.
+"""
+
+import os
+
+
+class RemoteConfig:
+    """Configuration for the remote MCP server."""
+
+    def __init__(self):
+        self.host = os.getenv("GARMIN_MCP_HOST", "0.0.0.0")
+        self.port = int(os.getenv("GARMIN_MCP_PORT", "8000"))
+        self.path = os.getenv("GARMIN_MCP_PATH", "/mcp")
+        self.server_url = os.getenv("GARMIN_MCP_SERVER_URL", "")
+        self.scope = os.getenv("MCP_SCOPE", "garmin")
+        self.db_path = os.getenv("DB_PATH", "/data/garmin_mcp.db")
+        self.session_storage_path = os.getenv(
+            "SESSION_STORAGE_PATH", "/data/garmin_sessions"
+        )
+
+    def validate(self):
+        """Validate required configuration."""
+        if not self.server_url:
+            raise ValueError(
+                "GARMIN_MCP_SERVER_URL is required. "
+                "Set it to the public URL of your server (e.g., https://garmin-mcp.example.com)"
+            )
+
+
+def get_config() -> RemoteConfig:
+    """Get and validate the remote server configuration."""
+    config = RemoteConfig()
+    config.validate()
+    return config

--- a/src/garmin_mcp/data_management.py
+++ b/src/garmin_mcp/data_management.py
@@ -5,6 +5,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -17,9 +20,10 @@ def configure(client):
 
 def register_tools(app):
     """Register all data management tools with the MCP server app"""
-    
+
     @app.tool()
     async def add_body_composition(
+        ctx: Context,
         date: str,
         weight: float,
         percent_fat: Optional[float] = None,
@@ -52,7 +56,7 @@ def register_tools(app):
             bmi: Body Mass Index
         """
         try:
-            result = garmin_client.add_body_composition(
+            result = get_client(ctx).add_body_composition(
                 date,
                 weight=weight,
                 percent_fat=percent_fat,
@@ -73,6 +77,7 @@ def register_tools(app):
     
     @app.tool()
     async def set_blood_pressure(
+        ctx: Context,
         systolic: int,
         diastolic: int,
         pulse: int,
@@ -87,7 +92,7 @@ def register_tools(app):
             notes: Optional notes
         """
         try:
-            result = garmin_client.set_blood_pressure(
+            result = get_client(ctx).set_blood_pressure(
                 systolic, diastolic, pulse, notes=notes
             )
             return json.dumps(result, indent=2)
@@ -96,6 +101,7 @@ def register_tools(app):
     
     @app.tool()
     async def add_hydration_data(
+        ctx: Context,
         value_in_ml: int,
         cdate: str,
         timestamp: str
@@ -108,7 +114,7 @@ def register_tools(app):
             timestamp: Timestamp in YYYY-MM-DDThh:mm:ss.sss format
         """
         try:
-            result = garmin_client.add_hydration_data(
+            result = get_client(ctx).add_hydration_data(
                 value_in_ml=value_in_ml,
                 cdate=cdate,
                 timestamp=timestamp

--- a/src/garmin_mcp/devices.py
+++ b/src/garmin_mcp/devices.py
@@ -6,6 +6,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -20,10 +23,10 @@ def register_tools(app):
     """Register all device-related tools with the MCP server app"""
 
     @app.tool()
-    async def get_devices() -> str:
+    async def get_devices(ctx: Context) -> str:
         """Get all Garmin devices associated with the user account"""
         try:
-            devices = garmin_client.get_devices()
+            devices = get_client(ctx).get_devices()
             if not devices:
                 return "No devices found."
 
@@ -59,10 +62,10 @@ def register_tools(app):
             return f"Error retrieving devices: {str(e)}"
 
     @app.tool()
-    async def get_device_last_used() -> str:
+    async def get_device_last_used(ctx: Context) -> str:
         """Get information about the last used Garmin device"""
         try:
-            device = garmin_client.get_device_last_used()
+            device = get_client(ctx).get_device_last_used()
             if not device:
                 return "No last used device found."
 
@@ -92,7 +95,7 @@ def register_tools(app):
             return f"Error retrieving last used device: {str(e)}"
 
     @app.tool()
-    async def get_device_settings(device_id: Union[int, str]) -> str:
+    async def get_device_settings(ctx: Context, device_id: Union[int, str]) -> str:
         """Get settings for a specific Garmin device
 
         Returns device configuration including time/date format, units,
@@ -102,7 +105,7 @@ def register_tools(app):
             device_id: Device ID (can be obtained from get_devices or get_device_last_used)
         """
         try:
-            settings = garmin_client.get_device_settings(device_id)
+            settings = get_client(ctx).get_device_settings(device_id)
             if not settings:
                 return f"No settings found for device ID {device_id}."
 
@@ -160,14 +163,14 @@ def register_tools(app):
             return f"Error retrieving device settings: {str(e)}"
 
     @app.tool()
-    async def get_primary_training_device() -> str:
+    async def get_primary_training_device(ctx: Context) -> str:
         """Get information about the primary training device
 
         Returns details about the device designated as primary for training
         metrics, along with other wearable devices on the account.
         """
         try:
-            data = garmin_client.get_primary_training_device()
+            data = get_client(ctx).get_primary_training_device()
             if not data:
                 return "No primary training device found."
 
@@ -212,7 +215,7 @@ def register_tools(app):
             return f"Error retrieving primary training device: {str(e)}"
 
     @app.tool()
-    async def get_device_solar_data(device_id: str, date: str) -> str:
+    async def get_device_solar_data(ctx: Context, device_id: str, date: str) -> str:
         """Get solar data for a specific device
 
         Returns solar charging data for devices with solar panels (e.g., Instinct Solar,
@@ -223,7 +226,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            solar_data = garmin_client.get_device_solar_data(device_id, date)
+            solar_data = get_client(ctx).get_device_solar_data(device_id, date)
             if not solar_data:
                 return f"No solar data found for device ID {device_id} on {date}."
 
@@ -262,13 +265,13 @@ def register_tools(app):
         return f"{hours:02d}:{mins:02d}"
 
     @app.tool()
-    async def get_device_alarms() -> str:
+    async def get_device_alarms(ctx: Context) -> str:
         """Get alarms from all Garmin devices
 
         Returns all configured alarms with their schedules, sounds, and enabled status.
         """
         try:
-            alarms = garmin_client.get_device_alarms()
+            alarms = get_client(ctx).get_device_alarms()
             if not alarms:
                 return "No device alarms found."
 

--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -4,6 +4,8 @@ Health & Wellness Data functions for Garmin Connect MCP Server
 import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
 
 # The garmin_client will be set by the main file
 garmin_client = None
@@ -19,7 +21,7 @@ def register_tools(app):
     """Register all health and wellness tools with the MCP server app"""
 
     @app.tool()
-    async def get_stats(date: str) -> str:
+    async def get_stats(ctx: Context, date: str) -> str:
         """Get daily activity stats with curated essential metrics
 
         Returns a summary of daily health and activity data including steps,
@@ -29,7 +31,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            stats = garmin_client.get_stats(date)
+            stats = get_client(ctx).get_stats(date)
             if not stats:
                 return f"No stats found for {date}"
 
@@ -96,14 +98,14 @@ def register_tools(app):
             return f"Error retrieving stats: {str(e)}"
 
     @app.tool()
-    async def get_user_summary(date: str) -> str:
+    async def get_user_summary(ctx: Context, date: str) -> str:
         """Get user summary data (compatible with garminconnect-ha)
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            summary = garmin_client.get_user_summary(date)
+            summary = get_client(ctx).get_user_summary(date)
             if not summary:
                 return f"No user summary found for {date}"
 
@@ -112,7 +114,7 @@ def register_tools(app):
             return f"Error retrieving user summary: {str(e)}"
 
     @app.tool()
-    async def get_body_composition(start_date: str, end_date: str = None) -> str:
+    async def get_body_composition(ctx: Context, start_date: str, end_date: str = None) -> str:
         """Get body composition data for a single date or date range
 
         Args:
@@ -121,11 +123,11 @@ def register_tools(app):
         """
         try:
             if end_date:
-                composition = garmin_client.get_body_composition(start_date, end_date)
+                composition = get_client(ctx).get_body_composition(start_date, end_date)
                 if not composition:
                     return f"No body composition data found between {start_date} and {end_date}"
             else:
-                composition = garmin_client.get_body_composition(start_date)
+                composition = get_client(ctx).get_body_composition(start_date)
                 if not composition:
                     return f"No body composition data found for {start_date}"
 
@@ -134,14 +136,14 @@ def register_tools(app):
             return f"Error retrieving body composition data: {str(e)}"
 
     @app.tool()
-    async def get_stats_and_body(date: str) -> str:
+    async def get_stats_and_body(ctx: Context, date: str) -> str:
         """Get stats and body composition data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            data = garmin_client.get_stats_and_body(date)
+            data = get_client(ctx).get_stats_and_body(date)
             if not data:
                 return f"No stats and body composition data found for {date}"
 
@@ -150,7 +152,7 @@ def register_tools(app):
             return f"Error retrieving stats and body composition data: {str(e)}"
 
     @app.tool()
-    async def get_steps_data(date: str) -> str:
+    async def get_steps_data(ctx: Context, date: str) -> str:
         """Get detailed steps data with 15-minute intervals
 
         Note: This returns full interval data (~14KB). For a compact summary,
@@ -160,7 +162,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            steps_data = garmin_client.get_steps_data(date)
+            steps_data = get_client(ctx).get_steps_data(date)
             if not steps_data:
                 return f"No steps data found for {date}"
 
@@ -169,7 +171,7 @@ def register_tools(app):
             return f"Error retrieving steps data: {str(e)}"
 
     @app.tool()
-    async def get_daily_steps(start_date: str, end_date: str) -> str:
+    async def get_daily_steps(ctx: Context, start_date: str, end_date: str) -> str:
         """Get steps data for a date range
 
         Args:
@@ -177,7 +179,7 @@ def register_tools(app):
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            steps_data = garmin_client.get_daily_steps(start_date, end_date)
+            steps_data = get_client(ctx).get_daily_steps(start_date, end_date)
             if not steps_data:
                 return f"No daily steps data found between {start_date} and {end_date}"
 
@@ -186,7 +188,7 @@ def register_tools(app):
             return f"Error retrieving daily steps data: {str(e)}"
 
     @app.tool()
-    async def get_training_readiness(date: str) -> str:
+    async def get_training_readiness(ctx: Context, date: str) -> str:
         """Get training readiness data with curated metrics
 
         Returns training readiness score and contributing factors.
@@ -195,7 +197,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            readiness_list = garmin_client.get_training_readiness(date)
+            readiness_list = get_client(ctx).get_training_readiness(date)
             if not readiness_list:
                 return f"No training readiness data found for {date}"
 
@@ -244,7 +246,7 @@ def register_tools(app):
             return f"Error retrieving training readiness data: {str(e)}"
 
     @app.tool()
-    async def get_body_battery(start_date: str, end_date: str) -> str:
+    async def get_body_battery(ctx: Context, start_date: str, end_date: str) -> str:
         """Get body battery data with events
 
         Args:
@@ -252,7 +254,7 @@ def register_tools(app):
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            battery_data = garmin_client.get_body_battery(start_date, end_date)
+            battery_data = get_client(ctx).get_body_battery(start_date, end_date)
             if not battery_data:
                 return f"No body battery data found between {start_date} and {end_date}"
 
@@ -290,14 +292,14 @@ def register_tools(app):
             return f"Error retrieving body battery data: {str(e)}"
 
     @app.tool()
-    async def get_body_battery_events(date: str) -> str:
+    async def get_body_battery_events(ctx: Context, date: str) -> str:
         """Get body battery events data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            events = garmin_client.get_body_battery_events(date)
+            events = get_client(ctx).get_body_battery_events(date)
             if not events:
                 return f"No body battery events found for {date}"
 
@@ -306,7 +308,7 @@ def register_tools(app):
             return f"Error retrieving body battery events: {str(e)}"
 
     @app.tool()
-    async def get_blood_pressure(start_date: str, end_date: str) -> str:
+    async def get_blood_pressure(ctx: Context, start_date: str, end_date: str) -> str:
         """Get blood pressure data
 
         Args:
@@ -314,7 +316,7 @@ def register_tools(app):
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            bp_data = garmin_client.get_blood_pressure(start_date, end_date)
+            bp_data = get_client(ctx).get_blood_pressure(start_date, end_date)
             if not bp_data:
                 return f"No blood pressure data found between {start_date} and {end_date}"
 
@@ -323,14 +325,14 @@ def register_tools(app):
             return f"Error retrieving blood pressure data: {str(e)}"
 
     @app.tool()
-    async def get_floors(date: str) -> str:
+    async def get_floors(ctx: Context, date: str) -> str:
         """Get floors climbed data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            floors_data = garmin_client.get_floors(date)
+            floors_data = get_client(ctx).get_floors(date)
             if not floors_data:
                 return f"No floors data found for {date}"
 
@@ -339,14 +341,14 @@ def register_tools(app):
             return f"Error retrieving floors data: {str(e)}"
 
     @app.tool()
-    async def get_rhr_day(date: str) -> str:
+    async def get_rhr_day(ctx: Context, date: str) -> str:
         """Get resting heart rate data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            rhr_data = garmin_client.get_rhr_day(date)
+            rhr_data = get_client(ctx).get_rhr_day(date)
             if not rhr_data:
                 return f"No resting heart rate data found for {date}"
 
@@ -355,7 +357,7 @@ def register_tools(app):
             return f"Error retrieving resting heart rate data: {str(e)}"
 
     @app.tool()
-    async def get_heart_rates(date: str) -> str:
+    async def get_heart_rates(ctx: Context, date: str) -> str:
         """Get full heart rate time-series data
 
         Note: This returns detailed 2-minute interval data (~25KB).
@@ -365,7 +367,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            hr_data = garmin_client.get_heart_rates(date)
+            hr_data = get_client(ctx).get_heart_rates(date)
             if not hr_data:
                 return f"No heart rate data found for {date}"
 
@@ -374,7 +376,7 @@ def register_tools(app):
             return f"Error retrieving heart rate data: {str(e)}"
 
     @app.tool()
-    async def get_heart_rates_summary(date: str) -> str:
+    async def get_heart_rates_summary(ctx: Context, date: str) -> str:
         """Get heart rate summary with essential metrics (lightweight version)
 
         Returns a compact summary (~500 bytes) instead of full time-series data (~25KB).
@@ -384,7 +386,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            hr_data = garmin_client.get_heart_rates(date)
+            hr_data = get_client(ctx).get_heart_rates(date)
             if not hr_data:
                 return f"No heart rate data found for {date}"
 
@@ -412,14 +414,14 @@ def register_tools(app):
             return f"Error retrieving heart rate summary: {str(e)}"
 
     @app.tool()
-    async def get_hydration_data(date: str) -> str:
+    async def get_hydration_data(ctx: Context, date: str) -> str:
         """Get hydration data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            hydration_data = garmin_client.get_hydration_data(date)
+            hydration_data = get_client(ctx).get_hydration_data(date)
             if not hydration_data:
                 return f"No hydration data found for {date}"
 
@@ -428,7 +430,7 @@ def register_tools(app):
             return f"Error retrieving hydration data: {str(e)}"
 
     @app.tool()
-    async def get_sleep_data(date: str) -> str:
+    async def get_sleep_data(ctx: Context, date: str) -> str:
         """Get full sleep data with all details
 
         Note: This returns detailed sleep data (~50KB).
@@ -438,7 +440,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            sleep_data = garmin_client.get_sleep_data(date)
+            sleep_data = get_client(ctx).get_sleep_data(date)
             if not sleep_data:
                 return f"No sleep data found for {date}"
 
@@ -447,7 +449,7 @@ def register_tools(app):
             return f"Error retrieving sleep data: {str(e)}"
 
     @app.tool()
-    async def get_sleep_summary(date: str) -> str:
+    async def get_sleep_summary(ctx: Context, date: str) -> str:
         """Get sleep summary with only essential metrics (lightweight version)
 
         This endpoint returns a compact summary of sleep data (~350 bytes) instead of
@@ -458,7 +460,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            sleep_data = garmin_client.get_sleep_data(date)
+            sleep_data = get_client(ctx).get_sleep_data(date)
             if not sleep_data:
                 return f"No sleep summary found for {date}"
 
@@ -521,7 +523,7 @@ def register_tools(app):
             return f"Error retrieving sleep summary: {str(e)}"
 
     @app.tool()
-    async def get_stress_data(date: str) -> str:
+    async def get_stress_data(ctx: Context, date: str) -> str:
         """Get full stress time-series data
 
         Note: This returns detailed interval data (~35KB) including body battery.
@@ -531,7 +533,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            stress_data = garmin_client.get_stress_data(date)
+            stress_data = get_client(ctx).get_stress_data(date)
             if not stress_data:
                 return f"No stress data found for {date}"
 
@@ -540,7 +542,7 @@ def register_tools(app):
             return f"Error retrieving stress data: {str(e)}"
 
     @app.tool()
-    async def get_stress_summary(date: str) -> str:
+    async def get_stress_summary(ctx: Context, date: str) -> str:
         """Get stress summary with essential metrics (lightweight version)
 
         Returns a compact summary (~400 bytes) instead of full time-series data (~35KB).
@@ -550,7 +552,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            stress_data = garmin_client.get_stress_data(date)
+            stress_data = get_client(ctx).get_stress_data(date)
             if not stress_data:
                 return f"No stress data found for {date}"
 
@@ -585,7 +587,7 @@ def register_tools(app):
             return f"Error retrieving stress summary: {str(e)}"
 
     @app.tool()
-    async def get_respiration_data(date: str) -> str:
+    async def get_respiration_data(ctx: Context, date: str) -> str:
         """Get full respiration time-series data
 
         Note: This returns detailed interval data (~20KB).
@@ -595,7 +597,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            respiration_data = garmin_client.get_respiration_data(date)
+            respiration_data = get_client(ctx).get_respiration_data(date)
             if not respiration_data:
                 return f"No respiration data found for {date}"
 
@@ -604,7 +606,7 @@ def register_tools(app):
             return f"Error retrieving respiration data: {str(e)}"
 
     @app.tool()
-    async def get_respiration_summary(date: str) -> str:
+    async def get_respiration_summary(ctx: Context, date: str) -> str:
         """Get respiration summary with essential metrics (lightweight version)
 
         Returns a compact summary (~300 bytes) instead of full time-series data (~20KB).
@@ -613,7 +615,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            resp_data = garmin_client.get_respiration_data(date)
+            resp_data = get_client(ctx).get_respiration_data(date)
             if not resp_data:
                 return f"No respiration data found for {date}"
 
@@ -633,14 +635,14 @@ def register_tools(app):
             return f"Error retrieving respiration summary: {str(e)}"
 
     @app.tool()
-    async def get_spo2_data(date: str) -> str:
+    async def get_spo2_data(ctx: Context, date: str) -> str:
         """Get SpO2 (blood oxygen) data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            spo2_data = garmin_client.get_spo2_data(date)
+            spo2_data = get_client(ctx).get_spo2_data(date)
             if not spo2_data:
                 return f"No SpO2 data found for {date}"
 
@@ -668,14 +670,14 @@ def register_tools(app):
             return f"Error retrieving SpO2 data: {str(e)}"
 
     @app.tool()
-    async def get_all_day_stress(date: str) -> str:
+    async def get_all_day_stress(ctx: Context, date: str) -> str:
         """Get all-day stress data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            stress_data = garmin_client.get_all_day_stress(date)
+            stress_data = get_client(ctx).get_all_day_stress(date)
             if not stress_data:
                 return f"No all-day stress data found for {date}"
 
@@ -684,14 +686,14 @@ def register_tools(app):
             return f"Error retrieving all-day stress data: {str(e)}"
 
     @app.tool()
-    async def get_all_day_events(date: str) -> str:
+    async def get_all_day_events(ctx: Context, date: str) -> str:
         """Get daily wellness events data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            events = garmin_client.get_all_day_events(date)
+            events = get_client(ctx).get_all_day_events(date)
             if not events:
                 return f"No daily wellness events found for {date}"
 
@@ -700,7 +702,7 @@ def register_tools(app):
             return f"Error retrieving daily wellness events: {str(e)}"
 
     @app.tool()
-    async def get_weekly_steps(end_date: str, weeks: int = 4) -> str:
+    async def get_weekly_steps(ctx: Context, end_date: str, weeks: int = 4) -> str:
         """Get weekly step data aggregates
 
         Returns weekly step totals for the specified number of weeks ending at end_date.
@@ -711,7 +713,7 @@ def register_tools(app):
         """
         try:
             weeks = min(weeks, 52)  # Cap at 52 weeks
-            weekly_data = garmin_client.get_weekly_steps(end_date, weeks)
+            weekly_data = get_client(ctx).get_weekly_steps(end_date, weeks)
             if not weekly_data:
                 return f"No weekly steps data found for {weeks} weeks ending {end_date}"
 
@@ -747,7 +749,7 @@ def register_tools(app):
             return f"Error retrieving weekly steps data: {str(e)}"
 
     @app.tool()
-    async def get_weekly_stress(end_date: str, weeks: int = 4) -> str:
+    async def get_weekly_stress(ctx: Context, end_date: str, weeks: int = 4) -> str:
         """Get weekly stress data aggregates
 
         Returns weekly stress values for the specified number of weeks ending at end_date.
@@ -758,7 +760,7 @@ def register_tools(app):
         """
         try:
             weeks = min(weeks, 52)  # Cap at 52 weeks
-            weekly_data = garmin_client.get_weekly_stress(end_date, weeks)
+            weekly_data = get_client(ctx).get_weekly_stress(end_date, weeks)
             if not weekly_data:
                 return f"No weekly stress data found for {weeks} weeks ending {end_date}"
 
@@ -789,7 +791,7 @@ def register_tools(app):
             return f"Error retrieving weekly stress data: {str(e)}"
 
     @app.tool()
-    async def get_weekly_intensity_minutes(end_date: str, weeks: int = 4) -> str:
+    async def get_weekly_intensity_minutes(ctx: Context, end_date: str, weeks: int = 4) -> str:
         """Get weekly intensity minutes data aggregates
 
         Returns weekly intensity minutes (moderate and vigorous) for the specified
@@ -807,7 +809,7 @@ def register_tools(app):
             start_dt = end_dt - datetime.timedelta(days=(weeks * 7) - 1)
             start_date = start_dt.strftime("%Y-%m-%d")
 
-            weekly_data = garmin_client.get_weekly_intensity_minutes(start_date, end_date)
+            weekly_data = get_client(ctx).get_weekly_intensity_minutes(start_date, end_date)
             if not weekly_data:
                 return f"No weekly intensity minutes data found for {weeks} weeks ending {end_date}"
 
@@ -845,7 +847,7 @@ def register_tools(app):
             return f"Error retrieving weekly intensity minutes data: {str(e)}"
 
     @app.tool()
-    async def get_morning_training_readiness(date: str) -> str:
+    async def get_morning_training_readiness(ctx: Context, date: str) -> str:
         """Get morning training readiness score
 
         Returns the morning training readiness assessment, which evaluates
@@ -855,7 +857,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            readiness = garmin_client.get_morning_training_readiness(date)
+            readiness = get_client(ctx).get_morning_training_readiness(date)
             if not readiness:
                 return f"No morning training readiness data found for {date}"
 

--- a/src/garmin_mcp/oauth_provider.py
+++ b/src/garmin_mcp/oauth_provider.py
@@ -491,48 +491,90 @@ class GarminOAuthProvider(
 
     # ─── Login pages ─────────────────────────────────────────────────
 
+    # Garmin delta logo as inline SVG
+    _GARMIN_LOGO_SVG = (
+        '<svg viewBox="0 0 40 40" width="48" height="48" xmlns="http://www.w3.org/2000/svg">'
+        '<path d="M20 0 L40 20 L20 40 L0 20 Z" fill="#1a8fc4"/>'
+        '<path d="M20 6 L34 20 L20 34 L6 20 Z" fill="white"/>'
+        '<path d="M20 12 L28 20 L20 28 L12 20 Z" fill="#1a8fc4"/>'
+        "</svg>"
+    )
+
     _PAGE_STYLE = """
-        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-               display: flex; justify-content: center; align-items: center;
-               min-height: 100vh; margin: 0; background: #f5f5f5; }
-        .card { background: white; padding: 2rem; border-radius: 8px;
-                 box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
-        h1 { margin: 0 0 1.5rem; font-size: 1.5rem; text-align: center; }
-        label { display: block; margin-bottom: 0.25rem; font-weight: 500; }
-        input { width: 100%; padding: 0.5rem; margin-bottom: 1rem;
-                 border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
-        button { width: 100%; padding: 0.75rem; background: #007bff; color: white;
-                  border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
-        button:hover { background: #0056b3; }
-        .error { color:#dc3545; margin-bottom:1rem; padding:0.75rem;
-                  background:#f8d7da; border-radius:4px; }
-        .info { color:#0c5460; margin-bottom:1rem; padding:0.75rem;
-                 background:#d1ecf1; border-radius:4px; text-align:center; }
+        * { box-sizing: border-box; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+               display: flex; flex-direction: column; justify-content: center; align-items: center;
+               min-height: 100vh; margin: 0; background: #f7f8fa; color: #2c3e50; }
+        .card { background: white; padding: 2.5rem 2rem 2rem; border-radius: 12px;
+                box-shadow: 0 4px 24px rgba(0,0,0,0.08); width: 100%; max-width: 420px; }
+        .logo { text-align: center; margin-bottom: 0.5rem; }
+        h1 { margin: 0 0 0.25rem; font-size: 1.35rem; text-align: center; color: #1a1a2e; }
+        .subtitle { text-align: center; color: #6b7280; font-size: 0.9rem; margin-bottom: 1.5rem; }
+        label { display: block; margin-bottom: 0.3rem; font-weight: 600; font-size: 0.85rem;
+                color: #374151; }
+        input[type="email"], input[type="password"], input[type="text"] {
+            width: 100%; padding: 0.65rem 0.75rem; margin-bottom: 1rem;
+            border: 1.5px solid #d1d5db; border-radius: 6px; font-size: 0.95rem;
+            transition: border-color 0.2s; outline: none; }
+        input:focus { border-color: #1a8fc4; box-shadow: 0 0 0 3px rgba(26,143,196,0.12); }
+        button { width: 100%; padding: 0.75rem; background: #1a8fc4; color: white;
+                 border: none; border-radius: 6px; font-size: 1rem; font-weight: 600;
+                 cursor: pointer; transition: background 0.2s; }
+        button:hover { background: #157aab; }
+        button:active { background: #12688f; }
+        .error { color: #991b1b; margin-bottom: 1rem; padding: 0.75rem 1rem;
+                 background: #fef2f2; border: 1px solid #fecaca; border-radius: 6px;
+                 font-size: 0.9rem; }
+        .info { color: #1e40af; margin-bottom: 1rem; padding: 0.75rem 1rem;
+                background: #eff6ff; border: 1px solid #bfdbfe; border-radius: 6px;
+                text-align: center; font-size: 0.9rem; }
+        .privacy { margin-top: 1.25rem; padding-top: 1rem; border-top: 1px solid #e5e7eb;
+                   text-align: center; font-size: 0.8rem; color: #6b7280; line-height: 1.5; }
+        .privacy svg { vertical-align: middle; margin-right: 0.25rem; }
+        .step { display: inline-block; background: #e0f2fe; color: #0369a1; font-size: 0.75rem;
+                font-weight: 700; padding: 0.2rem 0.6rem; border-radius: 10px;
+                margin-bottom: 0.75rem; }
     """
+
+    _LOCK_ICON = (
+        '<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" '
+        'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">'
+        '<rect x="3" y="11" width="18" height="11" rx="2" ry="2"/>'
+        '<path d="M7 11V7a5 5 0 0 1 10 0v4"/></svg>'
+    )
 
     async def get_login_page(self, state: str, error: str = "") -> Response:
         """Render the Garmin Connect login form."""
         error_html = f'<div class="error">{error}</div>' if error else ""
 
         html = f"""<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Garmin MCP - Sign In</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
     <style>{self._PAGE_STYLE}</style>
 </head>
 <body>
     <div class="card">
-        <h1>Sign in with Garmin Connect</h1>
+        <div class="logo">{self._GARMIN_LOGO_SVG}</div>
+        <h1>Connect to Garmin</h1>
+        <p class="subtitle">Sign in with your Garmin Connect account to grant access to your fitness data.</p>
         {error_html}
         <form method="POST" action="/login/callback">
             <input type="hidden" name="state" value="{state}">
             <label for="email">Garmin Connect Email</label>
-            <input type="email" id="email" name="email" required autofocus>
+            <input type="email" id="email" name="email" required autofocus
+                   placeholder="you@example.com">
             <label for="password">Password</label>
-            <input type="password" id="password" name="password" required>
-            <button type="submit">Sign In</button>
+            <input type="password" id="password" name="password" required
+                   placeholder="Your Garmin password">
+            <button type="submit">Sign In with Garmin</button>
         </form>
+        <div class="privacy">
+            {self._LOCK_ICON} Your credentials are used only to authenticate with Garmin
+            and are <strong>never stored</strong> on this server. Only secure session tokens are kept.
+        </div>
     </div>
 </body>
 </html>"""
@@ -601,16 +643,22 @@ class GarminOAuthProvider(
         error_html = f'<div class="error">{error}</div>' if error else ""
 
         html = f"""<!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
     <title>Garmin MCP - Verification</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta charset="utf-8">
     <style>{self._PAGE_STYLE}</style>
 </head>
 <body>
     <div class="card">
-        <h1>Two-Factor Authentication</h1>
-        <div class="info">A verification code has been sent to your email or phone.</div>
+        <div class="logo">{self._GARMIN_LOGO_SVG}</div>
+        <h1>Verify Your Identity</h1>
+        <p class="subtitle">One more step to secure your account.</p>
+        <div class="info">
+            Garmin has sent a verification code to your email or phone.
+            Check your inbox and enter the code below.
+        </div>
         {error_html}
         <form method="POST" action="/login/mfa/callback">
             <input type="hidden" name="state" value="{state}">
@@ -618,9 +666,14 @@ class GarminOAuthProvider(
             <input type="text" id="mfa_code" name="mfa_code"
                    inputmode="numeric" pattern="[0-9]*" maxlength="7"
                    autocomplete="one-time-code" required autofocus
-                   placeholder="Enter 6-digit code">
-            <button type="submit">Verify</button>
+                   placeholder="Enter 6-digit code"
+                   style="text-align:center; font-size:1.5rem; letter-spacing:0.3rem; padding:0.75rem;">
+            <button type="submit">Verify &amp; Connect</button>
         </form>
+        <div class="privacy">
+            {self._LOCK_ICON} This code is sent directly by Garmin.
+            We <strong>never</strong> have access to it after verification.
+        </div>
     </div>
 </body>
 </html>"""

--- a/src/garmin_mcp/oauth_provider.py
+++ b/src/garmin_mcp/oauth_provider.py
@@ -1,0 +1,625 @@
+"""
+OAuth2 Authorization Server Provider for Garmin MCP remote server.
+
+Implements OAuthAuthorizationServerProvider from the MCP SDK with SQLite storage.
+Users authenticate directly with their Garmin Connect credentials (email + password),
+with support for 2FA via a second web page.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import secrets
+import sqlite3
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any, Optional
+
+from mcp.server.auth.provider import (
+    AuthorizationCode,
+    AuthorizationParams,
+    OAuthAuthorizationServerProvider,
+    OAuthToken,
+    RefreshToken,
+    AccessToken,
+    construct_redirect_uri,
+)
+from mcp.shared.auth import OAuthClientInformationFull
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, RedirectResponse, Response
+
+logger = logging.getLogger(__name__)
+
+# TTL for pending MFA state (seconds)
+_MFA_TTL = 300  # 5 minutes
+
+
+@dataclass
+class _PendingMfa:
+    """Temporary storage for garth client_state during 2FA flow."""
+
+    client_state: dict[str, Any]
+    garmin_email: str
+    created_at: float = field(default_factory=time.time)
+
+    def is_expired(self) -> bool:
+        return time.time() - self.created_at > _MFA_TTL
+
+
+class GarminOAuthProvider(
+    OAuthAuthorizationServerProvider[AuthorizationCode, RefreshToken, AccessToken]
+):
+    """OAuth2 provider backed by SQLite for the Garmin MCP server."""
+
+    def __init__(self, db_path: str, server_url: str, session_manager=None):
+        self.db_path = db_path
+        self.server_url = server_url.rstrip("/")
+        self.session_manager = session_manager
+        self._pending_mfa: dict[str, _PendingMfa] = {}
+        self._mfa_lock = threading.Lock()
+        self._init_db()
+
+    # ─── Database ────────────────────────────────────────────────────
+
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self.db_path)
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA journal_mode=WAL")
+        conn.execute("PRAGMA foreign_keys=ON")
+        return conn
+
+    def _init_db(self):
+        os.makedirs(os.path.dirname(self.db_path) or ".", exist_ok=True)
+        conn = self._get_conn()
+        try:
+            # Check if old schema exists (with username/password_hash columns)
+            cols = {
+                row[1]
+                for row in conn.execute("PRAGMA table_info(users)").fetchall()
+            }
+            if "username" in cols:
+                # Migrate: drop old table, recreate with new schema
+                conn.executescript(
+                    """
+                    DROP TABLE IF EXISTS users;
+                    """
+                )
+
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id TEXT PRIMARY KEY,
+                    garmin_email TEXT UNIQUE NOT NULL,
+                    created_at REAL NOT NULL DEFAULT (strftime('%s', 'now'))
+                );
+                CREATE TABLE IF NOT EXISTS oauth_clients (
+                    client_id TEXT PRIMARY KEY,
+                    client_info_json TEXT NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS auth_codes (
+                    code TEXT PRIMARY KEY,
+                    client_id TEXT NOT NULL,
+                    user_id TEXT,
+                    scopes TEXT NOT NULL,
+                    code_challenge TEXT NOT NULL,
+                    redirect_uri TEXT NOT NULL,
+                    redirect_uri_provided_explicitly INTEGER NOT NULL DEFAULT 1,
+                    expires_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS access_tokens (
+                    token TEXT PRIMARY KEY,
+                    client_id TEXT NOT NULL,
+                    user_id TEXT,
+                    scopes TEXT NOT NULL,
+                    expires_at REAL NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS refresh_tokens (
+                    token TEXT PRIMARY KEY,
+                    client_id TEXT NOT NULL,
+                    user_id TEXT,
+                    scopes TEXT NOT NULL,
+                    expires_at REAL
+                );
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ─── User helpers ─────────────────────────────────────────────────
+
+    def _get_or_create_user(self, garmin_email: str) -> str:
+        """Upsert a user by Garmin email. Returns user_id."""
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT id FROM users WHERE garmin_email = ?", (garmin_email,)
+            ).fetchone()
+            if row:
+                return row["id"]
+
+            user_id = secrets.token_hex(16)
+            conn.execute(
+                "INSERT INTO users (id, garmin_email) VALUES (?, ?)",
+                (user_id, garmin_email),
+            )
+            conn.commit()
+            return user_id
+        finally:
+            conn.close()
+
+    def _complete_auth_flow(self, state: str, user_id: str) -> Response:
+        """Shared helper: look up pending auth, create auth code, redirect."""
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT * FROM auth_codes WHERE code = ? AND user_id IS NULL",
+                (state,),
+            ).fetchone()
+
+            if not row or row["expires_at"] < time.time():
+                return HTMLResponse(
+                    "<h1>Authorization expired</h1><p>Please try again.</p>",
+                    status_code=400,
+                )
+
+            # Generate actual authorization code
+            auth_code = secrets.token_urlsafe(32)
+
+            conn.execute(
+                """INSERT INTO auth_codes
+                   (code, client_id, user_id, scopes, code_challenge, redirect_uri,
+                    redirect_uri_provided_explicitly, expires_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    auth_code,
+                    row["client_id"],
+                    user_id,
+                    row["scopes"],
+                    row["code_challenge"],
+                    row["redirect_uri"],
+                    row["redirect_uri_provided_explicitly"],
+                    time.time() + 300,  # 5 min to exchange
+                ),
+            )
+
+            # Delete the state placeholder
+            conn.execute("DELETE FROM auth_codes WHERE code = ?", (state,))
+            conn.commit()
+
+            redirect_uri = row["redirect_uri"]
+        finally:
+            conn.close()
+
+        redirect_url = construct_redirect_uri(redirect_uri, code=auth_code)
+        return RedirectResponse(url=redirect_url, status_code=302)
+
+    def _cleanup_expired_mfa(self) -> None:
+        """Remove expired pending MFA entries. Must be called under _mfa_lock."""
+        expired = [k for k, v in self._pending_mfa.items() if v.is_expired()]
+        for k in expired:
+            del self._pending_mfa[k]
+
+    # ─── OAuthAuthorizationServerProvider methods ─────────────────────
+
+    async def get_client(self, client_id: str) -> Optional[OAuthClientInformationFull]:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT client_info_json FROM oauth_clients WHERE client_id = ?",
+                (client_id,),
+            ).fetchone()
+            if row:
+                return OAuthClientInformationFull.model_validate_json(
+                    row["client_info_json"]
+                )
+            return None
+        finally:
+            conn.close()
+
+    async def register_client(
+        self, client_info: OAuthClientInformationFull
+    ) -> None:
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                "INSERT OR REPLACE INTO oauth_clients (client_id, client_info_json) VALUES (?, ?)",
+                (client_info.client_id, client_info.model_dump_json()),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+    async def authorize(
+        self, client: OAuthClientInformationFull, params: AuthorizationParams
+    ) -> str:
+        """Redirect to login page with state info."""
+        state_token = secrets.token_urlsafe(32)
+        conn = self._get_conn()
+        try:
+            conn.execute(
+                """INSERT INTO auth_codes
+                   (code, client_id, user_id, scopes, code_challenge, redirect_uri,
+                    redirect_uri_provided_explicitly, expires_at)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                (
+                    state_token,
+                    client.client_id,
+                    None,  # user not yet authenticated
+                    ",".join(params.scopes or []),
+                    params.code_challenge,
+                    str(params.redirect_uri),
+                    1 if params.redirect_uri_provided_explicitly else 0,
+                    time.time() + 600,  # 10 min to complete login
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        return f"{self.server_url}/login?state={state_token}"
+
+    async def load_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: str
+    ) -> Optional[AuthorizationCode]:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                """SELECT * FROM auth_codes
+                   WHERE code = ? AND client_id = ? AND user_id IS NOT NULL""",
+                (authorization_code, client.client_id),
+            ).fetchone()
+            if not row or row["expires_at"] < time.time():
+                return None
+            return AuthorizationCode(
+                code=row["code"],
+                client_id=row["client_id"],
+                scopes=row["scopes"].split(",") if row["scopes"] else [],
+                code_challenge=row["code_challenge"],
+                redirect_uri=row["redirect_uri"],
+                redirect_uri_provided_explicitly=bool(
+                    row["redirect_uri_provided_explicitly"]
+                ),
+                expires_at=row["expires_at"],
+            )
+        finally:
+            conn.close()
+
+    async def exchange_authorization_code(
+        self, client: OAuthClientInformationFull, authorization_code: AuthorizationCode
+    ) -> OAuthToken:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT user_id FROM auth_codes WHERE code = ?",
+                (authorization_code.code,),
+            ).fetchone()
+            user_id = row["user_id"] if row else None
+
+            conn.execute(
+                "DELETE FROM auth_codes WHERE code = ?", (authorization_code.code,)
+            )
+
+            access_token_str = secrets.token_urlsafe(48)
+            refresh_token_str = secrets.token_urlsafe(48)
+            access_expires = time.time() + 3600  # 1 hour
+            refresh_expires = time.time() + 86400 * 30  # 30 days
+
+            conn.execute(
+                """INSERT INTO access_tokens (token, client_id, user_id, scopes, expires_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    access_token_str,
+                    client.client_id,
+                    user_id,
+                    ",".join(authorization_code.scopes),
+                    access_expires,
+                ),
+            )
+            conn.execute(
+                """INSERT INTO refresh_tokens (token, client_id, user_id, scopes, expires_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (
+                    refresh_token_str,
+                    client.client_id,
+                    user_id,
+                    ",".join(authorization_code.scopes),
+                    refresh_expires,
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        if user_id and self.session_manager:
+            self.session_manager.set_token_user_mapping(access_token_str, user_id)
+
+        return OAuthToken(
+            access_token=access_token_str,
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token=refresh_token_str,
+            scope=" ".join(authorization_code.scopes),
+        )
+
+    async def load_access_token(self, token: str) -> Optional[AccessToken]:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT * FROM access_tokens WHERE token = ?", (token,)
+            ).fetchone()
+            if not row or row["expires_at"] < time.time():
+                return None
+
+            if row["user_id"] and self.session_manager:
+                self.session_manager.set_token_user_mapping(token, row["user_id"])
+
+            return AccessToken(
+                token=row["token"],
+                client_id=row["client_id"],
+                scopes=row["scopes"].split(",") if row["scopes"] else [],
+                expires_at=int(row["expires_at"]),
+            )
+        finally:
+            conn.close()
+
+    async def load_refresh_token(
+        self, client: OAuthClientInformationFull, refresh_token: str
+    ) -> Optional[RefreshToken]:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT * FROM refresh_tokens WHERE token = ? AND client_id = ?",
+                (refresh_token, client.client_id),
+            ).fetchone()
+            if not row:
+                return None
+            if row["expires_at"] and row["expires_at"] < time.time():
+                return None
+            return RefreshToken(
+                token=row["token"],
+                client_id=row["client_id"],
+                scopes=row["scopes"].split(",") if row["scopes"] else [],
+                expires_at=int(row["expires_at"]) if row["expires_at"] else None,
+            )
+        finally:
+            conn.close()
+
+    async def exchange_refresh_token(
+        self,
+        client: OAuthClientInformationFull,
+        refresh_token: RefreshToken,
+        scopes: list[str],
+    ) -> OAuthToken:
+        conn = self._get_conn()
+        try:
+            row = conn.execute(
+                "SELECT user_id FROM refresh_tokens WHERE token = ?",
+                (refresh_token.token,),
+            ).fetchone()
+            user_id = row["user_id"] if row else None
+
+            conn.execute(
+                "DELETE FROM refresh_tokens WHERE token = ?", (refresh_token.token,)
+            )
+
+            new_access = secrets.token_urlsafe(48)
+            new_refresh = secrets.token_urlsafe(48)
+            access_expires = time.time() + 3600
+            refresh_expires = time.time() + 86400 * 30
+
+            use_scopes = scopes or refresh_token.scopes
+            scopes_str = ",".join(use_scopes)
+
+            conn.execute(
+                """INSERT INTO access_tokens (token, client_id, user_id, scopes, expires_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (new_access, client.client_id, user_id, scopes_str, access_expires),
+            )
+            conn.execute(
+                """INSERT INTO refresh_tokens (token, client_id, user_id, scopes, expires_at)
+                   VALUES (?, ?, ?, ?, ?)""",
+                (new_refresh, client.client_id, user_id, scopes_str, refresh_expires),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        if user_id and self.session_manager:
+            self.session_manager.set_token_user_mapping(new_access, user_id)
+
+        return OAuthToken(
+            access_token=new_access,
+            token_type="Bearer",
+            expires_in=3600,
+            refresh_token=new_refresh,
+            scope=" ".join(use_scopes),
+        )
+
+    async def revoke_token(
+        self, token: AccessToken | RefreshToken
+    ) -> None:
+        conn = self._get_conn()
+        try:
+            conn.execute("DELETE FROM access_tokens WHERE token = ?", (token.token,))
+            conn.execute("DELETE FROM refresh_tokens WHERE token = ?", (token.token,))
+            conn.commit()
+        finally:
+            conn.close()
+
+    # ─── Login pages ─────────────────────────────────────────────────
+
+    _PAGE_STYLE = """
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+               display: flex; justify-content: center; align-items: center;
+               min-height: 100vh; margin: 0; background: #f5f5f5; }
+        .card { background: white; padding: 2rem; border-radius: 8px;
+                 box-shadow: 0 2px 10px rgba(0,0,0,0.1); width: 100%; max-width: 400px; }
+        h1 { margin: 0 0 1.5rem; font-size: 1.5rem; text-align: center; }
+        label { display: block; margin-bottom: 0.25rem; font-weight: 500; }
+        input { width: 100%; padding: 0.5rem; margin-bottom: 1rem;
+                 border: 1px solid #ddd; border-radius: 4px; box-sizing: border-box; }
+        button { width: 100%; padding: 0.75rem; background: #007bff; color: white;
+                  border: none; border-radius: 4px; font-size: 1rem; cursor: pointer; }
+        button:hover { background: #0056b3; }
+        .error { color:#dc3545; margin-bottom:1rem; padding:0.75rem;
+                  background:#f8d7da; border-radius:4px; }
+        .info { color:#0c5460; margin-bottom:1rem; padding:0.75rem;
+                 background:#d1ecf1; border-radius:4px; text-align:center; }
+    """
+
+    async def get_login_page(self, state: str, error: str = "") -> Response:
+        """Render the Garmin Connect login form."""
+        error_html = f'<div class="error">{error}</div>' if error else ""
+
+        html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Garmin MCP - Sign In</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>{self._PAGE_STYLE}</style>
+</head>
+<body>
+    <div class="card">
+        <h1>Sign in with Garmin Connect</h1>
+        {error_html}
+        <form method="POST" action="/login/callback">
+            <input type="hidden" name="state" value="{state}">
+            <label for="email">Garmin Connect Email</label>
+            <input type="email" id="email" name="email" required autofocus>
+            <label for="password">Password</label>
+            <input type="password" id="password" name="password" required>
+            <button type="submit">Sign In</button>
+        </form>
+    </div>
+</body>
+</html>"""
+        return HTMLResponse(html)
+
+    async def handle_login_callback(self, request: Request) -> Response:
+        """Handle Garmin Connect login form submission."""
+        form = await request.form()
+        state = str(form.get("state", ""))
+        email = str(form.get("email", ""))
+        password = str(form.get("password", ""))
+
+        if not state or not email or not password:
+            return await self.get_login_page(state, "All fields are required.")
+
+        try:
+            from garth import sso as garth_sso
+
+            result = garth_sso.login(email, password, return_on_mfa=True)
+        except Exception as e:
+            logger.warning("Garmin login failed for %s: %s", email, e)
+            return await self.get_login_page(
+                state, "Invalid email or password."
+            )
+
+        # Check if MFA is required
+        if isinstance(result, tuple) and len(result) == 2 and result[0] == "needs_mfa":
+            client_state = result[1]
+            with self._mfa_lock:
+                self._cleanup_expired_mfa()
+                self._pending_mfa[state] = _PendingMfa(
+                    client_state=client_state,
+                    garmin_email=email,
+                )
+            return RedirectResponse(
+                url=f"{self.server_url}/login/mfa?state={state}",
+                status_code=302,
+            )
+
+        # Login succeeded without MFA
+        oauth1_token, oauth2_token = result
+        user_id = self._get_or_create_user(email)
+
+        if self.session_manager:
+            self.session_manager.create_session_from_garth_tokens(
+                user_id, oauth1_token, oauth2_token
+            )
+
+        return self._complete_auth_flow(state, user_id)
+
+    async def get_mfa_page(self, state: str, error: str = "") -> Response:
+        """Render the 2FA verification form."""
+        # Verify the state is valid
+        with self._mfa_lock:
+            pending = self._pending_mfa.get(state)
+            if not pending or pending.is_expired():
+                return HTMLResponse(
+                    "<h1>Session expired</h1><p>Please start the login process again.</p>",
+                    status_code=400,
+                )
+
+        error_html = f'<div class="error">{error}</div>' if error else ""
+
+        html = f"""<!DOCTYPE html>
+<html>
+<head>
+    <title>Garmin MCP - Verification</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <style>{self._PAGE_STYLE}</style>
+</head>
+<body>
+    <div class="card">
+        <h1>Two-Factor Authentication</h1>
+        <div class="info">A verification code has been sent to your email or phone.</div>
+        {error_html}
+        <form method="POST" action="/login/mfa/callback">
+            <input type="hidden" name="state" value="{state}">
+            <label for="mfa_code">Verification Code</label>
+            <input type="text" id="mfa_code" name="mfa_code"
+                   inputmode="numeric" pattern="[0-9]*" maxlength="7"
+                   autocomplete="one-time-code" required autofocus
+                   placeholder="Enter 6-digit code">
+            <button type="submit">Verify</button>
+        </form>
+    </div>
+</body>
+</html>"""
+        return HTMLResponse(html)
+
+    async def handle_mfa_callback(self, request: Request) -> Response:
+        """Handle 2FA verification form submission."""
+        form = await request.form()
+        state = str(form.get("state", ""))
+        mfa_code = str(form.get("mfa_code", "")).strip()
+
+        if not state or not mfa_code:
+            return await self.get_mfa_page(state, "Verification code is required.")
+
+        # Pop pending MFA (single use)
+        with self._mfa_lock:
+            pending = self._pending_mfa.pop(state, None)
+
+        if not pending or pending.is_expired():
+            return HTMLResponse(
+                "<h1>Session expired</h1><p>Please start the login process again.</p>",
+                status_code=400,
+            )
+
+        try:
+            from garth import sso as garth_sso
+
+            oauth1_token, oauth2_token = garth_sso.resume_login(
+                pending.client_state, mfa_code
+            )
+        except Exception as e:
+            logger.warning("MFA verification failed: %s", e)
+            # Put the state back so the user can retry
+            with self._mfa_lock:
+                self._pending_mfa[state] = pending
+            return await self.get_mfa_page(state, "Invalid verification code. Please try again.")
+
+        user_id = self._get_or_create_user(pending.garmin_email)
+
+        if self.session_manager:
+            self.session_manager.create_session_from_garth_tokens(
+                user_id, oauth1_token, oauth2_token
+            )
+
+        return self._complete_auth_flow(state, user_id)

--- a/src/garmin_mcp/remote.py
+++ b/src/garmin_mcp/remote.py
@@ -1,0 +1,129 @@
+"""
+Remote MCP server entry point with OAuth2 authentication.
+
+Runs the Garmin MCP server in remote mode with:
+- Streamable HTTP transport (network accessible)
+- OAuth2 authentication (integrated authorization server)
+- Multi-user support (each user links their own Garmin account)
+"""
+
+from __future__ import annotations
+
+import sys
+
+from pydantic import AnyHttpUrl
+from mcp.server.fastmcp import FastMCP
+from mcp.server.auth.settings import AuthSettings, ClientRegistrationOptions, RevocationOptions
+from starlette.requests import Request
+from starlette.responses import Response
+
+from garmin_mcp.config import get_config
+from garmin_mcp.oauth_provider import GarminOAuthProvider
+from garmin_mcp.session_manager import SessionManager
+from garmin_mcp.client_resolver import set_session_manager
+
+# Import all tool modules
+from garmin_mcp import activity_management
+from garmin_mcp import health_wellness
+from garmin_mcp import user_profile
+from garmin_mcp import devices
+from garmin_mcp import gear_management
+from garmin_mcp import weight_management
+from garmin_mcp import challenges
+from garmin_mcp import training
+from garmin_mcp import workouts
+from garmin_mcp import workout_templates
+from garmin_mcp import data_management
+from garmin_mcp import womens_health
+
+
+def main():
+    """Start the remote MCP server with OAuth2 authentication."""
+    # Load configuration
+    try:
+        config = get_config()
+    except ValueError as e:
+        print(f"Configuration error: {e}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"Starting Garmin MCP remote server...", file=sys.stderr)
+    print(f"  Server URL: {config.server_url}", file=sys.stderr)
+    print(f"  Listen: {config.host}:{config.port}", file=sys.stderr)
+    print(f"  MCP path: {config.path}", file=sys.stderr)
+    print(f"  DB: {config.db_path}", file=sys.stderr)
+    print(f"  Sessions: {config.session_storage_path}", file=sys.stderr)
+
+    # Initialize session manager
+    session_manager = SessionManager(config.session_storage_path)
+    set_session_manager(session_manager)
+
+    # Initialize OAuth provider
+    oauth_provider = GarminOAuthProvider(
+        db_path=config.db_path,
+        server_url=config.server_url,
+        session_manager=session_manager,
+    )
+
+    # Create the MCP app with OAuth2 authentication
+    app = FastMCP(
+        name="Garmin Connect v1.0",
+        auth_server_provider=oauth_provider,
+        auth=AuthSettings(
+            issuer_url=AnyHttpUrl(config.server_url),
+            client_registration_options=ClientRegistrationOptions(
+                enabled=True,
+                valid_scopes=[config.scope],
+                default_scopes=[config.scope],
+            ),
+            revocation_options=RevocationOptions(enabled=True),
+            required_scopes=[config.scope],
+            resource_server_url=None,  # Combined AS+RS mode
+        ),
+        host=config.host,
+        port=config.port,
+        streamable_http_path=config.path,
+    )
+
+    # Register custom routes for login pages
+    @app.custom_route("/login", methods=["GET"])
+    async def login_page(request: Request) -> Response:
+        state = request.query_params.get("state", "")
+        return await oauth_provider.get_login_page(state)
+
+    @app.custom_route("/login/callback", methods=["POST"])
+    async def login_callback(request: Request) -> Response:
+        return await oauth_provider.handle_login_callback(request)
+
+    @app.custom_route("/login/mfa", methods=["GET"])
+    async def mfa_page(request: Request) -> Response:
+        state = request.query_params.get("state", "")
+        return await oauth_provider.get_mfa_page(state)
+
+    @app.custom_route("/login/mfa/callback", methods=["POST"])
+    async def mfa_callback(request: Request) -> Response:
+        return await oauth_provider.handle_mfa_callback(request)
+
+    # Register tools from all modules
+    app = activity_management.register_tools(app)
+    app = health_wellness.register_tools(app)
+    app = user_profile.register_tools(app)
+    app = devices.register_tools(app)
+    app = gear_management.register_tools(app)
+    app = weight_management.register_tools(app)
+    app = challenges.register_tools(app)
+    app = training.register_tools(app)
+    app = workouts.register_tools(app)
+    app = data_management.register_tools(app)
+    app = womens_health.register_tools(app)
+
+    # Register resources (workout templates)
+    app = workout_templates.register_resources(app)
+
+    print("Server ready.", file=sys.stderr)
+
+    # Run the server with streamable HTTP transport
+    app.run(transport="streamable-http")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/garmin_mcp/remote.py
+++ b/src/garmin_mcp/remote.py
@@ -35,6 +35,7 @@ from garmin_mcp import workouts
 from garmin_mcp import workout_templates
 from garmin_mcp import data_management
 from garmin_mcp import womens_health
+from garmin_mcp import analytics
 
 
 def main():
@@ -115,6 +116,7 @@ def main():
     app = workouts.register_tools(app)
     app = data_management.register_tools(app)
     app = womens_health.register_tools(app)
+    app = analytics.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/session_manager.py
+++ b/src/garmin_mcp/session_manager.py
@@ -1,0 +1,148 @@
+"""
+Session manager for per-user Garmin sessions in remote mode.
+
+Manages Garmin Connect sessions using garth tokens, storing them
+per-user on disk and caching active clients in memory.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+import threading
+from typing import Dict, Optional
+
+from garminconnect import Garmin
+
+
+class SessionManager:
+    """Manages per-user Garmin Connect sessions."""
+
+    # Cache TTL in seconds (1 hour)
+    CACHE_TTL = 3600
+
+    def __init__(self, storage_path: str):
+        self.storage_path = storage_path
+        self._cache: Dict[str, _CachedClient] = {}
+        self._token_user_map: Dict[str, str] = {}
+        self._lock = threading.Lock()
+        os.makedirs(storage_path, exist_ok=True)
+
+    def get_user_id_for_token(self, token: str) -> Optional[str]:
+        """Get the user_id associated with an access token."""
+        return self._token_user_map.get(token)
+
+    def set_token_user_mapping(self, token: str, user_id: str) -> None:
+        """Associate an access token with a user_id."""
+        self._token_user_map[token] = user_id
+
+    def _user_token_dir(self, user_id: str) -> str:
+        """Get the token storage directory for a user."""
+        return os.path.join(self.storage_path, user_id)
+
+    def get_client(self, user_id: str) -> Optional[Garmin]:
+        """Get or restore a Garmin client for a user.
+
+        Returns None if no session exists for this user.
+        """
+        with self._lock:
+            # Check memory cache first
+            cached = self._cache.get(user_id)
+            if cached and not cached.is_expired():
+                return cached.client
+
+            # Try to restore from disk
+            token_dir = self._user_token_dir(user_id)
+            if not os.path.isdir(token_dir):
+                return None
+
+            try:
+                garmin = Garmin()
+                garmin.login(token_dir)
+                self._cache[user_id] = _CachedClient(garmin, self.CACHE_TTL)
+                return garmin
+            except Exception:
+                return None
+
+    def create_session(self, user_id: str, email: str, password: str) -> Garmin:
+        """Create a new Garmin session for a user.
+
+        Logs in with credentials and persists the garth tokens.
+
+        Raises:
+            Exception: If login fails.
+        """
+        garmin = Garmin(email=email, password=password, is_cn=False)
+        garmin.login()
+
+        # Persist tokens to disk
+        token_dir = self._user_token_dir(user_id)
+        os.makedirs(token_dir, exist_ok=True)
+        garmin.garth.dump(token_dir)
+
+        # Cache in memory
+        with self._lock:
+            self._cache[user_id] = _CachedClient(garmin, self.CACHE_TTL)
+
+        return garmin
+
+    def create_session_from_garth_tokens(
+        self, user_id: str, oauth1_token, oauth2_token
+    ) -> None:
+        """Persist garth tokens and invalidate the cache.
+
+        Args:
+            user_id: The user identifier.
+            oauth1_token: garth OAuth1Token from SSO login.
+            oauth2_token: garth OAuth2Token from SSO login.
+        """
+        from garth import Client as GarthClient
+
+        garth_client = GarthClient()
+        garth_client.oauth1_token = oauth1_token
+        garth_client.oauth2_token = oauth2_token
+
+        token_dir = self._user_token_dir(user_id)
+        os.makedirs(token_dir, exist_ok=True)
+        garth_client.dump(token_dir)
+
+        # Invalidate cache so next get_client() reloads from disk
+        with self._lock:
+            self._cache.pop(user_id, None)
+
+    def remove_session(self, user_id: str) -> bool:
+        """Remove a user's Garmin session and tokens.
+
+        Returns True if session existed and was removed.
+        """
+        import shutil
+
+        removed = False
+
+        with self._lock:
+            if user_id in self._cache:
+                del self._cache[user_id]
+                removed = True
+
+        token_dir = self._user_token_dir(user_id)
+        if os.path.isdir(token_dir):
+            shutil.rmtree(token_dir)
+            removed = True
+
+        return removed
+
+    def has_session(self, user_id: str) -> bool:
+        """Check if a user has a stored Garmin session."""
+        token_dir = self._user_token_dir(user_id)
+        return os.path.isdir(token_dir)
+
+
+class _CachedClient:
+    """A cached Garmin client with TTL."""
+
+    def __init__(self, client: Garmin, ttl: int):
+        self.client = client
+        self._expires_at = time.time() + ttl
+
+    def is_expired(self) -> bool:
+        return time.time() > self._expires_at

--- a/src/garmin_mcp/token_utils.py
+++ b/src/garmin_mcp/token_utils.py
@@ -1,11 +1,57 @@
 """Token management utilities for Garmin MCP authentication."""
 
 import os
+from contextlib import contextmanager
 from pathlib import Path
+from collections.abc import Iterator
 from typing import Tuple
 
 from garminconnect import Garmin
 from garth.exc import GarthHTTPError
+
+
+def _clean_config_value(value: str | None, default: str) -> str:
+    """Return a usable config value, ignoring blank or unresolved DXT placeholders."""
+    if value is None:
+        return default
+    cleaned = value.strip()
+    if not cleaned or cleaned.startswith("${user_config."):
+        return default
+    return cleaned
+
+
+def resolve_path(path: str | None, default: str | None = None) -> str:
+    """Expand user/env variables and return an absolute filesystem path."""
+    fallback = default or "~/.garminconnect"
+    cleaned = _clean_config_value(path, fallback)
+    return os.path.abspath(os.path.expandvars(os.path.expanduser(cleaned)))
+
+
+def ensure_token_directory(token_path: str | None = None) -> str:
+    """Create the token directory, replacing an empty placeholder file if needed."""
+    resolved_token_path = resolve_path(token_path or get_token_path())
+    path = Path(resolved_token_path)
+    if path.exists() and path.is_file():
+        if path.stat().st_size == 0:
+            path.unlink()
+        else:
+            raise ValueError(f"Token path must be a directory, but a file exists: {resolved_token_path}")
+    path.mkdir(parents=True, exist_ok=True)
+    return resolved_token_path
+
+
+@contextmanager
+def without_token_env() -> Iterator[None]:
+    """Temporarily remove token env vars so credential login does not load tokens."""
+    old_tokens = os.environ.pop("GARMINTOKENS", None)
+    old_tokens_base64 = os.environ.pop("GARMINTOKENS_BASE64", None)
+    try:
+        yield
+    finally:
+        if old_tokens is not None:
+            os.environ["GARMINTOKENS"] = old_tokens
+        if old_tokens_base64 is not None:
+            os.environ["GARMINTOKENS_BASE64"] = old_tokens_base64
 
 
 def get_token_path() -> str:
@@ -14,7 +60,7 @@ def get_token_path() -> str:
     Returns:
         str: Path to token storage directory
     """
-    return os.getenv("GARMINTOKENS") or "~/.garminconnect"
+    return _clean_config_value(os.getenv("GARMINTOKENS"), "~/.garminconnect")
 
 
 def get_token_base64_path() -> str:
@@ -23,7 +69,7 @@ def get_token_base64_path() -> str:
     Returns:
         str: Path to base64 token file
     """
-    return os.getenv("GARMINTOKENS_BASE64") or "~/.garminconnect_base64"
+    return _clean_config_value(os.getenv("GARMINTOKENS_BASE64"), "~/.garminconnect_base64")
 
 
 def token_exists(token_path: str = None) -> bool:
@@ -38,7 +84,9 @@ def token_exists(token_path: str = None) -> bool:
     if token_path is None:
         token_path = get_token_path()
 
-    expanded_path = Path(os.path.expanduser(token_path))
+    expanded_path = Path(resolve_path(token_path))
+    if expanded_path.is_file() and expanded_path.stat().st_size == 0:
+        return False
     return expanded_path.exists()
 
 
@@ -56,10 +104,11 @@ def validate_tokens(token_path: str = None) -> Tuple[bool, str]:
 
     if token_path is None:
         token_path = get_token_path()
+    resolved_token_path = resolve_path(token_path)
 
     # Check if tokens exist
-    if not token_exists(token_path):
-        return False, f"Token directory not found: {token_path}"
+    if not token_exists(resolved_token_path):
+        return False, f"Token directory not found: {resolved_token_path}"
 
     # Suppress stderr during validation to avoid confusing library error messages
     old_stderr = sys.stderr
@@ -67,7 +116,7 @@ def validate_tokens(token_path: str = None) -> Tuple[bool, str]:
 
     try:
         garmin = Garmin()
-        garmin.login(token_path)
+        garmin.login(resolved_token_path)
 
         # Try a simple API call to verify tokens work
         try:
@@ -85,7 +134,7 @@ def validate_tokens(token_path: str = None) -> Tuple[bool, str]:
                 return False, f"Authentication failed: {error_msg.split(':')[0]}"
 
     except FileNotFoundError:
-        return False, f"Token files not found in: {token_path}"
+        return False, f"Token files not found in: {resolved_token_path}"
     except GarthHTTPError as e:
         error_msg = str(e)
         if "401" in error_msg or "Unauthorized" in error_msg:
@@ -121,7 +170,7 @@ def remove_tokens(token_path: str = None, base64_path: str = None) -> None:
         base64_path = get_token_base64_path()
 
     # Remove token directory
-    expanded_token_path = Path(os.path.expanduser(token_path))
+    expanded_token_path = Path(resolve_path(token_path))
     if expanded_token_path.exists():
         if expanded_token_path.is_dir():
             shutil.rmtree(expanded_token_path)
@@ -129,7 +178,7 @@ def remove_tokens(token_path: str = None, base64_path: str = None) -> None:
             expanded_token_path.unlink()
 
     # Remove base64 token file
-    expanded_base64_path = Path(os.path.expanduser(base64_path))
+    expanded_base64_path = Path(resolve_path(base64_path, "~/.garminconnect_base64"))
     if expanded_base64_path.exists():
         expanded_base64_path.unlink()
 
@@ -146,16 +195,17 @@ def get_token_info(token_path: str = None) -> dict:
     if token_path is None:
         token_path = get_token_path()
 
-    exists = token_exists(token_path)
+    resolved_token_path = resolve_path(token_path)
+    exists = token_exists(resolved_token_path)
     is_valid = False
     error_msg = ""
 
     if exists:
-        is_valid, error_msg = validate_tokens(token_path)
+        is_valid, error_msg = validate_tokens(resolved_token_path)
 
     return {
         "path": token_path,
-        "expanded_path": os.path.expanduser(token_path),
+        "expanded_path": resolved_token_path,
         "exists": exists,
         "valid": is_valid,
         "error": error_msg

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -6,6 +6,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -74,7 +77,7 @@ def register_tools(app):
 
     @app.tool()
     async def get_progress_summary_between_dates(
-        start_date: str, end_date: str, metric: str
+        ctx: Context, start_date: str, end_date: str, metric: str
     ) -> str:
         """Get progress summary for a metric between dates
 
@@ -84,7 +87,7 @@ def register_tools(app):
             metric: Metric to get progress for (e.g., "elevationGain", "duration", "distance", "movingDuration")
         """
         try:
-            summary_data = garmin_client.get_progress_summary_between_dates(
+            summary_data = get_client(ctx).get_progress_summary_between_dates(
                 start_date, end_date, metric
             )
 
@@ -129,7 +132,7 @@ def register_tools(app):
             return f"Error retrieving progress summary: {str(e)}"
 
     @app.tool()
-    async def get_hill_score(start_date: str, end_date: str) -> str:
+    async def get_hill_score(ctx: Context, start_date: str, end_date: str) -> str:
         """Get hill score data between dates
 
         Args:
@@ -137,7 +140,7 @@ def register_tools(app):
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            hill_score_data = garmin_client.get_hill_score(start_date, end_date)
+            hill_score_data = get_client(ctx).get_hill_score(start_date, end_date)
 
             if not hill_score_data:
                 return f"No hill score data found between {start_date} and {end_date}."
@@ -186,7 +189,7 @@ def register_tools(app):
             return f"Error retrieving hill score data: {str(e)}"
 
     @app.tool()
-    async def get_endurance_score(start_date: str, end_date: str) -> str:
+    async def get_endurance_score(ctx: Context, start_date: str, end_date: str) -> str:
         """Get endurance score data between dates
 
         Args:
@@ -194,7 +197,7 @@ def register_tools(app):
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            endurance_data = garmin_client.get_endurance_score(start_date, end_date)
+            endurance_data = get_client(ctx).get_endurance_score(start_date, end_date)
             if not endurance_data:
                 return f"No endurance score data found between {start_date} and {end_date}."
 
@@ -300,7 +303,7 @@ def register_tools(app):
             return f"Error retrieving endurance score data: {str(e)}"
 
     @app.tool()
-    async def get_training_effect(activity_id: int) -> str:
+    async def get_training_effect(ctx: Context, activity_id: int) -> str:
         """Get training effect data for a specific activity
 
         Args:
@@ -309,7 +312,7 @@ def register_tools(app):
         try:
             # Training effect data is available through get_activity
             # The garminconnect library doesn't have a separate get_training_effect method
-            activity = garmin_client.get_activity(activity_id)
+            activity = get_client(ctx).get_activity(activity_id)
             if not activity:
                 return f"No activity found with ID {activity_id}."
 
@@ -343,7 +346,7 @@ def register_tools(app):
             return f"Error retrieving training effect data: {str(e)}"
 
     @app.tool()
-    async def get_hrv_data(date: str, return_timeseries: bool = False) -> str:
+    async def get_hrv_data(ctx: Context, date: str, return_timeseries: bool = False) -> str:
         """Get Heart Rate Variability (HRV) data
 
         Args:
@@ -351,7 +354,7 @@ def register_tools(app):
             return_timeseries: If True, include detailed 5-minute HRV readings (can be large)
         """
         try:
-            hrv_data = garmin_client.get_hrv_data(date)
+            hrv_data = get_client(ctx).get_hrv_data(date)
             if not hrv_data:
                 return f"No HRV data found for {date}."
 
@@ -399,7 +402,7 @@ def register_tools(app):
             return f"Error retrieving HRV data: {str(e)}"
 
     @app.tool()
-    async def get_fitnessage_data(date: str, details: bool = False) -> str:
+    async def get_fitnessage_data(ctx: Context, date: str, details: bool = False) -> str:
         """Get fitness age data
 
         Args:
@@ -408,7 +411,7 @@ def register_tools(app):
                      with targets and improvement suggestions
         """
         try:
-            fitness_age = garmin_client.get_fitnessage_data(date)
+            fitness_age = get_client(ctx).get_fitnessage_data(date)
             if not fitness_age:
                 return f"No fitness age data found for {date}."
 
@@ -478,7 +481,7 @@ def register_tools(app):
             return f"Error retrieving fitness age data: {str(e)}"
 
     @app.tool()
-    async def get_training_status(date: str) -> str:
+    async def get_training_status(ctx: Context, date: str) -> str:
         """Get training status with curated metrics
 
         Returns comprehensive training status including load, VO2 max, recovery,
@@ -488,7 +491,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            status = garmin_client.get_training_status(date)
+            status = get_client(ctx).get_training_status(date)
             if not status:
                 return f"No training status data found for {date}."
 
@@ -554,6 +557,7 @@ def register_tools(app):
 
     @app.tool()
     async def get_lactate_threshold(
+        ctx: Context,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> str:
@@ -570,13 +574,13 @@ def register_tools(app):
         try:
             # Call API with appropriate parameters
             if start_date and end_date:
-                threshold = garmin_client.get_lactate_threshold(
+                threshold = get_client(ctx).get_lactate_threshold(
                     latest=False,
                     start_date=start_date,
                     end_date=end_date,
                 )
             else:
-                threshold = garmin_client.get_lactate_threshold(latest=True)
+                threshold = get_client(ctx).get_lactate_threshold(latest=True)
 
             if not threshold:
                 if start_date and end_date:
@@ -656,14 +660,14 @@ def register_tools(app):
             return f"Error retrieving lactate threshold data: {str(e)}"
 
     @app.tool()
-    async def request_reload(date: str) -> str:
+    async def request_reload(ctx: Context, date: str) -> str:
         """Request reload of epoch data
 
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            result = garmin_client.request_reload(date)
+            result = get_client(ctx).request_reload(date)
             return json.dumps(result, indent=2)
         except Exception as e:
             return f"Error requesting data reload: {str(e)}"

--- a/src/garmin_mcp/user_profile.py
+++ b/src/garmin_mcp/user_profile.py
@@ -5,6 +5,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -17,30 +20,30 @@ def configure(client):
 
 def register_tools(app):
     """Register all user profile tools with the MCP server app"""
-    
+
     @app.tool()
-    async def get_full_name() -> str:
+    async def get_full_name(ctx: Context) -> str:
         """Get user's full name from profile"""
         try:
-            full_name = garmin_client.get_full_name()
+            full_name = get_client(ctx).get_full_name()
             return json.dumps({"full_name": full_name}, indent=2)
         except Exception as e:
             return f"Error retrieving user's full name: {str(e)}"
 
     @app.tool()
-    async def get_unit_system() -> str:
+    async def get_unit_system(ctx: Context) -> str:
         """Get user's preferred unit system from profile"""
         try:
-            unit_system = garmin_client.get_unit_system()
+            unit_system = get_client(ctx).get_unit_system()
             return json.dumps({"unit_system": unit_system}, indent=2)
         except Exception as e:
             return f"Error retrieving unit system: {str(e)}"
-    
+
     @app.tool()
-    async def get_user_profile() -> str:
+    async def get_user_profile(ctx: Context) -> str:
         """Get user profile information"""
         try:
-            profile = garmin_client.get_user_profile()
+            profile = get_client(ctx).get_user_profile()
             if not profile:
                 return "No user profile information found."
             return json.dumps(profile, indent=2)
@@ -48,10 +51,10 @@ def register_tools(app):
             return f"Error retrieving user profile: {str(e)}"
 
     @app.tool()
-    async def get_userprofile_settings() -> str:
+    async def get_userprofile_settings(ctx: Context) -> str:
         """Get user profile settings"""
         try:
-            settings = garmin_client.get_userprofile_settings()
+            settings = get_client(ctx).get_userprofile_settings()
             if not settings:
                 return "No user profile settings found."
             return json.dumps(settings, indent=2)

--- a/src/garmin_mcp/womens_health.py
+++ b/src/garmin_mcp/womens_health.py
@@ -5,6 +5,9 @@ import json
 import datetime
 from typing import Any, Dict, List, Optional, Union
 
+from mcp.server.fastmcp import Context
+from garmin_mcp.client_resolver import get_client
+
 # The garmin_client will be set by the main file
 garmin_client = None
 
@@ -17,43 +20,43 @@ def configure(client):
 
 def register_tools(app):
     """Register all women's health tools with the MCP server app"""
-    
+
     @app.tool()
-    async def get_pregnancy_summary() -> str:
+    async def get_pregnancy_summary(ctx: Context) -> str:
         """Get pregnancy summary data"""
         try:
-            summary = garmin_client.get_pregnancy_summary()
+            summary = get_client(ctx).get_pregnancy_summary()
             if not summary:
                 return "No pregnancy summary data found."
             return json.dumps(summary, indent=2)
         except Exception as e:
             return f"Error retrieving pregnancy summary: {str(e)}"
-    
+
     @app.tool()
-    async def get_menstrual_data_for_date(date: str) -> str:
+    async def get_menstrual_data_for_date(ctx: Context, date: str) -> str:
         """Get menstrual data for a specific date
-        
+
         Args:
             date: Date in YYYY-MM-DD format
         """
         try:
-            data = garmin_client.get_menstrual_data_for_date(date)
+            data = get_client(ctx).get_menstrual_data_for_date(date)
             if not data:
                 return f"No menstrual data found for {date}."
             return json.dumps(data, indent=2)
         except Exception as e:
             return f"Error retrieving menstrual data: {str(e)}"
-    
+
     @app.tool()
-    async def get_menstrual_calendar_data(start_date: str, end_date: str) -> str:
+    async def get_menstrual_calendar_data(ctx: Context, start_date: str, end_date: str) -> str:
         """Get menstrual calendar data between specified dates
-        
+
         Args:
             start_date: Start date in YYYY-MM-DD format
             end_date: End date in YYYY-MM-DD format
         """
         try:
-            data = garmin_client.get_menstrual_calendar_data(start_date, end_date)
+            data = get_client(ctx).get_menstrual_calendar_data(start_date, end_date)
             if not data:
                 return f"No menstrual calendar data found between {start_date} and {end_date}."
             return json.dumps(data, indent=2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import pytest
 from unittest.mock import Mock
 from datetime import datetime, timedelta
 from mcp.server.fastmcp import FastMCP
+from garmin_mcp.client_resolver import set_global_client
 
 
 @pytest.fixture
@@ -173,6 +174,9 @@ def create_test_app(module, mock_client):
     """
     # Configure the module with mock client
     module.configure(mock_client)
+
+    # Also set in client_resolver so get_client(ctx) works
+    set_global_client(mock_client)
 
     # Create app and register tools
     app = FastMCP("Test Garmin MCP")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -37,6 +37,7 @@ def mock_garmin_client():
     client.get_spo2_data = Mock(return_value={})
     client.get_all_day_stress = Mock(return_value={})
     client.get_all_day_events = Mock(return_value={})
+    client.get_activities_by_date = Mock(return_value=[])
 
     return client
 

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -6,6 +6,7 @@ Tests all 10 activity management tools using FastMCP integration with mocked Gar
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
+from garmin_mcp.client_resolver import set_global_client
 
 from garmin_mcp import activity_management
 from tests.fixtures.garmin_responses import (
@@ -21,6 +22,7 @@ from tests.fixtures.garmin_responses import (
 def app_with_activity_management(mock_garmin_client):
     """Create FastMCP app with activity_management tools registered"""
     activity_management.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Activity Management")
     app = activity_management.register_tools(app)
     return app

--- a/tests/integration/test_analytics_tools.py
+++ b/tests/integration/test_analytics_tools.py
@@ -1,0 +1,209 @@
+"""
+Integration tests for historical analytics MCP tools.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import date, timedelta
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import analytics
+from garmin_mcp.client_resolver import set_global_client
+
+
+@pytest.fixture
+def app_with_analytics(mock_garmin_client):
+    """Create FastMCP app with analytics tools registered."""
+    analytics.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
+    app = FastMCP("Test Analytics")
+    return analytics.register_tools(app)
+
+
+def tool_json(result):
+    """Extract JSON payload from FastMCP call_tool output."""
+    return json.loads(result[0][0].text)
+
+
+@pytest.fixture
+def analytics_history(mock_garmin_client):
+    """Mock 35 days of daily Garmin data with a few clear trends."""
+    start = date(2024, 1, 1)
+    stats_by_date = {}
+    sleep_by_date = {}
+    readiness_by_date = {}
+
+    for index in range(35):
+        current = start + timedelta(days=index)
+        date_text = current.isoformat()
+        hard_block = index >= 28
+        stats_by_date[date_text] = {
+            "calendarDate": date_text,
+            "totalSteps": 8000 + (index * 100),
+            "activeKilocalories": 420 + (index * 5),
+            "totalDistanceMeters": 6000 + (index * 80),
+            "restingHeartRate": 52 + (4 if hard_block else 0),
+            "averageStressLevel": 28 + (12 if hard_block else 0),
+            "maxStressLevel": 65 + (8 if hard_block else 0),
+            "bodyBatteryHighestValue": 86 - (12 if hard_block else 0),
+            "bodyBatteryLowestValue": 28 + (6 if hard_block else 0),
+            "bodyBatteryChargedValue": 58 - (8 if hard_block else 0),
+            "bodyBatteryDrainedValue": 42 + (9 if hard_block else 0),
+        }
+        sleep_by_date[date_text] = {
+            "dailySleepDTO": {
+                "sleepTimeSeconds": (8 * 3600) - (1800 if hard_block else 0),
+                "deepSleepSeconds": 7200 - (900 if hard_block else 0),
+                "remSleepSeconds": 5400 - (600 if hard_block else 0),
+                "avgSleepStress": 14 + (8 if hard_block else 0),
+                "sleepScores": {"overall": {"value": 84 - (13 if hard_block else 0)}},
+            },
+            "avgOvernightHrv": 48 - (6 if hard_block else 0),
+        }
+        readiness_by_date[date_text] = [{"score": 82 - (15 if hard_block else 0)}]
+
+    stats_by_date["2024-01-31"]["averageStressLevel"] = 75
+
+    def get_stats(date_text):
+        return stats_by_date.get(date_text, {})
+
+    def get_sleep_data(date_text):
+        return sleep_by_date.get(date_text, {})
+
+    def get_training_readiness(date_text):
+        return readiness_by_date.get(date_text, [])
+
+    mock_garmin_client.get_stats.side_effect = get_stats
+    mock_garmin_client.get_sleep_data.side_effect = get_sleep_data
+    mock_garmin_client.get_training_readiness.side_effect = get_training_readiness
+    mock_garmin_client.get_activities_by_date.return_value = [
+        {
+            "startTimeLocal": "2024-01-29 07:00:00",
+            "distance": 10000,
+            "duration": 3600,
+            "calories": 700,
+        },
+        {
+            "startTimeLocal": "2024-01-30 07:00:00",
+            "distance": 12000,
+            "duration": 4000,
+            "calories": 760,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_health_baselines(app_with_analytics, analytics_history):
+    """Test baseline tool returns latest values and deltas."""
+    result = await app_with_analytics.call_tool(
+        "get_health_baselines",
+        {"end_date": "2024-02-04", "days": 35, "baseline_window": 28},
+    )
+    payload = tool_json(result)
+
+    assert payload["window"]["days"] == 35
+    assert payload["latest_date"] == "2024-02-04"
+    assert payload["metrics"]["resting_hr"]["latest"] == 56
+    assert payload["metrics"]["sleep_score"]["baseline_avg"] is not None
+
+
+@pytest.mark.asyncio
+async def test_get_wellness_anomalies(app_with_analytics, analytics_history):
+    """Test anomaly tool finds the stress spike."""
+    result = await app_with_analytics.call_tool(
+        "get_wellness_anomalies",
+        {"end_date": "2024-02-04", "days": 35, "baseline_window": 21, "z_threshold": 1.5},
+    )
+    payload = tool_json(result)
+
+    assert payload["count"] > 0
+    assert any(item["metric"] == "stress_avg" for item in payload["anomalies"])
+
+
+@pytest.mark.asyncio
+async def test_get_lagged_health_correlations(app_with_analytics, analytics_history):
+    """Test lagged correlation tool returns ranked relationships."""
+    result = await app_with_analytics.call_tool(
+        "get_lagged_health_correlations",
+        {"end_date": "2024-02-04", "days": 35, "max_lag_days": 3},
+    )
+    payload = tool_json(result)
+
+    assert payload["strongest"]
+    assert payload["strongest"][0]["pairs"] >= 8
+
+
+@pytest.mark.asyncio
+async def test_get_weekly_health_review(app_with_analytics, analytics_history):
+    """Test weekly review includes comparisons and notable signals."""
+    result = await app_with_analytics.call_tool(
+        "get_weekly_health_review",
+        {"end_date": "2024-02-04"},
+    )
+    payload = tool_json(result)
+
+    assert payload["window"] == {"start": "2024-01-29", "end": "2024-02-04", "days": 7}
+    assert "comparisons" in payload
+    assert payload["summary_notes"]
+
+
+@pytest.mark.asyncio
+async def test_custom_health_report_groups_metrics(app_with_analytics, analytics_history):
+    """Test custom report tool groups selected metrics."""
+    result = await app_with_analytics.call_tool(
+        "run_custom_health_report",
+        {
+            "end_date": "2024-02-04",
+            "days": 35,
+            "metrics": "steps,sleep_score,recovery_pressure",
+            "group_by": "week",
+            "aggregation": "avg",
+            "include_daily_rows": True,
+        },
+    )
+    payload = tool_json(result)
+
+    assert payload["columns"] == ["group", "days", "steps", "sleep_score", "recovery_pressure"]
+    assert payload["rows"]
+    assert payload["daily_rows"]
+    assert payload["chart_hint"]["series"][0]["metric"] == "steps"
+
+
+@pytest.mark.asyncio
+async def test_saved_custom_health_report_round_trip(
+    app_with_analytics, analytics_history, monkeypatch, tmp_path
+):
+    """Test saving, listing, and running a custom report definition."""
+    monkeypatch.setenv("GARMIN_REPORTS_PATH", str(tmp_path / "reports.json"))
+
+    save_result = await app_with_analytics.call_tool(
+        "save_custom_health_report",
+        {
+            "name": "Recovery Watch",
+            "description": "Weekly recovery report",
+            "metrics": "overnight_hrv,resting_hr,recovery_pressure",
+            "group_by": "week",
+            "aggregation": "latest",
+            "days": 35,
+            "end_date": "2024-02-04",
+        },
+    )
+    save_payload = tool_json(save_result)
+    assert save_payload["saved"] is True
+
+    list_result = await app_with_analytics.call_tool("list_saved_health_reports", {})
+    list_payload = tool_json(list_result)
+    assert list_payload["count"] == 1
+    assert list_payload["reports"][0]["name"] == "Recovery Watch"
+
+    run_result = await app_with_analytics.call_tool(
+        "run_custom_health_report",
+        {"saved_report_name": "Recovery Watch"},
+    )
+    run_payload = tool_json(run_result)
+    assert run_payload["definition"]["name"] == "Recovery Watch"
+    assert run_payload["definition"]["aggregation"] == "latest"
+    assert run_payload["rows"]

--- a/tests/integration/test_auth_tools.py
+++ b/tests/integration/test_auth_tools.py
@@ -1,0 +1,190 @@
+"""
+Integration tests for MCP Garmin authentication tools.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock, mock_open, patch
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import auth_tools
+
+
+@pytest.fixture
+def app_with_auth_tools():
+    """Create FastMCP app with auth tools registered."""
+    app = FastMCP("Test Auth Tools")
+    auth_tools.configure(lambda client: None)
+    return auth_tools.register_tools(app)
+
+
+def tool_json(result):
+    """Extract JSON payload from FastMCP call_tool output."""
+    return json.loads(result[0][0].text)
+
+
+@pytest.mark.asyncio
+@patch("garmin_mcp.auth_tools.get_token_info")
+async def test_check_garmin_auth_reports_valid_tokens(mock_info, app_with_auth_tools):
+    """Test auth status returns valid token state."""
+    mock_info.return_value = {
+        "path": "/tmp/tokens",
+        "expanded_path": "/tmp/tokens",
+        "exists": True,
+        "valid": True,
+        "error": "",
+    }
+
+    result = await app_with_auth_tools.call_tool("check_garmin_auth", {"token_path": "/tmp/tokens"})
+    payload = tool_json(result)
+
+    assert payload["authenticated"] is True
+    assert payload["next_step"] == "You can use Garmin tools now."
+
+
+@pytest.mark.asyncio
+@patch("garmin_mcp.auth_tools.get_token_info")
+@patch("garmin_mcp.auth_tools.Garmin")
+async def test_login_to_garmin_saves_tokens_without_otp(mock_garmin, mock_info, app_with_auth_tools):
+    """Test successful non-OTP login saves tokens."""
+    mock_info.return_value = {"exists": False, "valid": False, "expanded_path": "/tmp/tokens"}
+    garmin = Mock()
+    garmin.garth.dumps.return_value = "base64-token"
+    mock_garmin.return_value = garmin
+
+    with patch("builtins.open", mock_open()) as open_mock:
+        result = await app_with_auth_tools.call_tool(
+            "login_to_garmin",
+            {
+                "email": "test@example.com",
+                "password": "secret",
+                "token_path": "/tmp/tokens",
+                "token_base64_path": "/tmp/tokens.b64",
+            },
+        )
+
+    payload = tool_json(result)
+    assert payload["status"] == "authenticated"
+    garmin.login.assert_called_once()
+    garmin.garth.dump.assert_called_once_with("/tmp/tokens")
+    open_mock().write.assert_called_once_with("base64-token")
+
+
+@pytest.mark.asyncio
+@patch("garmin_mcp.auth_tools._prompt_local_input", return_value="")
+@patch("garmin_mcp.auth_tools.get_token_info")
+@patch("garmin_mcp.auth_tools.Garmin")
+async def test_login_to_garmin_returns_mfa_required_without_otp(
+    mock_garmin, mock_info, mock_prompt, app_with_auth_tools
+):
+    """Test OTP accounts get an actionable mfa_required response."""
+    mock_info.return_value = {"exists": False, "valid": False, "expanded_path": "/tmp/tokens"}
+    garmin = Mock()
+    mfa_prompt = None
+
+    def create_garmin(**kwargs):
+        nonlocal mfa_prompt
+        mfa_prompt = kwargs["prompt_mfa"]
+        return garmin
+
+    def require_mfa():
+        mfa_prompt()
+
+    mock_garmin.side_effect = create_garmin
+    garmin.login.side_effect = require_mfa
+
+    result = await app_with_auth_tools.call_tool(
+        "login_to_garmin",
+        {"email": "test@example.com", "password": "secret", "token_path": "/tmp/tokens"},
+    )
+
+    payload = tool_json(result)
+    assert payload["status"] == "mfa_required"
+    assert "one-time code" in payload["message"]
+
+
+@pytest.mark.asyncio
+@patch("garmin_mcp.auth_tools.get_token_info")
+@patch("garmin_mcp.auth_tools.Garmin")
+async def test_login_to_garmin_uses_otp_code(mock_garmin, mock_info, app_with_auth_tools):
+    """Test OTP code can satisfy Garmin MFA prompt and save tokens."""
+    mock_info.return_value = {"exists": False, "valid": False, "expanded_path": "/tmp/tokens"}
+    garmin = Mock()
+    garmin.garth.dumps.return_value = "base64-token"
+    mfa_prompt = None
+
+    def create_garmin(**kwargs):
+        nonlocal mfa_prompt
+        mfa_prompt = kwargs["prompt_mfa"]
+        return garmin
+
+    def use_mfa():
+        assert mfa_prompt() == "123456"
+
+    mock_garmin.side_effect = create_garmin
+    garmin.login.side_effect = use_mfa
+
+    with patch("builtins.open", mock_open()):
+        result = await app_with_auth_tools.call_tool(
+            "login_to_garmin",
+            {
+                "email": "test@example.com",
+                "password": "secret",
+                "otp_code": "123456",
+                "token_path": "/tmp/tokens",
+            },
+        )
+
+    payload = tool_json(result)
+    assert payload["status"] == "authenticated"
+    garmin.garth.dump.assert_called_once_with("/tmp/tokens")
+
+
+@pytest.mark.asyncio
+@patch("garmin_mcp.auth_tools.get_token_info")
+@patch("garmin_mcp.auth_tools._prompt_local_input")
+async def test_login_to_garmin_uses_local_password_prompt(
+    mock_prompt, mock_info, app_with_auth_tools
+):
+    """Test local dialog prompt can provide missing password without chat."""
+    mock_info.return_value = {"exists": False, "valid": False, "expanded_path": "/tmp/tokens"}
+    mock_prompt.side_effect = ["local-secret"]
+
+    with patch.dict("os.environ", {"GARMIN_EMAIL": "test@example.com"}, clear=False):
+        with patch("garmin_mcp.auth_tools.Garmin") as mock_garmin:
+            garmin = Mock()
+            garmin.garth.dumps.return_value = "base64-token"
+            mock_garmin.return_value = garmin
+
+            with patch("builtins.open", mock_open()):
+                result = await app_with_auth_tools.call_tool(
+                    "login_to_garmin",
+                    {"token_path": "/tmp/tokens"},
+                )
+
+    payload = tool_json(result)
+    assert payload["status"] == "authenticated"
+    mock_garmin.assert_called_once()
+    assert mock_garmin.call_args.kwargs["password"] == "local-secret"
+
+
+@pytest.mark.asyncio
+@patch("garmin_mcp.auth_tools.get_token_info")
+@patch("garmin_mcp.auth_tools._prompt_local_input", return_value="")
+async def test_login_to_garmin_reports_missing_credentials_after_cancelled_prompt(
+    mock_prompt, mock_info, app_with_auth_tools
+):
+    """Test cancelled local prompt returns missing credentials."""
+    mock_info.return_value = {"exists": False, "valid": False, "expanded_path": "/tmp/tokens"}
+
+    with patch.dict("os.environ", {}, clear=True):
+        result = await app_with_auth_tools.call_tool(
+            "login_to_garmin",
+            {"token_path": "/tmp/tokens"},
+        )
+
+    payload = tool_json(result)
+    assert payload["status"] == "missing_credentials"

--- a/tests/integration/test_challenges_tools.py
+++ b/tests/integration/test_challenges_tools.py
@@ -6,6 +6,7 @@ Tests all 9 challenges and badges tools using FastMCP integration with mocked Ga
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
+from garmin_mcp.client_resolver import set_global_client
 
 from garmin_mcp import challenges
 from tests.fixtures.garmin_responses import (
@@ -19,6 +20,7 @@ from tests.fixtures.garmin_responses import (
 def app_with_challenges(mock_garmin_client):
     """Create FastMCP app with challenges tools registered"""
     challenges.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Challenges")
     app = challenges.register_tools(app)
     return app

--- a/tests/integration/test_health_wellness_tools.py
+++ b/tests/integration/test_health_wellness_tools.py
@@ -6,6 +6,7 @@ Tests all 22 health and wellness tools using FastMCP integration with mocked Gar
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
+from garmin_mcp.client_resolver import set_global_client
 
 from garmin_mcp import health_wellness
 from tests.fixtures.garmin_responses import (
@@ -37,6 +38,7 @@ from tests.fixtures.garmin_responses import (
 def app_with_health_wellness(mock_garmin_client):
     """Create FastMCP app with health_wellness tools registered"""
     health_wellness.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Health Wellness")
     app = health_wellness.register_tools(app)
     return app

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -14,6 +14,7 @@ Total: 25 tools
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
+from garmin_mcp.client_resolver import set_global_client
 
 from garmin_mcp import (
     devices,
@@ -44,6 +45,7 @@ from tests.fixtures.garmin_responses import (
 def app_with_devices(mock_garmin_client):
     """Create FastMCP app with devices tools registered"""
     devices.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Devices")
     app = devices.register_tools(app)
     return app
@@ -121,6 +123,7 @@ async def test_get_device_alarms_tool(app_with_devices, mock_garmin_client):
 def app_with_weight(mock_garmin_client):
     """Create FastMCP app with weight_management tools registered"""
     weight_management.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Weight Management")
     app = weight_management.register_tools(app)
     return app
@@ -194,6 +197,7 @@ async def test_add_weigh_in_with_timestamps_tool(app_with_weight, mock_garmin_cl
 def app_with_user_profile(mock_garmin_client):
     """Create FastMCP app with user_profile tools registered"""
     user_profile.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test User Profile")
     app = user_profile.register_tools(app)
     return app
@@ -241,6 +245,7 @@ async def test_get_userprofile_settings_tool(app_with_user_profile, mock_garmin_
 def app_with_data_management(mock_garmin_client):
     """Create FastMCP app with data_management tools registered"""
     data_management.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Data Management")
     app = data_management.register_tools(app)
     return app
@@ -308,6 +313,7 @@ async def test_add_hydration_data_tool(app_with_data_management, mock_garmin_cli
 def app_with_gear(mock_garmin_client):
     """Create FastMCP app with gear_management tools registered"""
     gear_management.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Gear Management")
     app = gear_management.register_tools(app)
     return app
@@ -376,6 +382,7 @@ async def test_remove_gear_from_activity_tool(app_with_gear, mock_garmin_client)
 def app_with_womens_health(mock_garmin_client):
     """Create FastMCP app with womens_health tools registered"""
     womens_health.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Womens Health")
     app = womens_health.register_tools(app)
     return app

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -6,6 +6,7 @@ Tests all 8 training tools using FastMCP integration with mocked Garmin API resp
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
+from garmin_mcp.client_resolver import set_global_client
 
 import json
 
@@ -25,6 +26,7 @@ from tests.fixtures.garmin_responses import (
 def app_with_training(mock_garmin_client):
     """Create FastMCP app with training tools registered"""
     training.configure(mock_garmin_client)
+    set_global_client(mock_garmin_client)
     app = FastMCP("Test Training")
     app = training.register_tools(app)
     return app
@@ -95,7 +97,7 @@ async def test_get_endurance_score_tool(app_with_training, mock_garmin_client):
     mock_garmin_client.get_endurance_score.assert_called_once_with("2024-01-08", "2024-01-15")
 
     # Parse the result and verify content
-    data = json.loads(result[0].text)
+    data = json.loads(result[0][0].text)
 
     # Check period summary
     assert data["period_avg_score"] == 5631
@@ -260,7 +262,7 @@ async def test_get_lactate_threshold_tool_latest(app_with_training, mock_garmin_
     mock_garmin_client.get_lactate_threshold.assert_called_once_with(latest=True)
 
     # Verify output structure
-    data = json.loads(result[0].text)
+    data = json.loads(result[0][0].text)
     assert data["lactate_threshold_speed_mps"] == 0.32222132
     assert data["lactate_threshold_heart_rate_bpm"] == 169
     assert data["functional_threshold_power_watts"] == 334
@@ -289,7 +291,7 @@ async def test_get_lactate_threshold_tool_range(app_with_training, mock_garmin_c
     )
 
     # Verify output structure
-    data = json.loads(result[0].text)
+    data = json.loads(result[0][0].text)
     assert data["start_date"] == "2024-01-08"
     assert data["end_date"] == "2024-01-15"
     assert "speed_history" in data

--- a/tests/unit/test_auth_cli.py
+++ b/tests/unit/test_auth_cli.py
@@ -20,6 +20,13 @@ from garmin_mcp.auth_cli import (
 class TestGetMfa:
     """Tests for get_mfa function."""
 
+    def test_get_mfa_from_env(self):
+        """Test getting MFA code from environment."""
+        with patch.dict(os.environ, {"GARMIN_MFA_CODE": " 654321 "}):
+            result = get_mfa()
+
+        assert result == "654321"
+
     @patch("builtins.input", return_value="123456")
     @patch("builtins.print")
     def test_get_mfa_success(self, mock_print, mock_input):

--- a/tests/unit/test_token_utils.py
+++ b/tests/unit/test_token_utils.py
@@ -8,12 +8,15 @@ from unittest.mock import Mock, patch, MagicMock
 import pytest
 
 from garmin_mcp.token_utils import (
+    ensure_token_directory,
     get_token_path,
     get_token_base64_path,
+    resolve_path,
     token_exists,
     validate_tokens,
     remove_tokens,
     get_token_info,
+    without_token_env,
 )
 
 
@@ -32,6 +35,11 @@ class TestGetTokenPath:
         with patch.dict(os.environ, {"GARMINTOKENS": "/custom/path"}):
             assert get_token_path() == "/custom/path"
 
+    def test_ignores_unresolved_dxt_placeholder(self):
+        """Test that unresolved DXT placeholders fall back to the default path."""
+        with patch.dict(os.environ, {"GARMINTOKENS": "${user_config.token_path}"}):
+            assert get_token_path() == "~/.garminconnect"
+
 
 class TestGetTokenBase64Path:
     """Tests for get_token_base64_path function."""
@@ -49,6 +57,42 @@ class TestGetTokenBase64Path:
             assert get_token_base64_path() == "/custom/path.b64"
 
 
+class TestResolvePath:
+    """Tests for path normalization."""
+
+    def test_expands_home_env_var(self):
+        """Test DXT-style HOME defaults resolve to absolute paths."""
+        expected = str(Path.home() / ".garminconnect")
+        assert resolve_path("${HOME}/.garminconnect") == expected
+
+    def test_expands_tilde(self):
+        """Test shell-style home paths resolve to absolute paths."""
+        expected = str(Path.home() / ".garminconnect")
+        assert resolve_path("~/.garminconnect") == expected
+
+    def test_placeholder_uses_default(self):
+        """Test unresolved user_config placeholders do not become real paths."""
+        expected = str(Path.home() / ".garminconnect")
+        assert resolve_path("${user_config.token_path}") == expected
+
+
+class TestWithoutTokenEnv:
+    """Tests for removing token env vars during credential login."""
+
+    def test_temporarily_removes_token_env(self):
+        """Test token env vars are removed only inside the context."""
+        with patch.dict(
+            os.environ,
+            {"GARMINTOKENS": "/tmp/tokens", "GARMINTOKENS_BASE64": "/tmp/tokens.b64"},
+        ):
+            with without_token_env():
+                assert "GARMINTOKENS" not in os.environ
+                assert "GARMINTOKENS_BASE64" not in os.environ
+
+            assert os.environ["GARMINTOKENS"] == "/tmp/tokens"
+            assert os.environ["GARMINTOKENS_BASE64"] == "/tmp/tokens.b64"
+
+
 class TestTokenExists:
     """Tests for token_exists function."""
 
@@ -60,7 +104,14 @@ class TestTokenExists:
     def test_token_file_exists(self):
         """Test that existing token file is detected."""
         with tempfile.NamedTemporaryFile() as tmpfile:
+            tmpfile.write(b"token")
+            tmpfile.flush()
             assert token_exists(tmpfile.name) is True
+
+    def test_empty_token_file_does_not_exist(self):
+        """Test that empty placeholder files are not treated as valid token stores."""
+        with tempfile.NamedTemporaryFile() as tmpfile:
+            assert token_exists(tmpfile.name) is False
 
     def test_token_not_exists(self):
         """Test that non-existent token path is detected."""
@@ -147,6 +198,39 @@ class TestValidateTokens:
 
         assert is_valid is False
         assert "authentication failed" in error.lower() or "failed" in error.lower()
+
+
+class TestEnsureTokenDirectory:
+    """Tests for preparing token storage paths."""
+
+    def test_creates_missing_directory(self):
+        """Test that missing token directories are created."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_dir = Path(tmpdir) / "tokens"
+            result = ensure_token_directory(str(token_dir))
+
+            assert result == str(token_dir)
+            assert token_dir.is_dir()
+
+    def test_replaces_empty_placeholder_file(self):
+        """Test that an empty file can be converted into the token directory."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_dir = Path(tmpdir) / "tokens"
+            token_dir.write_text("")
+
+            result = ensure_token_directory(str(token_dir))
+
+            assert result == str(token_dir)
+            assert token_dir.is_dir()
+
+    def test_rejects_non_empty_file(self):
+        """Test that non-empty files are not overwritten."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_dir = Path(tmpdir) / "tokens"
+            token_dir.write_text("do not remove")
+
+            with pytest.raises(ValueError):
+                ensure_token_directory(str(token_dir))
 
 
 class TestRemoveTokens:

--- a/uv.lock
+++ b/uv.lock
@@ -1,13 +1,23 @@
 version = 1
+revision = 3
 requires-python = ">=3.10"
+
+[[package]]
+name = "aiosqlite"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4e/8a/64761f4005f17809769d23e518d915db74e6310474e733e3593cfc854ef1/aiosqlite-0.22.1.tar.gz", hash = "sha256:043e0bd78d32888c0a9ca90fc788b38796843360c855a7262a532813133a0650", size = 14821, upload-time = "2025-12-23T19:25:43.997Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b7/e3bf5133d697a08128598c8d0abc5e16377b51465a33756de24fa7dee953/aiosqlite-0.22.1-py3-none-any.whl", hash = "sha256:21c002eb13823fad740196c5a2e9d8e62f6243bd9e7e4a1f87fb5e44ecb4fceb", size = 17405, upload-time = "2025-12-23T19:25:42.139Z" },
+]
 
 [[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081 }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643 },
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
 ]
 
 [[package]]
@@ -20,88 +30,179 @@ dependencies = [
     { name = "sniffio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126 }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/73/199a98fc2dae33535d6b8e8e6ec01f8c1d76c9adb096c6b7d64823038cde/anyio-4.8.0.tar.gz", hash = "sha256:1d9fe889df5212298c0c0723fa20479d1b94883a2df44bd3897aa91083316f7a", size = 181126, upload-time = "2025-01-05T13:13:11.095Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041 },
+    { url = "https://files.pythonhosted.org/packages/46/eb/e7f063ad1fec6b3178a3cd82d1a3c4de82cccf283fc42746168188e1cdd5/anyio-4.8.0-py3-none-any.whl", hash = "sha256:b5011f270ab5eb0abf13385f851315585cc37ef330dd88e27ec3d34d651fd47a", size = 96041, upload-time = "2025-01-05T13:13:07.985Z" },
+]
+
+[[package]]
+name = "attrs"
+version = "25.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
 ]
 
 [[package]]
 name = "backports-asyncio-runner"
 version = "1.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893 }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/ff/70dca7d7cb1cbc0edb2c6cc0c38b65cba36cccc491eca64cabd5fe7f8670/backports_asyncio_runner-1.2.0.tar.gz", hash = "sha256:a5aa7b2b7d8f8bfcaa2b57313f70792df84e32a2a746f585213373f900b42162", size = 69893, upload-time = "2025-07-02T02:27:15.685Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313 },
+    { url = "https://files.pythonhosted.org/packages/a0/59/76ab57e3fe74484f48a53f8e337171b4a2349e506eabe136d7e01d059086/backports_asyncio_runner-1.2.0-py3-none-any.whl", hash = "sha256:0da0a936a8aeb554eccb426dc55af3ba63bcdc69fa1a600b5bb305413a4477b5", size = 12313, upload-time = "2025-07-02T02:27:14.263Z" },
 ]
 
 [[package]]
 name = "certifi"
 version = "2025.1.31"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577 }
+sdist = { url = "https://files.pythonhosted.org/packages/1c/ab/c9f1e32b7b1bf505bf26f0ef697775960db7932abeb7b516de930ba2705f/certifi-2025.1.31.tar.gz", hash = "sha256:3d5da6925056f6f18f119200434a4780a94263f10d1c21d032a6f6b2baa20651", size = 167577, upload-time = "2025-01-31T02:16:47.166Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393 },
+    { url = "https://files.pythonhosted.org/packages/38/fc/bce832fd4fd99766c04d1ee0eead6b0ec6486fb100ae5e74c1d91292b982/certifi-2025.1.31-py3-none-any.whl", hash = "sha256:ca78db4565a652026a4db2bcdf68f2fb589ea80d0be70e03929ed730746b84fe", size = 166393, upload-time = "2025-01-31T02:16:45.015Z" },
+]
+
+[[package]]
+name = "cffi"
+version = "2.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/56/b1ba7935a17738ae8453301356628e8147c79dbb825bcbc73dc7401f9846/cffi-2.0.0.tar.gz", hash = "sha256:44d1b5909021139fe36001ae048dbdde8214afa20200eda0f64c068cac5d5529", size = 523588, upload-time = "2025-09-08T23:24:04.541Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/d7/516d984057745a6cd96575eea814fe1edd6646ee6efd552fb7b0921dec83/cffi-2.0.0-cp310-cp310-macosx_10_13_x86_64.whl", hash = "sha256:0cf2d91ecc3fcc0625c2c530fe004f82c110405f101548512cce44322fa8ac44", size = 184283, upload-time = "2025-09-08T23:22:08.01Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/84/ad6a0b408daa859246f57c03efd28e5dd1b33c21737c2db84cae8c237aa5/cffi-2.0.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:f73b96c41e3b2adedc34a7356e64c8eb96e03a3782b535e043a986276ce12a49", size = 180504, upload-time = "2025-09-08T23:22:10.637Z" },
+    { url = "https://files.pythonhosted.org/packages/50/bd/b1a6362b80628111e6653c961f987faa55262b4002fcec42308cad1db680/cffi-2.0.0-cp310-cp310-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:53f77cbe57044e88bbd5ed26ac1d0514d2acf0591dd6bb02a3ae37f76811b80c", size = 208811, upload-time = "2025-09-08T23:22:12.267Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/27/6933a8b2562d7bd1fb595074cf99cc81fc3789f6a6c05cdabb46284a3188/cffi-2.0.0-cp310-cp310-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:3e837e369566884707ddaf85fc1744b47575005c0a229de3327f8f9a20f4efeb", size = 216402, upload-time = "2025-09-08T23:22:13.455Z" },
+    { url = "https://files.pythonhosted.org/packages/05/eb/b86f2a2645b62adcfff53b0dd97e8dfafb5c8aa864bd0d9a2c2049a0d551/cffi-2.0.0-cp310-cp310-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:5eda85d6d1879e692d546a078b44251cdd08dd1cfb98dfb77b670c97cee49ea0", size = 203217, upload-time = "2025-09-08T23:22:14.596Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/e0/6cbe77a53acf5acc7c08cc186c9928864bd7c005f9efd0d126884858a5fe/cffi-2.0.0-cp310-cp310-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9332088d75dc3241c702d852d4671613136d90fa6881da7d770a483fd05248b4", size = 203079, upload-time = "2025-09-08T23:22:15.769Z" },
+    { url = "https://files.pythonhosted.org/packages/98/29/9b366e70e243eb3d14a5cb488dfd3a0b6b2f1fb001a203f653b93ccfac88/cffi-2.0.0-cp310-cp310-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fc7de24befaeae77ba923797c7c87834c73648a05a4bde34b3b7e5588973a453", size = 216475, upload-time = "2025-09-08T23:22:17.427Z" },
+    { url = "https://files.pythonhosted.org/packages/21/7a/13b24e70d2f90a322f2900c5d8e1f14fa7e2a6b3332b7309ba7b2ba51a5a/cffi-2.0.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:cf364028c016c03078a23b503f02058f1814320a56ad535686f90565636a9495", size = 218829, upload-time = "2025-09-08T23:22:19.069Z" },
+    { url = "https://files.pythonhosted.org/packages/60/99/c9dc110974c59cc981b1f5b66e1d8af8af764e00f0293266824d9c4254bc/cffi-2.0.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:e11e82b744887154b182fd3e7e8512418446501191994dbf9c9fc1f32cc8efd5", size = 211211, upload-time = "2025-09-08T23:22:20.588Z" },
+    { url = "https://files.pythonhosted.org/packages/49/72/ff2d12dbf21aca1b32a40ed792ee6b40f6dc3a9cf1644bd7ef6e95e0ac5e/cffi-2.0.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:8ea985900c5c95ce9db1745f7933eeef5d314f0565b27625d9a10ec9881e1bfb", size = 218036, upload-time = "2025-09-08T23:22:22.143Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/cc/027d7fb82e58c48ea717149b03bcadcbdc293553edb283af792bd4bcbb3f/cffi-2.0.0-cp310-cp310-win32.whl", hash = "sha256:1f72fb8906754ac8a2cc3f9f5aaa298070652a0ffae577e0ea9bd480dc3c931a", size = 172184, upload-time = "2025-09-08T23:22:23.328Z" },
+    { url = "https://files.pythonhosted.org/packages/33/fa/072dd15ae27fbb4e06b437eb6e944e75b068deb09e2a2826039e49ee2045/cffi-2.0.0-cp310-cp310-win_amd64.whl", hash = "sha256:b18a3ed7d5b3bd8d9ef7a8cb226502c6bf8308df1525e1cc676c3680e7176739", size = 182790, upload-time = "2025-09-08T23:22:24.752Z" },
+    { url = "https://files.pythonhosted.org/packages/12/4a/3dfd5f7850cbf0d06dc84ba9aa00db766b52ca38d8b86e3a38314d52498c/cffi-2.0.0-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:b4c854ef3adc177950a8dfc81a86f5115d2abd545751a304c5bcf2c2c7283cfe", size = 184344, upload-time = "2025-09-08T23:22:26.456Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/8b/f0e4c441227ba756aafbe78f117485b25bb26b1c059d01f137fa6d14896b/cffi-2.0.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:2de9a304e27f7596cd03d16f1b7c72219bd944e99cc52b84d0145aefb07cbd3c", size = 180560, upload-time = "2025-09-08T23:22:28.197Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/b7/1200d354378ef52ec227395d95c2576330fd22a869f7a70e88e1447eb234/cffi-2.0.0-cp311-cp311-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:baf5215e0ab74c16e2dd324e8ec067ef59e41125d3eade2b863d294fd5035c92", size = 209613, upload-time = "2025-09-08T23:22:29.475Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/56/6033f5e86e8cc9bb629f0077ba71679508bdf54a9a5e112a3c0b91870332/cffi-2.0.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:730cacb21e1bdff3ce90babf007d0a0917cc3e6492f336c2f0134101e0944f93", size = 216476, upload-time = "2025-09-08T23:22:31.063Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/7f/55fecd70f7ece178db2f26128ec41430d8720f2d12ca97bf8f0a628207d5/cffi-2.0.0-cp311-cp311-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:6824f87845e3396029f3820c206e459ccc91760e8fa24422f8b0c3d1731cbec5", size = 203374, upload-time = "2025-09-08T23:22:32.507Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ef/a7b77c8bdc0f77adc3b46888f1ad54be8f3b7821697a7b89126e829e676a/cffi-2.0.0-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:9de40a7b0323d889cf8d23d1ef214f565ab154443c42737dfe52ff82cf857664", size = 202597, upload-time = "2025-09-08T23:22:34.132Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/91/500d892b2bf36529a75b77958edfcd5ad8e2ce4064ce2ecfeab2125d72d1/cffi-2.0.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8941aaadaf67246224cee8c3803777eed332a19d909b47e29c9842ef1e79ac26", size = 215574, upload-time = "2025-09-08T23:22:35.443Z" },
+    { url = "https://files.pythonhosted.org/packages/44/64/58f6255b62b101093d5df22dcb752596066c7e89dd725e0afaed242a61be/cffi-2.0.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a05d0c237b3349096d3981b727493e22147f934b20f6f125a3eba8f994bec4a9", size = 218971, upload-time = "2025-09-08T23:22:36.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/49/fa72cebe2fd8a55fbe14956f9970fe8eb1ac59e5df042f603ef7c8ba0adc/cffi-2.0.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:94698a9c5f91f9d138526b48fe26a199609544591f859c870d477351dc7b2414", size = 211972, upload-time = "2025-09-08T23:22:38.436Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/28/dd0967a76aab36731b6ebfe64dec4e981aff7e0608f60c2d46b46982607d/cffi-2.0.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5fed36fccc0612a53f1d4d9a816b50a36702c28a2aa880cb8a122b3466638743", size = 217078, upload-time = "2025-09-08T23:22:39.776Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/c0/015b25184413d7ab0a410775fdb4a50fca20f5589b5dab1dbbfa3baad8ce/cffi-2.0.0-cp311-cp311-win32.whl", hash = "sha256:c649e3a33450ec82378822b3dad03cc228b8f5963c0c12fc3b1e0ab940f768a5", size = 172076, upload-time = "2025-09-08T23:22:40.95Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/8f/dc5531155e7070361eb1b7e4c1a9d896d0cb21c49f807a6c03fd63fc877e/cffi-2.0.0-cp311-cp311-win_amd64.whl", hash = "sha256:66f011380d0e49ed280c789fbd08ff0d40968ee7b665575489afa95c98196ab5", size = 182820, upload-time = "2025-09-08T23:22:42.463Z" },
+    { url = "https://files.pythonhosted.org/packages/95/5c/1b493356429f9aecfd56bc171285a4c4ac8697f76e9bbbbb105e537853a1/cffi-2.0.0-cp311-cp311-win_arm64.whl", hash = "sha256:c6638687455baf640e37344fe26d37c404db8b80d037c3d29f58fe8d1c3b194d", size = 177635, upload-time = "2025-09-08T23:22:43.623Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/47/4f61023ea636104d4f16ab488e268b93008c3d0bb76893b1b31db1f96802/cffi-2.0.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6d02d6655b0e54f54c4ef0b94eb6be0607b70853c45ce98bd278dc7de718be5d", size = 185271, upload-time = "2025-09-08T23:22:44.795Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a2/781b623f57358e360d62cdd7a8c681f074a71d445418a776eef0aadb4ab4/cffi-2.0.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:8eca2a813c1cb7ad4fb74d368c2ffbbb4789d377ee5bb8df98373c2cc0dee76c", size = 181048, upload-time = "2025-09-08T23:22:45.938Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/df/a4f0fbd47331ceeba3d37c2e51e9dfc9722498becbeec2bd8bc856c9538a/cffi-2.0.0-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:21d1152871b019407d8ac3985f6775c079416c282e431a4da6afe7aefd2bccbe", size = 212529, upload-time = "2025-09-08T23:22:47.349Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/72/12b5f8d3865bf0f87cf1404d8c374e7487dcf097a1c91c436e72e6badd83/cffi-2.0.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:b21e08af67b8a103c71a250401c78d5e0893beff75e28c53c98f4de42f774062", size = 220097, upload-time = "2025-09-08T23:22:48.677Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/95/7a135d52a50dfa7c882ab0ac17e8dc11cec9d55d2c18dda414c051c5e69e/cffi-2.0.0-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:1e3a615586f05fc4065a8b22b8152f0c1b00cdbc60596d187c2a74f9e3036e4e", size = 207983, upload-time = "2025-09-08T23:22:50.06Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/c8/15cb9ada8895957ea171c62dc78ff3e99159ee7adb13c0123c001a2546c1/cffi-2.0.0-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:81afed14892743bbe14dacb9e36d9e0e504cd204e0b165062c488942b9718037", size = 206519, upload-time = "2025-09-08T23:22:51.364Z" },
+    { url = "https://files.pythonhosted.org/packages/78/2d/7fa73dfa841b5ac06c7b8855cfc18622132e365f5b81d02230333ff26e9e/cffi-2.0.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:3e17ed538242334bf70832644a32a7aae3d83b57567f9fd60a26257e992b79ba", size = 219572, upload-time = "2025-09-08T23:22:52.902Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e0/267e57e387b4ca276b90f0434ff88b2c2241ad72b16d31836adddfd6031b/cffi-2.0.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3925dd22fa2b7699ed2617149842d2e6adde22b262fcbfada50e3d195e4b3a94", size = 222963, upload-time = "2025-09-08T23:22:54.518Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/75/1f2747525e06f53efbd878f4d03bac5b859cbc11c633d0fb81432d98a795/cffi-2.0.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:2c8f814d84194c9ea681642fd164267891702542f028a15fc97d4674b6206187", size = 221361, upload-time = "2025-09-08T23:22:55.867Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/2b/2b6435f76bfeb6bbf055596976da087377ede68df465419d192acf00c437/cffi-2.0.0-cp312-cp312-win32.whl", hash = "sha256:da902562c3e9c550df360bfa53c035b2f241fed6d9aef119048073680ace4a18", size = 172932, upload-time = "2025-09-08T23:22:57.188Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ed/13bd4418627013bec4ed6e54283b1959cf6db888048c7cf4b4c3b5b36002/cffi-2.0.0-cp312-cp312-win_amd64.whl", hash = "sha256:da68248800ad6320861f129cd9c1bf96ca849a2771a59e0344e88681905916f5", size = 183557, upload-time = "2025-09-08T23:22:58.351Z" },
+    { url = "https://files.pythonhosted.org/packages/95/31/9f7f93ad2f8eff1dbc1c3656d7ca5bfd8fb52c9d786b4dcf19b2d02217fa/cffi-2.0.0-cp312-cp312-win_arm64.whl", hash = "sha256:4671d9dd5ec934cb9a73e7ee9676f9362aba54f7f34910956b84d727b0d73fb6", size = 177762, upload-time = "2025-09-08T23:22:59.668Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/8d/a0a47a0c9e413a658623d014e91e74a50cdd2c423f7ccfd44086ef767f90/cffi-2.0.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:00bdf7acc5f795150faa6957054fbbca2439db2f775ce831222b66f192f03beb", size = 185230, upload-time = "2025-09-08T23:23:00.879Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/d2/a6c0296814556c68ee32009d9c2ad4f85f2707cdecfd7727951ec228005d/cffi-2.0.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:45d5e886156860dc35862657e1494b9bae8dfa63bf56796f2fb56e1679fc0bca", size = 181043, upload-time = "2025-09-08T23:23:02.231Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/1e/d22cc63332bd59b06481ceaac49d6c507598642e2230f201649058a7e704/cffi-2.0.0-cp313-cp313-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:07b271772c100085dd28b74fa0cd81c8fb1a3ba18b21e03d7c27f3436a10606b", size = 212446, upload-time = "2025-09-08T23:23:03.472Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/f5/a2c23eb03b61a0b8747f211eb716446c826ad66818ddc7810cc2cc19b3f2/cffi-2.0.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d48a880098c96020b02d5a1f7d9251308510ce8858940e6fa99ece33f610838b", size = 220101, upload-time = "2025-09-08T23:23:04.792Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7f/e6647792fc5850d634695bc0e6ab4111ae88e89981d35ac269956605feba/cffi-2.0.0-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f93fd8e5c8c0a4aa1f424d6173f14a892044054871c771f8566e4008eaa359d2", size = 207948, upload-time = "2025-09-08T23:23:06.127Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/1e/a5a1bd6f1fb30f22573f76533de12a00bf274abcdc55c8edab639078abb6/cffi-2.0.0-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:dd4f05f54a52fb558f1ba9f528228066954fee3ebe629fc1660d874d040ae5a3", size = 206422, upload-time = "2025-09-08T23:23:07.753Z" },
+    { url = "https://files.pythonhosted.org/packages/98/df/0a1755e750013a2081e863e7cd37e0cdd02664372c754e5560099eb7aa44/cffi-2.0.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c8d3b5532fc71b7a77c09192b4a5a200ea992702734a2e9279a37f2478236f26", size = 219499, upload-time = "2025-09-08T23:23:09.648Z" },
+    { url = "https://files.pythonhosted.org/packages/50/e1/a969e687fcf9ea58e6e2a928ad5e2dd88cc12f6f0ab477e9971f2309b57c/cffi-2.0.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:d9b29c1f0ae438d5ee9acb31cadee00a58c46cc9c0b2f9038c6b0b3470877a8c", size = 222928, upload-time = "2025-09-08T23:23:10.928Z" },
+    { url = "https://files.pythonhosted.org/packages/36/54/0362578dd2c9e557a28ac77698ed67323ed5b9775ca9d3fe73fe191bb5d8/cffi-2.0.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6d50360be4546678fc1b79ffe7a66265e28667840010348dd69a314145807a1b", size = 221302, upload-time = "2025-09-08T23:23:12.42Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/6d/bf9bda840d5f1dfdbf0feca87fbdb64a918a69bca42cfa0ba7b137c48cb8/cffi-2.0.0-cp313-cp313-win32.whl", hash = "sha256:74a03b9698e198d47562765773b4a8309919089150a0bb17d829ad7b44b60d27", size = 172909, upload-time = "2025-09-08T23:23:14.32Z" },
+    { url = "https://files.pythonhosted.org/packages/37/18/6519e1ee6f5a1e579e04b9ddb6f1676c17368a7aba48299c3759bbc3c8b3/cffi-2.0.0-cp313-cp313-win_amd64.whl", hash = "sha256:19f705ada2530c1167abacb171925dd886168931e0a7b78f5bffcae5c6b5be75", size = 183402, upload-time = "2025-09-08T23:23:15.535Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/0e/02ceeec9a7d6ee63bb596121c2c8e9b3a9e150936f4fbef6ca1943e6137c/cffi-2.0.0-cp313-cp313-win_arm64.whl", hash = "sha256:256f80b80ca3853f90c21b23ee78cd008713787b1b1e93eae9f3d6a7134abd91", size = 177780, upload-time = "2025-09-08T23:23:16.761Z" },
+    { url = "https://files.pythonhosted.org/packages/92/c4/3ce07396253a83250ee98564f8d7e9789fab8e58858f35d07a9a2c78de9f/cffi-2.0.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:fc33c5141b55ed366cfaad382df24fe7dcbc686de5be719b207bb248e3053dc5", size = 185320, upload-time = "2025-09-08T23:23:18.087Z" },
+    { url = "https://files.pythonhosted.org/packages/59/dd/27e9fa567a23931c838c6b02d0764611c62290062a6d4e8ff7863daf9730/cffi-2.0.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c654de545946e0db659b3400168c9ad31b5d29593291482c43e3564effbcee13", size = 181487, upload-time = "2025-09-08T23:23:19.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/43/0e822876f87ea8a4ef95442c3d766a06a51fc5298823f884ef87aaad168c/cffi-2.0.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:24b6f81f1983e6df8db3adc38562c83f7d4a0c36162885ec7f7b77c7dcbec97b", size = 220049, upload-time = "2025-09-08T23:23:20.853Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/89/76799151d9c2d2d1ead63c2429da9ea9d7aac304603de0c6e8764e6e8e70/cffi-2.0.0-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:12873ca6cb9b0f0d3a0da705d6086fe911591737a59f28b7936bdfed27c0d47c", size = 207793, upload-time = "2025-09-08T23:23:22.08Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/dd/3465b14bb9e24ee24cb88c9e3730f6de63111fffe513492bf8c808a3547e/cffi-2.0.0-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:d9b97165e8aed9272a6bb17c01e3cc5871a594a446ebedc996e2397a1c1ea8ef", size = 206300, upload-time = "2025-09-08T23:23:23.314Z" },
+    { url = "https://files.pythonhosted.org/packages/47/d9/d83e293854571c877a92da46fdec39158f8d7e68da75bf73581225d28e90/cffi-2.0.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:afb8db5439b81cf9c9d0c80404b60c3cc9c3add93e114dcae767f1477cb53775", size = 219244, upload-time = "2025-09-08T23:23:24.541Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0f/1f177e3683aead2bb00f7679a16451d302c436b5cbf2505f0ea8146ef59e/cffi-2.0.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:737fe7d37e1a1bffe70bd5754ea763a62a066dc5913ca57e957824b72a85e205", size = 222828, upload-time = "2025-09-08T23:23:26.143Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/0f/cafacebd4b040e3119dcb32fed8bdef8dfe94da653155f9d0b9dc660166e/cffi-2.0.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:38100abb9d1b1435bc4cc340bb4489635dc2f0da7456590877030c9b3d40b0c1", size = 220926, upload-time = "2025-09-08T23:23:27.873Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/aa/df335faa45b395396fcbc03de2dfcab242cd61a9900e914fe682a59170b1/cffi-2.0.0-cp314-cp314-win32.whl", hash = "sha256:087067fa8953339c723661eda6b54bc98c5625757ea62e95eb4898ad5e776e9f", size = 175328, upload-time = "2025-09-08T23:23:44.61Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/92/882c2d30831744296ce713f0feb4c1cd30f346ef747b530b5318715cc367/cffi-2.0.0-cp314-cp314-win_amd64.whl", hash = "sha256:203a48d1fb583fc7d78a4c6655692963b860a417c0528492a6bc21f1aaefab25", size = 185650, upload-time = "2025-09-08T23:23:45.848Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/2c/98ece204b9d35a7366b5b2c6539c350313ca13932143e79dc133ba757104/cffi-2.0.0-cp314-cp314-win_arm64.whl", hash = "sha256:dbd5c7a25a7cb98f5ca55d258b103a2054f859a46ae11aaf23134f9cc0d356ad", size = 180687, upload-time = "2025-09-08T23:23:47.105Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/61/c768e4d548bfa607abcda77423448df8c471f25dbe64fb2ef6d555eae006/cffi-2.0.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:9a67fc9e8eb39039280526379fb3a70023d77caec1852002b4da7e8b270c4dd9", size = 188773, upload-time = "2025-09-08T23:23:29.347Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ea/5f76bce7cf6fcd0ab1a1058b5af899bfbef198bea4d5686da88471ea0336/cffi-2.0.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:7a66c7204d8869299919db4d5069a82f1561581af12b11b3c9f48c584eb8743d", size = 185013, upload-time = "2025-09-08T23:23:30.63Z" },
+    { url = "https://files.pythonhosted.org/packages/be/b4/c56878d0d1755cf9caa54ba71e5d049479c52f9e4afc230f06822162ab2f/cffi-2.0.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7cc09976e8b56f8cebd752f7113ad07752461f48a58cbba644139015ac24954c", size = 221593, upload-time = "2025-09-08T23:23:31.91Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/0d/eb704606dfe8033e7128df5e90fee946bbcb64a04fcdaa97321309004000/cffi-2.0.0-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:92b68146a71df78564e4ef48af17551a5ddd142e5190cdf2c5624d0c3ff5b2e8", size = 209354, upload-time = "2025-09-08T23:23:33.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/19/3c435d727b368ca475fb8742ab97c9cb13a0de600ce86f62eab7fa3eea60/cffi-2.0.0-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b1e74d11748e7e98e2f426ab176d4ed720a64412b6a15054378afdb71e0f37dc", size = 208480, upload-time = "2025-09-08T23:23:34.495Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/44/681604464ed9541673e486521497406fadcc15b5217c3e326b061696899a/cffi-2.0.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:28a3a209b96630bca57cce802da70c266eb08c6e97e5afd61a75611ee6c64592", size = 221584, upload-time = "2025-09-08T23:23:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/25/8e/342a504ff018a2825d395d44d63a767dd8ebc927ebda557fecdaca3ac33a/cffi-2.0.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7553fb2090d71822f02c629afe6042c299edf91ba1bf94951165613553984512", size = 224443, upload-time = "2025-09-08T23:23:37.328Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/5e/b666bacbbc60fbf415ba9988324a132c9a7a0448a9a8f125074671c0f2c3/cffi-2.0.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6c6c373cfc5c83a975506110d17457138c8c63016b563cc9ed6e056a82f13ce4", size = 223437, upload-time = "2025-09-08T23:23:38.945Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
 ]
 
 [[package]]
 name = "charset-normalizer"
 version = "3.4.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188 }
+sdist = { url = "https://files.pythonhosted.org/packages/16/b0/572805e227f01586461c80e0fd25d65a2115599cc9dad142fee4b747c357/charset_normalizer-3.4.1.tar.gz", hash = "sha256:44251f18cd68a75b56585dd00dae26183e102cd5e0f9f1466e6df5da2ed64ea3", size = 123188, upload-time = "2024-12-24T18:12:35.43Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/58/5580c1716040bc89206c77d8f74418caf82ce519aae06450393ca73475d1/charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de", size = 198013 },
-    { url = "https://files.pythonhosted.org/packages/d0/11/00341177ae71c6f5159a08168bcb98c6e6d196d372c94511f9f6c9afe0c6/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176", size = 141285 },
-    { url = "https://files.pythonhosted.org/packages/01/09/11d684ea5819e5a8f5100fb0b38cf8d02b514746607934134d31233e02c8/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037", size = 151449 },
-    { url = "https://files.pythonhosted.org/packages/08/06/9f5a12939db324d905dc1f70591ae7d7898d030d7662f0d426e2286f68c9/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f", size = 143892 },
-    { url = "https://files.pythonhosted.org/packages/93/62/5e89cdfe04584cb7f4d36003ffa2936681b03ecc0754f8e969c2becb7e24/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a", size = 146123 },
-    { url = "https://files.pythonhosted.org/packages/a9/ac/ab729a15c516da2ab70a05f8722ecfccc3f04ed7a18e45c75bbbaa347d61/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a", size = 147943 },
-    { url = "https://files.pythonhosted.org/packages/03/d2/3f392f23f042615689456e9a274640c1d2e5dd1d52de36ab8f7955f8f050/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247", size = 142063 },
-    { url = "https://files.pythonhosted.org/packages/f2/e3/e20aae5e1039a2cd9b08d9205f52142329f887f8cf70da3650326670bddf/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408", size = 150578 },
-    { url = "https://files.pythonhosted.org/packages/8d/af/779ad72a4da0aed925e1139d458adc486e61076d7ecdcc09e610ea8678db/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb", size = 153629 },
-    { url = "https://files.pythonhosted.org/packages/c2/b6/7aa450b278e7aa92cf7732140bfd8be21f5f29d5bf334ae987c945276639/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d", size = 150778 },
-    { url = "https://files.pythonhosted.org/packages/39/f4/d9f4f712d0951dcbfd42920d3db81b00dd23b6ab520419626f4023334056/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807", size = 146453 },
-    { url = "https://files.pythonhosted.org/packages/49/2b/999d0314e4ee0cff3cb83e6bc9aeddd397eeed693edb4facb901eb8fbb69/charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f", size = 95479 },
-    { url = "https://files.pythonhosted.org/packages/2d/ce/3cbed41cff67e455a386fb5e5dd8906cdda2ed92fbc6297921f2e4419309/charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f", size = 102790 },
-    { url = "https://files.pythonhosted.org/packages/72/80/41ef5d5a7935d2d3a773e3eaebf0a9350542f2cab4eac59a7a4741fbbbbe/charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125", size = 194995 },
-    { url = "https://files.pythonhosted.org/packages/7a/28/0b9fefa7b8b080ec492110af6d88aa3dea91c464b17d53474b6e9ba5d2c5/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1", size = 139471 },
-    { url = "https://files.pythonhosted.org/packages/71/64/d24ab1a997efb06402e3fc07317e94da358e2585165930d9d59ad45fcae2/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3", size = 149831 },
-    { url = "https://files.pythonhosted.org/packages/37/ed/be39e5258e198655240db5e19e0b11379163ad7070962d6b0c87ed2c4d39/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd", size = 142335 },
-    { url = "https://files.pythonhosted.org/packages/88/83/489e9504711fa05d8dde1574996408026bdbdbd938f23be67deebb5eca92/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00", size = 143862 },
-    { url = "https://files.pythonhosted.org/packages/c6/c7/32da20821cf387b759ad24627a9aca289d2822de929b8a41b6241767b461/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12", size = 145673 },
-    { url = "https://files.pythonhosted.org/packages/68/85/f4288e96039abdd5aeb5c546fa20a37b50da71b5cf01e75e87f16cd43304/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77", size = 140211 },
-    { url = "https://files.pythonhosted.org/packages/28/a3/a42e70d03cbdabc18997baf4f0227c73591a08041c149e710045c281f97b/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146", size = 148039 },
-    { url = "https://files.pythonhosted.org/packages/85/e4/65699e8ab3014ecbe6f5c71d1a55d810fb716bbfd74f6283d5c2aa87febf/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd", size = 151939 },
-    { url = "https://files.pythonhosted.org/packages/b1/82/8e9fe624cc5374193de6860aba3ea8070f584c8565ee77c168ec13274bd2/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6", size = 149075 },
-    { url = "https://files.pythonhosted.org/packages/3d/7b/82865ba54c765560c8433f65e8acb9217cb839a9e32b42af4aa8e945870f/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8", size = 144340 },
-    { url = "https://files.pythonhosted.org/packages/b5/b6/9674a4b7d4d99a0d2df9b215da766ee682718f88055751e1e5e753c82db0/charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b", size = 95205 },
-    { url = "https://files.pythonhosted.org/packages/1e/ab/45b180e175de4402dcf7547e4fb617283bae54ce35c27930a6f35b6bef15/charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76", size = 102441 },
-    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105 },
-    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404 },
-    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423 },
-    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184 },
-    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268 },
-    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601 },
-    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098 },
-    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520 },
-    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852 },
-    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488 },
-    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192 },
-    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550 },
-    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785 },
-    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698 },
-    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162 },
-    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263 },
-    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966 },
-    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992 },
-    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162 },
-    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972 },
-    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095 },
-    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668 },
-    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073 },
-    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732 },
-    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391 },
-    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702 },
-    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767 },
+    { url = "https://files.pythonhosted.org/packages/0d/58/5580c1716040bc89206c77d8f74418caf82ce519aae06450393ca73475d1/charset_normalizer-3.4.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:91b36a978b5ae0ee86c394f5a54d6ef44db1de0815eb43de826d41d21e4af3de", size = 198013, upload-time = "2024-12-24T18:09:43.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/11/00341177ae71c6f5159a08168bcb98c6e6d196d372c94511f9f6c9afe0c6/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7461baadb4dc00fd9e0acbe254e3d7d2112e7f92ced2adc96e54ef6501c5f176", size = 141285, upload-time = "2024-12-24T18:09:48.113Z" },
+    { url = "https://files.pythonhosted.org/packages/01/09/11d684ea5819e5a8f5100fb0b38cf8d02b514746607934134d31233e02c8/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e218488cd232553829be0664c2292d3af2eeeb94b32bea483cf79ac6a694e037", size = 151449, upload-time = "2024-12-24T18:09:50.845Z" },
+    { url = "https://files.pythonhosted.org/packages/08/06/9f5a12939db324d905dc1f70591ae7d7898d030d7662f0d426e2286f68c9/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:80ed5e856eb7f30115aaf94e4a08114ccc8813e6ed1b5efa74f9f82e8509858f", size = 143892, upload-time = "2024-12-24T18:09:52.078Z" },
+    { url = "https://files.pythonhosted.org/packages/93/62/5e89cdfe04584cb7f4d36003ffa2936681b03ecc0754f8e969c2becb7e24/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b010a7a4fd316c3c484d482922d13044979e78d1861f0e0650423144c616a46a", size = 146123, upload-time = "2024-12-24T18:09:54.575Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/ac/ab729a15c516da2ab70a05f8722ecfccc3f04ed7a18e45c75bbbaa347d61/charset_normalizer-3.4.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4532bff1b8421fd0a320463030c7520f56a79c9024a4e88f01c537316019005a", size = 147943, upload-time = "2024-12-24T18:09:57.324Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d2/3f392f23f042615689456e9a274640c1d2e5dd1d52de36ab8f7955f8f050/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:d973f03c0cb71c5ed99037b870f2be986c3c05e63622c017ea9816881d2dd247", size = 142063, upload-time = "2024-12-24T18:09:59.794Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e3/e20aae5e1039a2cd9b08d9205f52142329f887f8cf70da3650326670bddf/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:3a3bd0dcd373514dcec91c411ddb9632c0d7d92aed7093b8c3bbb6d69ca74408", size = 150578, upload-time = "2024-12-24T18:10:02.357Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/af/779ad72a4da0aed925e1139d458adc486e61076d7ecdcc09e610ea8678db/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_ppc64le.whl", hash = "sha256:d9c3cdf5390dcd29aa8056d13e8e99526cda0305acc038b96b30352aff5ff2bb", size = 153629, upload-time = "2024-12-24T18:10:03.678Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/7aa450b278e7aa92cf7732140bfd8be21f5f29d5bf334ae987c945276639/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_s390x.whl", hash = "sha256:2bdfe3ac2e1bbe5b59a1a63721eb3b95fc9b6817ae4a46debbb4e11f6232428d", size = 150778, upload-time = "2024-12-24T18:10:06.197Z" },
+    { url = "https://files.pythonhosted.org/packages/39/f4/d9f4f712d0951dcbfd42920d3db81b00dd23b6ab520419626f4023334056/charset_normalizer-3.4.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:eab677309cdb30d047996b36d34caeda1dc91149e4fdca0b1a039b3f79d9a807", size = 146453, upload-time = "2024-12-24T18:10:08.848Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2b/999d0314e4ee0cff3cb83e6bc9aeddd397eeed693edb4facb901eb8fbb69/charset_normalizer-3.4.1-cp310-cp310-win32.whl", hash = "sha256:c0429126cf75e16c4f0ad00ee0eae4242dc652290f940152ca8c75c3a4b6ee8f", size = 95479, upload-time = "2024-12-24T18:10:10.044Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/ce/3cbed41cff67e455a386fb5e5dd8906cdda2ed92fbc6297921f2e4419309/charset_normalizer-3.4.1-cp310-cp310-win_amd64.whl", hash = "sha256:9f0b8b1c6d84c8034a44893aba5e767bf9c7a211e313a9605d9c617d7083829f", size = 102790, upload-time = "2024-12-24T18:10:11.323Z" },
+    { url = "https://files.pythonhosted.org/packages/72/80/41ef5d5a7935d2d3a773e3eaebf0a9350542f2cab4eac59a7a4741fbbbbe/charset_normalizer-3.4.1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:8bfa33f4f2672964266e940dd22a195989ba31669bd84629f05fab3ef4e2d125", size = 194995, upload-time = "2024-12-24T18:10:12.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/28/0b9fefa7b8b080ec492110af6d88aa3dea91c464b17d53474b6e9ba5d2c5/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:28bf57629c75e810b6ae989f03c0828d64d6b26a5e205535585f96093e405ed1", size = 139471, upload-time = "2024-12-24T18:10:14.101Z" },
+    { url = "https://files.pythonhosted.org/packages/71/64/d24ab1a997efb06402e3fc07317e94da358e2585165930d9d59ad45fcae2/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f08ff5e948271dc7e18a35641d2f11a4cd8dfd5634f55228b691e62b37125eb3", size = 149831, upload-time = "2024-12-24T18:10:15.512Z" },
+    { url = "https://files.pythonhosted.org/packages/37/ed/be39e5258e198655240db5e19e0b11379163ad7070962d6b0c87ed2c4d39/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:234ac59ea147c59ee4da87a0c0f098e9c8d169f4dc2a159ef720f1a61bbe27cd", size = 142335, upload-time = "2024-12-24T18:10:18.369Z" },
+    { url = "https://files.pythonhosted.org/packages/88/83/489e9504711fa05d8dde1574996408026bdbdbd938f23be67deebb5eca92/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:fd4ec41f914fa74ad1b8304bbc634b3de73d2a0889bd32076342a573e0779e00", size = 143862, upload-time = "2024-12-24T18:10:19.743Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/c7/32da20821cf387b759ad24627a9aca289d2822de929b8a41b6241767b461/charset_normalizer-3.4.1-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:eea6ee1db730b3483adf394ea72f808b6e18cf3cb6454b4d86e04fa8c4327a12", size = 145673, upload-time = "2024-12-24T18:10:21.139Z" },
+    { url = "https://files.pythonhosted.org/packages/68/85/f4288e96039abdd5aeb5c546fa20a37b50da71b5cf01e75e87f16cd43304/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c96836c97b1238e9c9e3fe90844c947d5afbf4f4c92762679acfe19927d81d77", size = 140211, upload-time = "2024-12-24T18:10:22.382Z" },
+    { url = "https://files.pythonhosted.org/packages/28/a3/a42e70d03cbdabc18997baf4f0227c73591a08041c149e710045c281f97b/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:4d86f7aff21ee58f26dcf5ae81a9addbd914115cdebcbb2217e4f0ed8982e146", size = 148039, upload-time = "2024-12-24T18:10:24.802Z" },
+    { url = "https://files.pythonhosted.org/packages/85/e4/65699e8ab3014ecbe6f5c71d1a55d810fb716bbfd74f6283d5c2aa87febf/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_ppc64le.whl", hash = "sha256:09b5e6733cbd160dcc09589227187e242a30a49ca5cefa5a7edd3f9d19ed53fd", size = 151939, upload-time = "2024-12-24T18:10:26.124Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/82/8e9fe624cc5374193de6860aba3ea8070f584c8565ee77c168ec13274bd2/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_s390x.whl", hash = "sha256:5777ee0881f9499ed0f71cc82cf873d9a0ca8af166dfa0af8ec4e675b7df48e6", size = 149075, upload-time = "2024-12-24T18:10:30.027Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/7b/82865ba54c765560c8433f65e8acb9217cb839a9e32b42af4aa8e945870f/charset_normalizer-3.4.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:237bdbe6159cff53b4f24f397d43c6336c6b0b42affbe857970cefbb620911c8", size = 144340, upload-time = "2024-12-24T18:10:32.679Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/b6/9674a4b7d4d99a0d2df9b215da766ee682718f88055751e1e5e753c82db0/charset_normalizer-3.4.1-cp311-cp311-win32.whl", hash = "sha256:8417cb1f36cc0bc7eaba8ccb0e04d55f0ee52df06df3ad55259b9a323555fc8b", size = 95205, upload-time = "2024-12-24T18:10:34.724Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/ab/45b180e175de4402dcf7547e4fb617283bae54ce35c27930a6f35b6bef15/charset_normalizer-3.4.1-cp311-cp311-win_amd64.whl", hash = "sha256:d7f50a1f8c450f3925cb367d011448c39239bb3eb4117c36a6d354794de4ce76", size = 102441, upload-time = "2024-12-24T18:10:37.574Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/9a/dd1e1cdceb841925b7798369a09279bd1cf183cef0f9ddf15a3a6502ee45/charset_normalizer-3.4.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:73d94b58ec7fecbc7366247d3b0b10a21681004153238750bb67bd9012414545", size = 196105, upload-time = "2024-12-24T18:10:38.83Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8c/90bfabf8c4809ecb648f39794cf2a84ff2e7d2a6cf159fe68d9a26160467/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dad3e487649f498dd991eeb901125411559b22e8d7ab25d3aeb1af367df5efd7", size = 140404, upload-time = "2024-12-24T18:10:44.272Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/8f/e410d57c721945ea3b4f1a04b74f70ce8fa800d393d72899f0a40526401f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c30197aa96e8eed02200a83fba2657b4c3acd0f0aa4bdc9f6c1af8e8962e0757", size = 150423, upload-time = "2024-12-24T18:10:45.492Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/b8/e6825e25deb691ff98cf5c9072ee0605dc2acfca98af70c2d1b1bc75190d/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2369eea1ee4a7610a860d88f268eb39b95cb588acd7235e02fd5a5601773d4fa", size = 143184, upload-time = "2024-12-24T18:10:47.898Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/a2/513f6cbe752421f16d969e32f3583762bfd583848b763913ddab8d9bfd4f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bc2722592d8998c870fa4e290c2eec2c1569b87fe58618e67d38b4665dfa680d", size = 145268, upload-time = "2024-12-24T18:10:50.589Z" },
+    { url = "https://files.pythonhosted.org/packages/74/94/8a5277664f27c3c438546f3eb53b33f5b19568eb7424736bdc440a88a31f/charset_normalizer-3.4.1-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ffc9202a29ab3920fa812879e95a9e78b2465fd10be7fcbd042899695d75e616", size = 147601, upload-time = "2024-12-24T18:10:52.541Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/5f/6d352c51ee763623a98e31194823518e09bfa48be2a7e8383cf691bbb3d0/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:804a4d582ba6e5b747c625bf1255e6b1507465494a40a2130978bda7b932c90b", size = 141098, upload-time = "2024-12-24T18:10:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/78/d4/f5704cb629ba5ab16d1d3d741396aec6dc3ca2b67757c45b0599bb010478/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:0f55e69f030f7163dffe9fd0752b32f070566451afe180f99dbeeb81f511ad8d", size = 149520, upload-time = "2024-12-24T18:10:55.048Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/96/64120b1d02b81785f222b976c0fb79a35875457fa9bb40827678e54d1bc8/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:c4c3e6da02df6fa1410a7680bd3f63d4f710232d3139089536310d027950696a", size = 152852, upload-time = "2024-12-24T18:10:57.647Z" },
+    { url = "https://files.pythonhosted.org/packages/84/c9/98e3732278a99f47d487fd3468bc60b882920cef29d1fa6ca460a1fdf4e6/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:5df196eb874dae23dcfb968c83d4f8fdccb333330fe1fc278ac5ceeb101003a9", size = 150488, upload-time = "2024-12-24T18:10:59.43Z" },
+    { url = "https://files.pythonhosted.org/packages/13/0e/9c8d4cb99c98c1007cc11eda969ebfe837bbbd0acdb4736d228ccaabcd22/charset_normalizer-3.4.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e358e64305fe12299a08e08978f51fc21fac060dcfcddd95453eabe5b93ed0e1", size = 146192, upload-time = "2024-12-24T18:11:00.676Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/21/2b6b5b860781a0b49427309cb8670785aa543fb2178de875b87b9cc97746/charset_normalizer-3.4.1-cp312-cp312-win32.whl", hash = "sha256:9b23ca7ef998bc739bf6ffc077c2116917eabcc901f88da1b9856b210ef63f35", size = 95550, upload-time = "2024-12-24T18:11:01.952Z" },
+    { url = "https://files.pythonhosted.org/packages/21/5b/1b390b03b1d16c7e382b561c5329f83cc06623916aab983e8ab9239c7d5c/charset_normalizer-3.4.1-cp312-cp312-win_amd64.whl", hash = "sha256:6ff8a4a60c227ad87030d76e99cd1698345d4491638dfa6673027c48b3cd395f", size = 102785, upload-time = "2024-12-24T18:11:03.142Z" },
+    { url = "https://files.pythonhosted.org/packages/38/94/ce8e6f63d18049672c76d07d119304e1e2d7c6098f0841b51c666e9f44a0/charset_normalizer-3.4.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:aabfa34badd18f1da5ec1bc2715cadc8dca465868a4e73a0173466b688f29dda", size = 195698, upload-time = "2024-12-24T18:11:05.834Z" },
+    { url = "https://files.pythonhosted.org/packages/24/2e/dfdd9770664aae179a96561cc6952ff08f9a8cd09a908f259a9dfa063568/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:22e14b5d70560b8dd51ec22863f370d1e595ac3d024cb8ad7d308b4cd95f8313", size = 140162, upload-time = "2024-12-24T18:11:07.064Z" },
+    { url = "https://files.pythonhosted.org/packages/24/4e/f646b9093cff8fc86f2d60af2de4dc17c759de9d554f130b140ea4738ca6/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8436c508b408b82d87dc5f62496973a1805cd46727c34440b0d29d8a2f50a6c9", size = 150263, upload-time = "2024-12-24T18:11:08.374Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/67/2937f8d548c3ef6e2f9aab0f6e21001056f692d43282b165e7c56023e6dd/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2d074908e1aecee37a7635990b2c6d504cd4766c7bc9fc86d63f9c09af3fa11b", size = 142966, upload-time = "2024-12-24T18:11:09.831Z" },
+    { url = "https://files.pythonhosted.org/packages/52/ed/b7f4f07de100bdb95c1756d3a4d17b90c1a3c53715c1a476f8738058e0fa/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:955f8851919303c92343d2f66165294848d57e9bba6cf6e3625485a70a038d11", size = 144992, upload-time = "2024-12-24T18:11:12.03Z" },
+    { url = "https://files.pythonhosted.org/packages/96/2c/d49710a6dbcd3776265f4c923bb73ebe83933dfbaa841c5da850fe0fd20b/charset_normalizer-3.4.1-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:44ecbf16649486d4aebafeaa7ec4c9fed8b88101f4dd612dcaf65d5e815f837f", size = 147162, upload-time = "2024-12-24T18:11:13.372Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/41/35ff1f9a6bd380303dea55e44c4933b4cc3c4850988927d4082ada230273/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:0924e81d3d5e70f8126529951dac65c1010cdf117bb75eb02dd12339b57749dd", size = 140972, upload-time = "2024-12-24T18:11:14.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/43/c6a0b685fe6910d08ba971f62cd9c3e862a85770395ba5d9cad4fede33ab/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:2967f74ad52c3b98de4c3b32e1a44e32975e008a9cd2a8cc8966d6a5218c5cb2", size = 149095, upload-time = "2024-12-24T18:11:17.672Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/ff/a9a504662452e2d2878512115638966e75633519ec11f25fca3d2049a94a/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:c75cb2a3e389853835e84a2d8fb2b81a10645b503eca9bcb98df6b5a43eb8886", size = 152668, upload-time = "2024-12-24T18:11:18.989Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/71/189996b6d9a4b932564701628af5cee6716733e9165af1d5e1b285c530ed/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:09b26ae6b1abf0d27570633b2b078a2a20419c99d66fb2823173d73f188ce601", size = 150073, upload-time = "2024-12-24T18:11:21.507Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/93/946a86ce20790e11312c87c75ba68d5f6ad2208cfb52b2d6a2c32840d922/charset_normalizer-3.4.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:fa88b843d6e211393a37219e6a1c1df99d35e8fd90446f1118f4216e307e48cd", size = 145732, upload-time = "2024-12-24T18:11:22.774Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/e5/131d2fb1b0dddafc37be4f3a2fa79aa4c037368be9423061dccadfd90091/charset_normalizer-3.4.1-cp313-cp313-win32.whl", hash = "sha256:eb8178fe3dba6450a3e024e95ac49ed3400e506fd4e9e5c32d30adda88cbd407", size = 95391, upload-time = "2024-12-24T18:11:24.139Z" },
+    { url = "https://files.pythonhosted.org/packages/27/f2/4f9a69cc7712b9b5ad8fdb87039fd89abba997ad5cbe690d1835d40405b0/charset_normalizer-3.4.1-cp313-cp313-win_amd64.whl", hash = "sha256:b1ac5992a838106edb89654e0aebfc24f5848ae2547d22c2c3f66454daa11971", size = 102702, upload-time = "2024-12-24T18:11:26.535Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/f6/65ecc6878a89bb1c23a086ea335ad4bf21a588990c3f535a227b9eea9108/charset_normalizer-3.4.1-py3-none-any.whl", hash = "sha256:d98b1668f06378c6dbefec3b92299716b931cd4e6061f3c875a71ced1780ab85", size = 49767, upload-time = "2024-12-24T18:12:32.852Z" },
 ]
 
 [[package]]
@@ -109,20 +210,80 @@ name = "click"
 version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "colorama", marker = "platform_system == 'Windows'" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593, upload-time = "2024-12-21T18:38:44.339Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188, upload-time = "2024-12-21T18:38:41.666Z" },
 ]
 
 [[package]]
 name = "colorama"
 version = "0.4.6"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335 },
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "46.0.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/04/ee2a9e8542e4fa2773b81771ff8349ff19cdd56b7258a0cc442639052edb/cryptography-46.0.5.tar.gz", hash = "sha256:abace499247268e3757271b2f1e244b36b06f8515cf27c4d49468fc9eb16e93d", size = 750064, upload-time = "2026-02-10T19:18:38.255Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f7/81/b0bb27f2ba931a65409c6b8a8b358a7f03c0e46eceacddff55f7c84b1f3b/cryptography-46.0.5-cp311-abi3-macosx_10_9_universal2.whl", hash = "sha256:351695ada9ea9618b3500b490ad54c739860883df6c1f555e088eaf25b1bbaad", size = 7176289, upload-time = "2026-02-10T19:17:08.274Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/9e/6b4397a3e3d15123de3b1806ef342522393d50736c13b20ec4c9ea6693a6/cryptography-46.0.5-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:c18ff11e86df2e28854939acde2d003f7984f721eba450b56a200ad90eeb0e6b", size = 4275637, upload-time = "2026-02-10T19:17:10.53Z" },
+    { url = "https://files.pythonhosted.org/packages/63/e7/471ab61099a3920b0c77852ea3f0ea611c9702f651600397ac567848b897/cryptography-46.0.5-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d7e3d356b8cd4ea5aff04f129d5f66ebdc7b6f8eae802b93739ed520c47c79b", size = 4424742, upload-time = "2026-02-10T19:17:12.388Z" },
+    { url = "https://files.pythonhosted.org/packages/37/53/a18500f270342d66bf7e4d9f091114e31e5ee9e7375a5aba2e85a91e0044/cryptography-46.0.5-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:50bfb6925eff619c9c023b967d5b77a54e04256c4281b0e21336a130cd7fc263", size = 4277528, upload-time = "2026-02-10T19:17:13.853Z" },
+    { url = "https://files.pythonhosted.org/packages/22/29/c2e812ebc38c57b40e7c583895e73c8c5adb4d1e4a0cc4c5a4fdab2b1acc/cryptography-46.0.5-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:803812e111e75d1aa73690d2facc295eaefd4439be1023fefc4995eaea2af90d", size = 4947993, upload-time = "2026-02-10T19:17:15.618Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/e7/237155ae19a9023de7e30ec64e5d99a9431a567407ac21170a046d22a5a3/cryptography-46.0.5-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ee190460e2fbe447175cda91b88b84ae8322a104fc27766ad09428754a618ed", size = 4456855, upload-time = "2026-02-10T19:17:17.221Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/87/fc628a7ad85b81206738abbd213b07702bcbdada1dd43f72236ef3cffbb5/cryptography-46.0.5-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:f145bba11b878005c496e93e257c1e88f154d278d2638e6450d17e0f31e558d2", size = 3984635, upload-time = "2026-02-10T19:17:18.792Z" },
+    { url = "https://files.pythonhosted.org/packages/84/29/65b55622bde135aedf4565dc509d99b560ee4095e56989e815f8fd2aa910/cryptography-46.0.5-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:e9251e3be159d1020c4030bd2e5f84d6a43fe54b6c19c12f51cde9542a2817b2", size = 4277038, upload-time = "2026-02-10T19:17:20.256Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/36/45e76c68d7311432741faf1fbf7fac8a196a0a735ca21f504c75d37e2558/cryptography-46.0.5-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:47fb8a66058b80e509c47118ef8a75d14c455e81ac369050f20ba0d23e77fee0", size = 4912181, upload-time = "2026-02-10T19:17:21.825Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/1a/c1ba8fead184d6e3d5afcf03d569acac5ad063f3ac9fb7258af158f7e378/cryptography-46.0.5-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:4c3341037c136030cb46e4b1e17b7418ea4cbd9dd207e4a6f3b2b24e0d4ac731", size = 4456482, upload-time = "2026-02-10T19:17:25.133Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/e5/3fb22e37f66827ced3b902cf895e6a6bc1d095b5b26be26bd13c441fdf19/cryptography-46.0.5-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:890bcb4abd5a2d3f852196437129eb3667d62630333aacc13dfd470fad3aaa82", size = 4405497, upload-time = "2026-02-10T19:17:26.66Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/df/9d58bb32b1121a8a2f27383fabae4d63080c7ca60b9b5c88be742be04ee7/cryptography-46.0.5-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:80a8d7bfdf38f87ca30a5391c0c9ce4ed2926918e017c29ddf643d0ed2778ea1", size = 4667819, upload-time = "2026-02-10T19:17:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/ed/325d2a490c5e94038cdb0117da9397ece1f11201f425c4e9c57fe5b9f08b/cryptography-46.0.5-cp311-abi3-win32.whl", hash = "sha256:60ee7e19e95104d4c03871d7d7dfb3d22ef8a9b9c6778c94e1c8fcc8365afd48", size = 3028230, upload-time = "2026-02-10T19:17:30.518Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/5a/ac0f49e48063ab4255d9e3b79f5def51697fce1a95ea1370f03dc9db76f6/cryptography-46.0.5-cp311-abi3-win_amd64.whl", hash = "sha256:38946c54b16c885c72c4f59846be9743d699eee2b69b6988e0a00a01f46a61a4", size = 3480909, upload-time = "2026-02-10T19:17:32.083Z" },
+    { url = "https://files.pythonhosted.org/packages/00/13/3d278bfa7a15a96b9dc22db5a12ad1e48a9eb3d40e1827ef66a5df75d0d0/cryptography-46.0.5-cp314-cp314t-macosx_10_9_universal2.whl", hash = "sha256:94a76daa32eb78d61339aff7952ea819b1734b46f73646a07decb40e5b3448e2", size = 7119287, upload-time = "2026-02-10T19:17:33.801Z" },
+    { url = "https://files.pythonhosted.org/packages/67/c8/581a6702e14f0898a0848105cbefd20c058099e2c2d22ef4e476dfec75d7/cryptography-46.0.5-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:5be7bf2fb40769e05739dd0046e7b26f9d4670badc7b032d6ce4db64dddc0678", size = 4265728, upload-time = "2026-02-10T19:17:35.569Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/4a/ba1a65ce8fc65435e5a849558379896c957870dd64fecea97b1ad5f46a37/cryptography-46.0.5-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:fe346b143ff9685e40192a4960938545c699054ba11d4f9029f94751e3f71d87", size = 4408287, upload-time = "2026-02-10T19:17:36.938Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/67/8ffdbf7b65ed1ac224d1c2df3943553766914a8ca718747ee3871da6107e/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:c69fd885df7d089548a42d5ec05be26050ebcd2283d89b3d30676eb32ff87dee", size = 4270291, upload-time = "2026-02-10T19:17:38.748Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e5/f52377ee93bc2f2bba55a41a886fd208c15276ffbd2569f2ddc89d50e2c5/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_ppc64le.whl", hash = "sha256:8293f3dea7fc929ef7240796ba231413afa7b68ce38fd21da2995549f5961981", size = 4927539, upload-time = "2026-02-10T19:17:40.241Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/02/cfe39181b02419bbbbcf3abdd16c1c5c8541f03ca8bda240debc467d5a12/cryptography-46.0.5-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:1abfdb89b41c3be0365328a410baa9df3ff8a9110fb75e7b52e66803ddabc9a9", size = 4442199, upload-time = "2026-02-10T19:17:41.789Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/96/2fcaeb4873e536cf71421a388a6c11b5bc846e986b2b069c79363dc1648e/cryptography-46.0.5-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:d66e421495fdb797610a08f43b05269e0a5ea7f5e652a89bfd5a7d3c1dee3648", size = 3960131, upload-time = "2026-02-10T19:17:43.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/d2/b27631f401ddd644e94c5cf33c9a4069f72011821cf3dc7309546b0642a0/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_aarch64.whl", hash = "sha256:4e817a8920bfbcff8940ecfd60f23d01836408242b30f1a708d93198393a80b4", size = 4270072, upload-time = "2026-02-10T19:17:45.481Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/a7/60d32b0370dae0b4ebe55ffa10e8599a2a59935b5ece1b9f06edb73abdeb/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_ppc64le.whl", hash = "sha256:68f68d13f2e1cb95163fa3b4db4bf9a159a418f5f6e7242564fc75fcae667fd0", size = 4892170, upload-time = "2026-02-10T19:17:46.997Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/b9/cf73ddf8ef1164330eb0b199a589103c363afa0cf794218c24d524a58eab/cryptography-46.0.5-cp314-cp314t-manylinux_2_34_x86_64.whl", hash = "sha256:a3d1fae9863299076f05cb8a778c467578262fae09f9dc0ee9b12eb4268ce663", size = 4441741, upload-time = "2026-02-10T19:17:48.661Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/eb/eee00b28c84c726fe8fa0158c65afe312d9c3b78d9d01daf700f1f6e37ff/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4143987a42a2397f2fc3b4d7e3a7d313fbe684f67ff443999e803dd75a76826", size = 4396728, upload-time = "2026-02-10T19:17:50.058Z" },
+    { url = "https://files.pythonhosted.org/packages/65/f4/6bc1a9ed5aef7145045114b75b77c2a8261b4d38717bd8dea111a63c3442/cryptography-46.0.5-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:7d731d4b107030987fd61a7f8ab512b25b53cef8f233a97379ede116f30eb67d", size = 4652001, upload-time = "2026-02-10T19:17:51.54Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/5d00ef966ddd71ac2e6951d278884a84a40ffbd88948ef0e294b214ae9e4/cryptography-46.0.5-cp314-cp314t-win32.whl", hash = "sha256:c3bcce8521d785d510b2aad26ae2c966092b7daa8f45dd8f44734a104dc0bc1a", size = 3003637, upload-time = "2026-02-10T19:17:52.997Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/57/f3f4160123da6d098db78350fdfd9705057aad21de7388eacb2401dceab9/cryptography-46.0.5-cp314-cp314t-win_amd64.whl", hash = "sha256:4d8ae8659ab18c65ced284993c2265910f6c9e650189d4e3f68445ef82a810e4", size = 3469487, upload-time = "2026-02-10T19:17:54.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/fa/a66aa722105ad6a458bebd64086ca2b72cdd361fed31763d20390f6f1389/cryptography-46.0.5-cp38-abi3-macosx_10_9_universal2.whl", hash = "sha256:4108d4c09fbbf2789d0c926eb4152ae1760d5a2d97612b92d508d96c861e4d31", size = 7170514, upload-time = "2026-02-10T19:17:56.267Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/04/c85bdeab78c8bc77b701bf0d9bdcf514c044e18a46dcff330df5448631b0/cryptography-46.0.5-cp38-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:7d1f30a86d2757199cb2d56e48cce14deddf1f9c95f1ef1b64ee91ea43fe2e18", size = 4275349, upload-time = "2026-02-10T19:17:58.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/32/9b87132a2f91ee7f5223b091dc963055503e9b442c98fc0b8a5ca765fab0/cryptography-46.0.5-cp38-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:039917b0dc418bb9f6edce8a906572d69e74bd330b0b3fea4f79dab7f8ddd235", size = 4420667, upload-time = "2026-02-10T19:18:00.619Z" },
+    { url = "https://files.pythonhosted.org/packages/a1/a6/a7cb7010bec4b7c5692ca6f024150371b295ee1c108bdc1c400e4c44562b/cryptography-46.0.5-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:ba2a27ff02f48193fc4daeadf8ad2590516fa3d0adeeb34336b96f7fa64c1e3a", size = 4276980, upload-time = "2026-02-10T19:18:02.379Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/7c/c4f45e0eeff9b91e3f12dbd0e165fcf2a38847288fcfd889deea99fb7b6d/cryptography-46.0.5-cp38-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:61aa400dce22cb001a98014f647dc21cda08f7915ceb95df0c9eaf84b4b6af76", size = 4939143, upload-time = "2026-02-10T19:18:03.964Z" },
+    { url = "https://files.pythonhosted.org/packages/37/19/e1b8f964a834eddb44fa1b9a9976f4e414cbb7aa62809b6760c8803d22d1/cryptography-46.0.5-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3ce58ba46e1bc2aac4f7d9290223cead56743fa6ab94a5d53292ffaac6a91614", size = 4453674, upload-time = "2026-02-10T19:18:05.588Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ed/db15d3956f65264ca204625597c410d420e26530c4e2943e05a0d2f24d51/cryptography-46.0.5-cp38-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:420d0e909050490d04359e7fdb5ed7e667ca5c3c402b809ae2563d7e66a92229", size = 3978801, upload-time = "2026-02-10T19:18:07.167Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e2/df40a31d82df0a70a0daf69791f91dbb70e47644c58581d654879b382d11/cryptography-46.0.5-cp38-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:582f5fcd2afa31622f317f80426a027f30dc792e9c80ffee87b993200ea115f1", size = 4276755, upload-time = "2026-02-10T19:18:09.813Z" },
+    { url = "https://files.pythonhosted.org/packages/33/45/726809d1176959f4a896b86907b98ff4391a8aa29c0aaaf9450a8a10630e/cryptography-46.0.5-cp38-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:bfd56bb4b37ed4f330b82402f6f435845a5f5648edf1ad497da51a8452d5d62d", size = 4901539, upload-time = "2026-02-10T19:18:11.263Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0f/a3076874e9c88ecb2ecc31382f6e7c21b428ede6f55aafa1aa272613e3cd/cryptography-46.0.5-cp38-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:a3d507bb6a513ca96ba84443226af944b0f7f47dcc9a399d110cd6146481d24c", size = 4452794, upload-time = "2026-02-10T19:18:12.914Z" },
+    { url = "https://files.pythonhosted.org/packages/02/ef/ffeb542d3683d24194a38f66ca17c0a4b8bf10631feef44a7ef64e631b1a/cryptography-46.0.5-cp38-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:9f16fbdf4da055efb21c22d81b89f155f02ba420558db21288b3d0035bafd5f4", size = 4404160, upload-time = "2026-02-10T19:18:14.375Z" },
+    { url = "https://files.pythonhosted.org/packages/96/93/682d2b43c1d5f1406ed048f377c0fc9fc8f7b0447a478d5c65ab3d3a66eb/cryptography-46.0.5-cp38-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:ced80795227d70549a411a4ab66e8ce307899fad2220ce5ab2f296e687eacde9", size = 4667123, upload-time = "2026-02-10T19:18:15.886Z" },
+    { url = "https://files.pythonhosted.org/packages/45/2d/9c5f2926cb5300a8eefc3f4f0b3f3df39db7f7ce40c8365444c49363cbda/cryptography-46.0.5-cp38-abi3-win32.whl", hash = "sha256:02f547fce831f5096c9a567fd41bc12ca8f11df260959ecc7c3202555cc47a72", size = 3010220, upload-time = "2026-02-10T19:18:17.361Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ef/0c2f4a8e31018a986949d34a01115dd057bf536905dca38897bacd21fac3/cryptography-46.0.5-cp38-abi3-win_amd64.whl", hash = "sha256:556e106ee01aa13484ce9b0239bca667be5004efb0aabbed28d353df86445595", size = 3467050, upload-time = "2026-02-10T19:18:18.899Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/dd/2d9fdb07cebdf3d51179730afb7d5e576153c6744c3ff8fded23030c204e/cryptography-46.0.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:3b4995dc971c9fb83c25aa44cf45f02ba86f71ee600d81091c2f0cbae116b06c", size = 3476964, upload-time = "2026-02-10T19:18:20.687Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/6f/6cc6cc9955caa6eaf83660b0da2b077c7fe8ff9950a3c5e45d605038d439/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_aarch64.whl", hash = "sha256:bc84e875994c3b445871ea7181d424588171efec3e185dced958dad9e001950a", size = 4218321, upload-time = "2026-02-10T19:18:22.349Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/5d/c4da701939eeee699566a6c1367427ab91a8b7088cc2328c09dbee940415/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_28_x86_64.whl", hash = "sha256:2ae6971afd6246710480e3f15824ed3029a60fc16991db250034efd0b9fb4356", size = 4381786, upload-time = "2026-02-10T19:18:24.529Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/97/a538654732974a94ff96c1db621fa464f455c02d4bb7d2652f4edc21d600/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_aarch64.whl", hash = "sha256:d861ee9e76ace6cf36a6a89b959ec08e7bc2493ee39d07ffe5acb23ef46d27da", size = 4217990, upload-time = "2026-02-10T19:18:25.957Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/11/7e500d2dd3ba891197b9efd2da5454b74336d64a7cc419aa7327ab74e5f6/cryptography-46.0.5-pp311-pypy311_pp73-manylinux_2_34_x86_64.whl", hash = "sha256:2b7a67c9cd56372f3249b39699f2ad479f6991e62ea15800973b956f4b73e257", size = 4381252, upload-time = "2026-02-10T19:18:27.496Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/58/6b3d24e6b9bc474a2dcdee65dfd1f008867015408a271562e4b690561a4d/cryptography-46.0.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:8456928655f856c6e1533ff59d5be76578a7157224dbd9ce6872f25055ab9ab7", size = 3407605, upload-time = "2026-02-10T19:18:29.233Z" },
 ]
 
 [[package]]
@@ -132,9 +293,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749 }
+sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674 },
+    { url = "https://files.pythonhosted.org/packages/36/f4/c6e662dade71f56cd2f3735141b265c3c79293c109549c1e6933b0651ffc/exceptiongroup-1.3.0-py3-none-any.whl", hash = "sha256:4d111e6e0c13d0644cad6ddaa7ed0261a0b36971f6d23e7ec9b4b9097da78a10", size = 16674, upload-time = "2025-05-10T17:42:49.33Z" },
 ]
 
 [[package]]
@@ -142,8 +303,10 @@ name = "garmin-mcp"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosqlite" },
     { name = "garminconnect" },
     { name = "garth" },
+    { name = "httpx" },
     { name = "mcp" },
     { name = "python-dotenv" },
     { name = "requests" },
@@ -159,9 +322,11 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosqlite", specifier = ">=0.20.0" },
     { name = "garminconnect", specifier = "==0.2.38" },
     { name = "garth", specifier = ">=0.5.17,<0.6.0" },
-    { name = "mcp", specifier = "==1.3.0" },
+    { name = "httpx", specifier = ">=0.27.0" },
+    { name = "mcp", specifier = ">=1.26.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "requests", specifier = "==2.32.3" },
 ]
@@ -181,9 +346,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "garth" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b5/c2d3c7fb53c98f74ef208b44b686e48f01cb6434d091f66593e29fd4d2ed/garminconnect-0.2.38.tar.gz", hash = "sha256:53f0d73e821dfa9e93731a6a1c81c34e689ce157c2751edd22dd462d4e4f9e04", size = 37502 }
+sdist = { url = "https://files.pythonhosted.org/packages/04/b5/c2d3c7fb53c98f74ef208b44b686e48f01cb6434d091f66593e29fd4d2ed/garminconnect-0.2.38.tar.gz", hash = "sha256:53f0d73e821dfa9e93731a6a1c81c34e689ce157c2751edd22dd462d4e4f9e04", size = 37502, upload-time = "2026-01-04T12:08:57.563Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/dc/9e0b1eee113fedfefd6577de45205e33505fcdc1520d4d28ee4c339e9862/garminconnect-0.2.38-py3-none-any.whl", hash = "sha256:801f64834d8d2ff41f10679e4111fc157312550980b0e29b0c2f263fd628a604", size = 32733 },
+    { url = "https://files.pythonhosted.org/packages/91/dc/9e0b1eee113fedfefd6577de45205e33505fcdc1520d4d28ee4c339e9862/garminconnect-0.2.38-py3-none-any.whl", hash = "sha256:801f64834d8d2ff41f10679e4111fc157312550980b0e29b0c2f263fd628a604", size = 32733, upload-time = "2026-01-04T12:08:55.45Z" },
 ]
 
 [[package]]
@@ -195,18 +360,18 @@ dependencies = [
     { name = "requests" },
     { name = "requests-oauthlib" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/14/1a/e559feb5efd53e9a5d15c28007a714e240a51363c79a306727977fe1999b/garth-0.5.21.tar.gz", hash = "sha256:8d979595d1d4ea23a1b466ab4a60955d139b71f886f46490be140fcee584dab4", size = 1840358 }
+sdist = { url = "https://files.pythonhosted.org/packages/14/1a/e559feb5efd53e9a5d15c28007a714e240a51363c79a306727977fe1999b/garth-0.5.21.tar.gz", hash = "sha256:8d979595d1d4ea23a1b466ab4a60955d139b71f886f46490be140fcee584dab4", size = 1840358, upload-time = "2026-01-07T23:12:33.828Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c5/14/b7c77f363ff04cc0c57991277b8c3564df5210b0879894e2033f90f55ff5/garth-0.5.21-py3-none-any.whl", hash = "sha256:24b8c517ef24ef030bca14cf4e8d7ad7a191d9bc60ece6077fec6ea743a5d039", size = 33265 },
+    { url = "https://files.pythonhosted.org/packages/c5/14/b7c77f363ff04cc0c57991277b8c3564df5210b0879894e2033f90f55ff5/garth-0.5.21-py3-none-any.whl", hash = "sha256:24b8c517ef24ef030bca14cf4e8d7ad7a191d9bc60ece6077fec6ea743a5d039", size = 33265, upload-time = "2026-01-07T23:12:32.069Z" },
 ]
 
 [[package]]
 name = "h11"
 version = "0.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418 }
+sdist = { url = "https://files.pythonhosted.org/packages/f5/38/3af3d3633a34a3316095b39c8e8fb4853a28a536e55d347bd8d8e9a14b03/h11-0.14.0.tar.gz", hash = "sha256:8f19fbbe99e72420ff35c00b27a34cb9937e902a8b810e2c88300c6f0a3b699d", size = 100418, upload-time = "2022-09-25T15:40:01.519Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259 },
+    { url = "https://files.pythonhosted.org/packages/95/04/ff642e65ad6b90db43e668d70ffb6736436c7ce41fcc549f4e9472234127/h11-0.14.0-py3-none-any.whl", hash = "sha256:e3fe4ac4b851c468cc8363d500db52c2ead036020723024a109d37346efaa761", size = 58259, upload-time = "2022-09-25T15:39:59.68Z" },
 ]
 
 [[package]]
@@ -217,9 +382,9 @@ dependencies = [
     { name = "certifi" },
     { name = "h11" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196 }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/41/d7d0a89eb493922c37d343b607bc1b5da7f5be7e383740b4753ad8943e90/httpcore-1.0.7.tar.gz", hash = "sha256:8551cb62a169ec7162ac7be8d4817d561f60e08eaa485234898414bb5a8a0b4c", size = 85196, upload-time = "2024-11-15T12:30:47.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551 },
+    { url = "https://files.pythonhosted.org/packages/87/f5/72347bc88306acb359581ac4d52f23c0ef445b57157adedb9aee0cd689d2/httpcore-1.0.7-py3-none-any.whl", hash = "sha256:a3fff8f43dc260d5bd363d9f9cf1830fa3a458b332856f34282de498ed420edd", size = 78551, upload-time = "2024-11-15T12:30:45.782Z" },
 ]
 
 [[package]]
@@ -232,171 +397,257 @@ dependencies = [
     { name = "httpcore" },
     { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406 }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517 },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
 name = "httpx-sse"
 version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624 }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/60/8f4281fa9bbf3c8034fd54c0e7412e66edbab6bc74c4996bd616f8d0406e/httpx-sse-0.4.0.tar.gz", hash = "sha256:1e81a3a3070ce322add1d3529ed42eb5f70817f45ed6ec915ab753f961139721", size = 12624, upload-time = "2023-12-22T08:01:21.083Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819 },
+    { url = "https://files.pythonhosted.org/packages/e1/9b/a181f281f65d776426002f330c31849b86b31fc9d848db62e16f03ff739f/httpx_sse-0.4.0-py3-none-any.whl", hash = "sha256:f329af6eae57eaa2bdfd962b42524764af68075ea87370a2de920af5341e318f", size = 7819, upload-time = "2023-12-22T08:01:19.89Z" },
 ]
 
 [[package]]
 name = "idna"
 version = "3.10"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490 }
+sdist = { url = "https://files.pythonhosted.org/packages/f1/70/7703c29685631f5a7590aa73f1f1d3fa9a380e654b86af429e0934a32f7d/idna-3.10.tar.gz", hash = "sha256:12f65c9b470abda6dc35cf8e63cc574b1c52b11df2c86030af0ac09b01b13ea9", size = 190490, upload-time = "2024-09-15T18:07:39.745Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442 },
+    { url = "https://files.pythonhosted.org/packages/76/c6/c88e154df9c4e1a2a66ccf0005a88dfb2650c1dffb6f5ce603dfbd452ce3/idna-3.10-py3-none-any.whl", hash = "sha256:946d195a0d259cbba61165e88e65941f16e9b36ea6ddb97f00452bae8b1287d3", size = 70442, upload-time = "2024-09-15T18:07:37.964Z" },
 ]
 
 [[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484 },
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jsonschema"
+version = "4.26.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "jsonschema-specifications" },
+    { name = "referencing" },
+    { name = "rpds-py" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b3/fc/e067678238fa451312d4c62bf6e6cf5ec56375422aee02f9cb5f909b3047/jsonschema-4.26.0.tar.gz", hash = "sha256:0c26707e2efad8aa1bfc5b7ce170f3fccc2e4918ff85989ba9ffa9facb2be326", size = 366583, upload-time = "2026-01-07T13:41:07.246Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/69/90/f63fb5873511e014207a475e2bb4e8b2e570d655b00ac19a9a0ca0a385ee/jsonschema-4.26.0-py3-none-any.whl", hash = "sha256:d489f15263b8d200f8387e64b4c3a75f06629559fb73deb8fdfb525f2dab50ce", size = 90630, upload-time = "2026-01-07T13:41:05.306Z" },
+]
+
+[[package]]
+name = "jsonschema-specifications"
+version = "2025.9.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/74/a633ee74eb36c44aa6d1095e7cc5569bebf04342ee146178e2d36600708b/jsonschema_specifications-2025.9.1.tar.gz", hash = "sha256:b540987f239e745613c7a9176f3edb72b832a4ac465cf02712288397832b5e8d", size = 32855, upload-time = "2025-09-08T01:34:59.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/41/45/1a4ed80516f02155c51f51e8cedb3c1902296743db0bbc66608a0db2814f/jsonschema_specifications-2025.9.1-py3-none-any.whl", hash = "sha256:98802fee3a11ee76ecaca44429fda8a41bff98b00a0f2838151b113f210cc6fe", size = 18437, upload-time = "2025-09-08T01:34:57.871Z" },
 ]
 
 [[package]]
 name = "mcp"
-version = "1.3.0"
+version = "1.26.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "httpx" },
     { name = "httpx-sse" },
+    { name = "jsonschema" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
+    { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "sse-starlette" },
     { name = "starlette" },
-    { name = "uvicorn" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+    { name = "uvicorn", marker = "sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6b/b6/81e5f2490290351fc97bf46c24ff935128cb7d34d68e3987b522f26f7ada/mcp-1.3.0.tar.gz", hash = "sha256:f409ae4482ce9d53e7ac03f3f7808bcab735bdfc0fba937453782efb43882d45", size = 150235 }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d0/d2/a9e87b506b2094f5aa9becc1af5178842701b27217fa43877353da2577e3/mcp-1.3.0-py3-none-any.whl", hash = "sha256:2829d67ce339a249f803f22eba5e90385eafcac45c94b00cab6cef7e8f217211", size = 70672 },
+    { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
 ]
 
 [[package]]
 name = "oauthlib"
 version = "3.2.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352 }
+sdist = { url = "https://files.pythonhosted.org/packages/6d/fa/fbf4001037904031639e6bfbfc02badfc7e12f137a8afa254df6c4c8a670/oauthlib-3.2.2.tar.gz", hash = "sha256:9859c40929662bec5d64f34d01c99e093149682a3f38915dc0655d5a633dd918", size = 177352, upload-time = "2022-10-17T20:04:27.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688 },
+    { url = "https://files.pythonhosted.org/packages/7e/80/cab10959dc1faead58dc8384a781dfbf93cb4d33d50988f7a69f1b7c9bbe/oauthlib-3.2.2-py3-none-any.whl", hash = "sha256:8139f29aac13e25d502680e9e19963e83f16838d48a0d71c287fe40e7067fbca", size = 151688, upload-time = "2022-10-17T20:04:24.037Z" },
 ]
 
 [[package]]
 name = "packaging"
 version = "25.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727 }
+sdist = { url = "https://files.pythonhosted.org/packages/a1/d4/1fc4078c65507b51b96ca8f8c3ba19e6a61c8253c72794544580a7b6c24d/packaging-25.0.tar.gz", hash = "sha256:d443872c98d677bf60f6a1f2f8c1cb748e8fe762d2bf9d3148b5599295b0fc4f", size = 165727, upload-time = "2025-04-19T11:48:59.673Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469 },
+    { url = "https://files.pythonhosted.org/packages/20/12/38679034af332785aac8774540895e234f4d07f7545804097de4b666afd8/packaging-25.0-py3-none-any.whl", hash = "sha256:29572ef2b1f17581046b3a2227d5c611fb25ec70ca1ba8554b24b0e69331a484", size = 66469, upload-time = "2025-04-19T11:48:57.875Z" },
 ]
 
 [[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412 }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538 },
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]
 name = "pydantic"
-version = "2.10.6"
+version = "2.12.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-types" },
     { name = "pydantic-core" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b7/ae/d5220c5c52b158b1de7ca89fc5edb72f304a70a4c540c84c8844bf4008de/pydantic-2.10.6.tar.gz", hash = "sha256:ca5daa827cce33de7a42be142548b0096bf05a7e7b365aebfa5f8eeec7128236", size = 761681 }
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/3c/8cc1cc84deffa6e25d2d0c688ebb80635dfdbf1dbea3e30c541c8cf4d860/pydantic-2.10.6-py3-none-any.whl", hash = "sha256:427d664bf0b8a2b34ff5dd0f5a18df00591adcee7198fbd71981054cef37b584", size = 431696 },
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
 ]
 
 [[package]]
 name = "pydantic-core"
-version = "2.27.2"
+version = "2.41.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/01/f3e5ac5e7c25833db5eb555f7b7ab24cd6f8c322d3a3ad2d67a952dc0abc/pydantic_core-2.27.2.tar.gz", hash = "sha256:eb026e5a4c1fee05726072337ff51d1efb6f59090b7da90d30ea58625b1ffb39", size = 413443 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3a/bc/fed5f74b5d802cf9a03e83f60f18864e90e3aed7223adaca5ffb7a8d8d64/pydantic_core-2.27.2-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:2d367ca20b2f14095a8f4fa1210f5a7b78b8a20009ecced6b12818f455b1e9fa", size = 1895938 },
-    { url = "https://files.pythonhosted.org/packages/71/2a/185aff24ce844e39abb8dd680f4e959f0006944f4a8a0ea372d9f9ae2e53/pydantic_core-2.27.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:491a2b73db93fab69731eaee494f320faa4e093dbed776be1a829c2eb222c34c", size = 1815684 },
-    { url = "https://files.pythonhosted.org/packages/c3/43/fafabd3d94d159d4f1ed62e383e264f146a17dd4d48453319fd782e7979e/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7969e133a6f183be60e9f6f56bfae753585680f3b7307a8e555a948d443cc05a", size = 1829169 },
-    { url = "https://files.pythonhosted.org/packages/a2/d1/f2dfe1a2a637ce6800b799aa086d079998959f6f1215eb4497966efd2274/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3de9961f2a346257caf0aa508a4da705467f53778e9ef6fe744c038119737ef5", size = 1867227 },
-    { url = "https://files.pythonhosted.org/packages/7d/39/e06fcbcc1c785daa3160ccf6c1c38fea31f5754b756e34b65f74e99780b5/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:e2bb4d3e5873c37bb3dd58714d4cd0b0e6238cebc4177ac8fe878f8b3aa8e74c", size = 2037695 },
-    { url = "https://files.pythonhosted.org/packages/7a/67/61291ee98e07f0650eb756d44998214231f50751ba7e13f4f325d95249ab/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:280d219beebb0752699480fe8f1dc61ab6615c2046d76b7ab7ee38858de0a4e7", size = 2741662 },
-    { url = "https://files.pythonhosted.org/packages/32/90/3b15e31b88ca39e9e626630b4c4a1f5a0dfd09076366f4219429e6786076/pydantic_core-2.27.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47956ae78b6422cbd46f772f1746799cbb862de838fd8d1fbd34a82e05b0983a", size = 1993370 },
-    { url = "https://files.pythonhosted.org/packages/ff/83/c06d333ee3a67e2e13e07794995c1535565132940715931c1c43bfc85b11/pydantic_core-2.27.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:14d4a5c49d2f009d62a2a7140d3064f686d17a5d1a268bc641954ba181880236", size = 1996813 },
-    { url = "https://files.pythonhosted.org/packages/7c/f7/89be1c8deb6e22618a74f0ca0d933fdcb8baa254753b26b25ad3acff8f74/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:337b443af21d488716f8d0b6164de833e788aa6bd7e3a39c005febc1284f4962", size = 2005287 },
-    { url = "https://files.pythonhosted.org/packages/b7/7d/8eb3e23206c00ef7feee17b83a4ffa0a623eb1a9d382e56e4aa46fd15ff2/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:03d0f86ea3184a12f41a2d23f7ccb79cdb5a18e06993f8a45baa8dfec746f0e9", size = 2128414 },
-    { url = "https://files.pythonhosted.org/packages/4e/99/fe80f3ff8dd71a3ea15763878d464476e6cb0a2db95ff1c5c554133b6b83/pydantic_core-2.27.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:7041c36f5680c6e0f08d922aed302e98b3745d97fe1589db0a3eebf6624523af", size = 2155301 },
-    { url = "https://files.pythonhosted.org/packages/2b/a3/e50460b9a5789ca1451b70d4f52546fa9e2b420ba3bfa6100105c0559238/pydantic_core-2.27.2-cp310-cp310-win32.whl", hash = "sha256:50a68f3e3819077be2c98110c1f9dcb3817e93f267ba80a2c05bb4f8799e2ff4", size = 1816685 },
-    { url = "https://files.pythonhosted.org/packages/57/4c/a8838731cb0f2c2a39d3535376466de6049034d7b239c0202a64aaa05533/pydantic_core-2.27.2-cp310-cp310-win_amd64.whl", hash = "sha256:e0fd26b16394ead34a424eecf8a31a1f5137094cabe84a1bcb10fa6ba39d3d31", size = 1982876 },
-    { url = "https://files.pythonhosted.org/packages/c2/89/f3450af9d09d44eea1f2c369f49e8f181d742f28220f88cc4dfaae91ea6e/pydantic_core-2.27.2-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:8e10c99ef58cfdf2a66fc15d66b16c4a04f62bca39db589ae8cba08bc55331bc", size = 1893421 },
-    { url = "https://files.pythonhosted.org/packages/9e/e3/71fe85af2021f3f386da42d291412e5baf6ce7716bd7101ea49c810eda90/pydantic_core-2.27.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:26f32e0adf166a84d0cb63be85c562ca8a6fa8de28e5f0d92250c6b7e9e2aff7", size = 1814998 },
-    { url = "https://files.pythonhosted.org/packages/a6/3c/724039e0d848fd69dbf5806894e26479577316c6f0f112bacaf67aa889ac/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8c19d1ea0673cd13cc2f872f6c9ab42acc4e4f492a7ca9d3795ce2b112dd7e15", size = 1826167 },
-    { url = "https://files.pythonhosted.org/packages/2b/5b/1b29e8c1fb5f3199a9a57c1452004ff39f494bbe9bdbe9a81e18172e40d3/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5e68c4446fe0810e959cdff46ab0a41ce2f2c86d227d96dc3847af0ba7def306", size = 1865071 },
-    { url = "https://files.pythonhosted.org/packages/89/6c/3985203863d76bb7d7266e36970d7e3b6385148c18a68cc8915fd8c84d57/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:d9640b0059ff4f14d1f37321b94061c6db164fbe49b334b31643e0528d100d99", size = 2036244 },
-    { url = "https://files.pythonhosted.org/packages/0e/41/f15316858a246b5d723f7d7f599f79e37493b2e84bfc789e58d88c209f8a/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:40d02e7d45c9f8af700f3452f329ead92da4c5f4317ca9b896de7ce7199ea459", size = 2737470 },
-    { url = "https://files.pythonhosted.org/packages/a8/7c/b860618c25678bbd6d1d99dbdfdf0510ccb50790099b963ff78a124b754f/pydantic_core-2.27.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c1fd185014191700554795c99b347d64f2bb637966c4cfc16998a0ca700d048", size = 1992291 },
-    { url = "https://files.pythonhosted.org/packages/bf/73/42c3742a391eccbeab39f15213ecda3104ae8682ba3c0c28069fbcb8c10d/pydantic_core-2.27.2-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d81d2068e1c1228a565af076598f9e7451712700b673de8f502f0334f281387d", size = 1994613 },
-    { url = "https://files.pythonhosted.org/packages/94/7a/941e89096d1175d56f59340f3a8ebaf20762fef222c298ea96d36a6328c5/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:1a4207639fb02ec2dbb76227d7c751a20b1a6b4bc52850568e52260cae64ca3b", size = 2002355 },
-    { url = "https://files.pythonhosted.org/packages/6e/95/2359937a73d49e336a5a19848713555605d4d8d6940c3ec6c6c0ca4dcf25/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:3de3ce3c9ddc8bbd88f6e0e304dea0e66d843ec9de1b0042b0911c1663ffd474", size = 2126661 },
-    { url = "https://files.pythonhosted.org/packages/2b/4c/ca02b7bdb6012a1adef21a50625b14f43ed4d11f1fc237f9d7490aa5078c/pydantic_core-2.27.2-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:30c5f68ded0c36466acede341551106821043e9afaad516adfb6e8fa80a4e6a6", size = 2153261 },
-    { url = "https://files.pythonhosted.org/packages/72/9d/a241db83f973049a1092a079272ffe2e3e82e98561ef6214ab53fe53b1c7/pydantic_core-2.27.2-cp311-cp311-win32.whl", hash = "sha256:c70c26d2c99f78b125a3459f8afe1aed4d9687c24fd677c6a4436bc042e50d6c", size = 1812361 },
-    { url = "https://files.pythonhosted.org/packages/e8/ef/013f07248041b74abd48a385e2110aa3a9bbfef0fbd97d4e6d07d2f5b89a/pydantic_core-2.27.2-cp311-cp311-win_amd64.whl", hash = "sha256:08e125dbdc505fa69ca7d9c499639ab6407cfa909214d500897d02afb816e7cc", size = 1982484 },
-    { url = "https://files.pythonhosted.org/packages/10/1c/16b3a3e3398fd29dca77cea0a1d998d6bde3902fa2706985191e2313cc76/pydantic_core-2.27.2-cp311-cp311-win_arm64.whl", hash = "sha256:26f0d68d4b235a2bae0c3fc585c585b4ecc51382db0e3ba402a22cbc440915e4", size = 1867102 },
-    { url = "https://files.pythonhosted.org/packages/d6/74/51c8a5482ca447871c93e142d9d4a92ead74de6c8dc5e66733e22c9bba89/pydantic_core-2.27.2-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:9e0c8cfefa0ef83b4da9588448b6d8d2a2bf1a53c3f1ae5fca39eb3061e2f0b0", size = 1893127 },
-    { url = "https://files.pythonhosted.org/packages/d3/f3/c97e80721735868313c58b89d2de85fa80fe8dfeeed84dc51598b92a135e/pydantic_core-2.27.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:83097677b8e3bd7eaa6775720ec8e0405f1575015a463285a92bfdfe254529ef", size = 1811340 },
-    { url = "https://files.pythonhosted.org/packages/9e/91/840ec1375e686dbae1bd80a9e46c26a1e0083e1186abc610efa3d9a36180/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:172fce187655fece0c90d90a678424b013f8fbb0ca8b036ac266749c09438cb7", size = 1822900 },
-    { url = "https://files.pythonhosted.org/packages/f6/31/4240bc96025035500c18adc149aa6ffdf1a0062a4b525c932065ceb4d868/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:519f29f5213271eeeeb3093f662ba2fd512b91c5f188f3bb7b27bc5973816934", size = 1869177 },
-    { url = "https://files.pythonhosted.org/packages/fa/20/02fbaadb7808be578317015c462655c317a77a7c8f0ef274bc016a784c54/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:05e3a55d124407fffba0dd6b0c0cd056d10e983ceb4e5dbd10dda135c31071d6", size = 2038046 },
-    { url = "https://files.pythonhosted.org/packages/06/86/7f306b904e6c9eccf0668248b3f272090e49c275bc488a7b88b0823444a4/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9c3ed807c7b91de05e63930188f19e921d1fe90de6b4f5cd43ee7fcc3525cb8c", size = 2685386 },
-    { url = "https://files.pythonhosted.org/packages/8d/f0/49129b27c43396581a635d8710dae54a791b17dfc50c70164866bbf865e3/pydantic_core-2.27.2-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fb4aadc0b9a0c063206846d603b92030eb6f03069151a625667f982887153e2", size = 1997060 },
-    { url = "https://files.pythonhosted.org/packages/0d/0f/943b4af7cd416c477fd40b187036c4f89b416a33d3cc0ab7b82708a667aa/pydantic_core-2.27.2-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:28ccb213807e037460326424ceb8b5245acb88f32f3d2777427476e1b32c48c4", size = 2004870 },
-    { url = "https://files.pythonhosted.org/packages/35/40/aea70b5b1a63911c53a4c8117c0a828d6790483f858041f47bab0b779f44/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:de3cd1899e2c279b140adde9357c4495ed9d47131b4a4eaff9052f23398076b3", size = 1999822 },
-    { url = "https://files.pythonhosted.org/packages/f2/b3/807b94fd337d58effc5498fd1a7a4d9d59af4133e83e32ae39a96fddec9d/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:220f892729375e2d736b97d0e51466252ad84c51857d4d15f5e9692f9ef12be4", size = 2130364 },
-    { url = "https://files.pythonhosted.org/packages/fc/df/791c827cd4ee6efd59248dca9369fb35e80a9484462c33c6649a8d02b565/pydantic_core-2.27.2-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:a0fcd29cd6b4e74fe8ddd2c90330fd8edf2e30cb52acda47f06dd615ae72da57", size = 2158303 },
-    { url = "https://files.pythonhosted.org/packages/9b/67/4e197c300976af185b7cef4c02203e175fb127e414125916bf1128b639a9/pydantic_core-2.27.2-cp312-cp312-win32.whl", hash = "sha256:1e2cb691ed9834cd6a8be61228471d0a503731abfb42f82458ff27be7b2186fc", size = 1834064 },
-    { url = "https://files.pythonhosted.org/packages/1f/ea/cd7209a889163b8dcca139fe32b9687dd05249161a3edda62860430457a5/pydantic_core-2.27.2-cp312-cp312-win_amd64.whl", hash = "sha256:cc3f1a99a4f4f9dd1de4fe0312c114e740b5ddead65bb4102884b384c15d8bc9", size = 1989046 },
-    { url = "https://files.pythonhosted.org/packages/bc/49/c54baab2f4658c26ac633d798dab66b4c3a9bbf47cff5284e9c182f4137a/pydantic_core-2.27.2-cp312-cp312-win_arm64.whl", hash = "sha256:3911ac9284cd8a1792d3cb26a2da18f3ca26c6908cc434a18f730dc0db7bfa3b", size = 1885092 },
-    { url = "https://files.pythonhosted.org/packages/41/b1/9bc383f48f8002f99104e3acff6cba1231b29ef76cfa45d1506a5cad1f84/pydantic_core-2.27.2-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:7d14bd329640e63852364c306f4d23eb744e0f8193148d4044dd3dacdaacbd8b", size = 1892709 },
-    { url = "https://files.pythonhosted.org/packages/10/6c/e62b8657b834f3eb2961b49ec8e301eb99946245e70bf42c8817350cbefc/pydantic_core-2.27.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:82f91663004eb8ed30ff478d77c4d1179b3563df6cdb15c0817cd1cdaf34d154", size = 1811273 },
-    { url = "https://files.pythonhosted.org/packages/ba/15/52cfe49c8c986e081b863b102d6b859d9defc63446b642ccbbb3742bf371/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:71b24c7d61131bb83df10cc7e687433609963a944ccf45190cfc21e0887b08c9", size = 1823027 },
-    { url = "https://files.pythonhosted.org/packages/b1/1c/b6f402cfc18ec0024120602bdbcebc7bdd5b856528c013bd4d13865ca473/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fa8e459d4954f608fa26116118bb67f56b93b209c39b008277ace29937453dc9", size = 1868888 },
-    { url = "https://files.pythonhosted.org/packages/bd/7b/8cb75b66ac37bc2975a3b7de99f3c6f355fcc4d89820b61dffa8f1e81677/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:ce8918cbebc8da707ba805b7fd0b382816858728ae7fe19a942080c24e5b7cd1", size = 2037738 },
-    { url = "https://files.pythonhosted.org/packages/c8/f1/786d8fe78970a06f61df22cba58e365ce304bf9b9f46cc71c8c424e0c334/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:eda3f5c2a021bbc5d976107bb302e0131351c2ba54343f8a496dc8783d3d3a6a", size = 2685138 },
-    { url = "https://files.pythonhosted.org/packages/a6/74/d12b2cd841d8724dc8ffb13fc5cef86566a53ed358103150209ecd5d1999/pydantic_core-2.27.2-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bd8086fa684c4775c27f03f062cbb9eaa6e17f064307e86b21b9e0abc9c0f02e", size = 1997025 },
-    { url = "https://files.pythonhosted.org/packages/a0/6e/940bcd631bc4d9a06c9539b51f070b66e8f370ed0933f392db6ff350d873/pydantic_core-2.27.2-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:8d9b3388db186ba0c099a6d20f0604a44eabdeef1777ddd94786cdae158729e4", size = 2004633 },
-    { url = "https://files.pythonhosted.org/packages/50/cc/a46b34f1708d82498c227d5d80ce615b2dd502ddcfd8376fc14a36655af1/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:7a66efda2387de898c8f38c0cf7f14fca0b51a8ef0b24bfea5849f1b3c95af27", size = 1999404 },
-    { url = "https://files.pythonhosted.org/packages/ca/2d/c365cfa930ed23bc58c41463bae347d1005537dc8db79e998af8ba28d35e/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:18a101c168e4e092ab40dbc2503bdc0f62010e95d292b27827871dc85450d7ee", size = 2130130 },
-    { url = "https://files.pythonhosted.org/packages/f4/d7/eb64d015c350b7cdb371145b54d96c919d4db516817f31cd1c650cae3b21/pydantic_core-2.27.2-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:ba5dd002f88b78a4215ed2f8ddbdf85e8513382820ba15ad5ad8955ce0ca19a1", size = 2157946 },
-    { url = "https://files.pythonhosted.org/packages/a4/99/bddde3ddde76c03b65dfd5a66ab436c4e58ffc42927d4ff1198ffbf96f5f/pydantic_core-2.27.2-cp313-cp313-win32.whl", hash = "sha256:1ebaf1d0481914d004a573394f4be3a7616334be70261007e47c2a6fe7e50130", size = 1834387 },
-    { url = "https://files.pythonhosted.org/packages/71/47/82b5e846e01b26ac6f1893d3c5f9f3a2eb6ba79be26eef0b759b4fe72946/pydantic_core-2.27.2-cp313-cp313-win_amd64.whl", hash = "sha256:953101387ecf2f5652883208769a79e48db18c6df442568a0b5ccd8c2723abee", size = 1990453 },
-    { url = "https://files.pythonhosted.org/packages/51/b2/b2b50d5ecf21acf870190ae5d093602d95f66c9c31f9d5de6062eb329ad1/pydantic_core-2.27.2-cp313-cp313-win_arm64.whl", hash = "sha256:ac4dbfd1691affb8f48c2c13241a2e3b60ff23247cbcf981759c768b6633cf8b", size = 1885186 },
-    { url = "https://files.pythonhosted.org/packages/46/72/af70981a341500419e67d5cb45abe552a7c74b66326ac8877588488da1ac/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:2bf14caea37e91198329b828eae1618c068dfb8ef17bb33287a7ad4b61ac314e", size = 1891159 },
-    { url = "https://files.pythonhosted.org/packages/ad/3d/c5913cccdef93e0a6a95c2d057d2c2cba347815c845cda79ddd3c0f5e17d/pydantic_core-2.27.2-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:b0cb791f5b45307caae8810c2023a184c74605ec3bcbb67d13846c28ff731ff8", size = 1768331 },
-    { url = "https://files.pythonhosted.org/packages/f6/f0/a3ae8fbee269e4934f14e2e0e00928f9346c5943174f2811193113e58252/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:688d3fd9fcb71f41c4c015c023d12a79d1c4c0732ec9eb35d96e3388a120dcf3", size = 1822467 },
-    { url = "https://files.pythonhosted.org/packages/d7/7a/7bbf241a04e9f9ea24cd5874354a83526d639b02674648af3f350554276c/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3d591580c34f4d731592f0e9fe40f9cc1b430d297eecc70b962e93c5c668f15f", size = 1979797 },
-    { url = "https://files.pythonhosted.org/packages/4f/5f/4784c6107731f89e0005a92ecb8a2efeafdb55eb992b8e9d0a2be5199335/pydantic_core-2.27.2-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:82f986faf4e644ffc189a7f1aafc86e46ef70372bb153e7001e8afccc6e54133", size = 1987839 },
-    { url = "https://files.pythonhosted.org/packages/6d/a7/61246562b651dff00de86a5f01b6e4befb518df314c54dec187a78d81c84/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:bec317a27290e2537f922639cafd54990551725fc844249e64c523301d0822fc", size = 1998861 },
-    { url = "https://files.pythonhosted.org/packages/86/aa/837821ecf0c022bbb74ca132e117c358321e72e7f9702d1b6a03758545e2/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:0296abcb83a797db256b773f45773da397da75a08f5fcaef41f2044adec05f50", size = 2116582 },
-    { url = "https://files.pythonhosted.org/packages/81/b0/5e74656e95623cbaa0a6278d16cf15e10a51f6002e3ec126541e95c29ea3/pydantic_core-2.27.2-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:0d75070718e369e452075a6017fbf187f788e17ed67a3abd47fa934d001863d9", size = 2151985 },
-    { url = "https://files.pythonhosted.org/packages/63/37/3e32eeb2a451fddaa3898e2163746b0cffbbdbb4740d38372db0490d67f3/pydantic_core-2.27.2-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:7e17b560be3c98a8e3aa66ce828bdebb9e9ac6ad5466fba92eb74c4c95cb1151", size = 2004715 },
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
 ]
 
 [[package]]
@@ -407,18 +658,32 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550 }
+sdist = { url = "https://files.pythonhosted.org/packages/88/82/c79424d7d8c29b994fb01d277da57b0a9b09cc03c3ff875f9bd8a86b2145/pydantic_settings-2.8.1.tar.gz", hash = "sha256:d5c663dfbe9db9d5e1c646b2e161da12f0d734d422ee56f567d0ea2cee4e8585", size = 83550, upload-time = "2025-02-27T10:10:32.338Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839 },
+    { url = "https://files.pythonhosted.org/packages/0b/53/a64f03044927dc47aafe029c42a5b7aabc38dfb813475e0e1bf71c4a59d0/pydantic_settings-2.8.1-py3-none-any.whl", hash = "sha256:81942d5ac3d905f7f3ee1a70df5dfb62d5569c12f51a5a647defc1c3d9ee2e9c", size = 30839, upload-time = "2025-02-27T10:10:30.711Z" },
 ]
 
 [[package]]
 name = "pygments"
 version = "2.19.2"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631 }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217 },
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.11.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/5a/b46fa56bf322901eee5b0454a34343cdbdae202cd421775a8ee4e42fd519/pyjwt-2.11.0.tar.gz", hash = "sha256:35f95c1f0fbe5d5ba6e43f00271c275f7a1a4db1dab27bf708073b75318ea623", size = 98019, upload-time = "2026-01-30T19:59:55.694Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6f/01/c26ce75ba460d5cd503da9e13b21a33804d38c2165dec7b716d06b13010c/pyjwt-2.11.0-py3-none-any.whl", hash = "sha256:94a6bde30eb5c8e04fee991062b534071fd1439ef58d2adc9ccb823e7bcd0469", size = 28224, upload-time = "2026-01-30T19:59:54.539Z" },
+]
+
+[package.optional-dependencies]
+crypto = [
+    { name = "cryptography" },
 ]
 
 [[package]]
@@ -434,9 +699,9 @@ dependencies = [
     { name = "pygments" },
     { name = "tomli", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901 }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801 },
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
 ]
 
 [[package]]
@@ -448,9 +713,9 @@ dependencies = [
     { name = "pytest" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087 }
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075 },
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]
@@ -460,9 +725,9 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036 }
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095 },
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]
@@ -472,18 +737,63 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "pytest" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973 }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382 },
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]
 name = "python-dotenv"
 version = "1.0.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115 }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/57/e84d88dfe0aec03b7a2d4327012c1627ab5f03652216c63d49846d7a6c58/python-dotenv-1.0.1.tar.gz", hash = "sha256:e324ee90a023d808f1959c46bcbc04446a10ced277783dc6ee09987c37ec10ca", size = 39115, upload-time = "2024-01-23T06:33:00.505Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863 },
+    { url = "https://files.pythonhosted.org/packages/6a/3e/b68c118422ec867fa7ab88444e1274aa40681c606d59ac27de5a5588f082/python_dotenv-1.0.1-py3-none-any.whl", hash = "sha256:f7b63ef50f1b690dddf550d03497b66d609393b40b564ed0d674909a68ebf16a", size = 19863, upload-time = "2024-01-23T06:32:58.246Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/94/01/979e98d542a70714b0cb2b6728ed0b7c46792b695e3eaec3e20711271ca3/python_multipart-0.0.22.tar.gz", hash = "sha256:7340bef99a7e0032613f56dc36027b959fd3b30a787ed62d310e951f7c3a3a58", size = 37612, upload-time = "2026-01-25T10:15:56.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1b/d0/397f9626e711ff749a95d96b7af99b9c566a9bb5129b8e4c10fc4d100304/python_multipart-0.0.22-py3-none-any.whl", hash = "sha256:2b2cd894c83d21bf49d702499531c7bafd057d730c201782048f7945d82de155", size = 24579, upload-time = "2026-01-25T10:15:54.811Z" },
+]
+
+[[package]]
+name = "pywin32"
+version = "311"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7b/40/44efbb0dfbd33aca6a6483191dae0716070ed99e2ecb0c53683f400a0b4f/pywin32-311-cp310-cp310-win32.whl", hash = "sha256:d03ff496d2a0cd4a5893504789d4a15399133fe82517455e78bad62efbb7f0a3", size = 8760432, upload-time = "2025-07-14T20:13:05.9Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bf/360243b1e953bd254a82f12653974be395ba880e7ec23e3731d9f73921cc/pywin32-311-cp310-cp310-win_amd64.whl", hash = "sha256:797c2772017851984b97180b0bebe4b620bb86328e8a884bb626156295a63b3b", size = 9590103, upload-time = "2025-07-14T20:13:07.698Z" },
+    { url = "https://files.pythonhosted.org/packages/57/38/d290720e6f138086fb3d5ffe0b6caa019a791dd57866940c82e4eeaf2012/pywin32-311-cp310-cp310-win_arm64.whl", hash = "sha256:0502d1facf1fed4839a9a51ccbcc63d952cf318f78ffc00a7e78528ac27d7a2b", size = 8778557, upload-time = "2025-07-14T20:13:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/449a6a91e5d6db51420875c54f6aff7c97a86a3b13a0b4f1a5c13b988de3/pywin32-311-cp311-cp311-win32.whl", hash = "sha256:184eb5e436dea364dcd3d2316d577d625c0351bf237c4e9a5fabbcfa5a58b151", size = 8697031, upload-time = "2025-07-14T20:13:13.266Z" },
+    { url = "https://files.pythonhosted.org/packages/51/8f/9bb81dd5bb77d22243d33c8397f09377056d5c687aa6d4042bea7fbf8364/pywin32-311-cp311-cp311-win_amd64.whl", hash = "sha256:3ce80b34b22b17ccbd937a6e78e7225d80c52f5ab9940fe0506a1a16f3dab503", size = 9508308, upload-time = "2025-07-14T20:13:15.147Z" },
+    { url = "https://files.pythonhosted.org/packages/44/7b/9c2ab54f74a138c491aba1b1cd0795ba61f144c711daea84a88b63dc0f6c/pywin32-311-cp311-cp311-win_arm64.whl", hash = "sha256:a733f1388e1a842abb67ffa8e7aad0e70ac519e09b0f6a784e65a136ec7cefd2", size = 8703930, upload-time = "2025-07-14T20:13:16.945Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/ab/01ea1943d4eba0f850c3c61e78e8dd59757ff815ff3ccd0a84de5f541f42/pywin32-311-cp312-cp312-win32.whl", hash = "sha256:750ec6e621af2b948540032557b10a2d43b0cee2ae9758c54154d711cc852d31", size = 8706543, upload-time = "2025-07-14T20:13:20.765Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a8/a0e8d07d4d051ec7502cd58b291ec98dcc0c3fff027caad0470b72cfcc2f/pywin32-311-cp312-cp312-win_amd64.whl", hash = "sha256:b8c095edad5c211ff31c05223658e71bf7116daa0ecf3ad85f3201ea3190d067", size = 9495040, upload-time = "2025-07-14T20:13:22.543Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/3a/2ae996277b4b50f17d61f0603efd8253cb2d79cc7ae159468007b586396d/pywin32-311-cp312-cp312-win_arm64.whl", hash = "sha256:e286f46a9a39c4a18b319c28f59b61de793654af2f395c102b4f819e584b5852", size = 8710102, upload-time = "2025-07-14T20:13:24.682Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/be/3fd5de0979fcb3994bfee0d65ed8ca9506a8a1260651b86174f6a86f52b3/pywin32-311-cp313-cp313-win32.whl", hash = "sha256:f95ba5a847cba10dd8c4d8fefa9f2a6cf283b8b88ed6178fa8a6c1ab16054d0d", size = 8705700, upload-time = "2025-07-14T20:13:26.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/28/e0a1909523c6890208295a29e05c2adb2126364e289826c0a8bc7297bd5c/pywin32-311-cp313-cp313-win_amd64.whl", hash = "sha256:718a38f7e5b058e76aee1c56ddd06908116d35147e133427e59a3983f703a20d", size = 9494700, upload-time = "2025-07-14T20:13:28.243Z" },
+    { url = "https://files.pythonhosted.org/packages/04/bf/90339ac0f55726dce7d794e6d79a18a91265bdf3aa70b6b9ca52f35e022a/pywin32-311-cp313-cp313-win_arm64.whl", hash = "sha256:7b4075d959648406202d92a2310cb990fea19b535c7f4a78d3f5e10b926eeb8a", size = 8709318, upload-time = "2025-07-14T20:13:30.348Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/31/097f2e132c4f16d99a22bfb777e0fd88bd8e1c634304e102f313af69ace5/pywin32-311-cp314-cp314-win32.whl", hash = "sha256:b7a2c10b93f8986666d0c803ee19b5990885872a7de910fc460f9b0c2fbf92ee", size = 8840714, upload-time = "2025-07-14T20:13:32.449Z" },
+    { url = "https://files.pythonhosted.org/packages/90/4b/07c77d8ba0e01349358082713400435347df8426208171ce297da32c313d/pywin32-311-cp314-cp314-win_amd64.whl", hash = "sha256:3aca44c046bd2ed8c90de9cb8427f581c479e594e99b5c0bb19b29c10fd6cb87", size = 9656800, upload-time = "2025-07-14T20:13:34.312Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d2/21af5c535501a7233e734b8af901574572da66fcc254cb35d0609c9080dd/pywin32-311-cp314-cp314-win_arm64.whl", hash = "sha256:a508e2d9025764a8270f93111a970e1d0fbfc33f4153b388bb649b7eec4f9b42", size = 8932540, upload-time = "2025-07-14T20:13:36.379Z" },
+]
+
+[[package]]
+name = "referencing"
+version = "0.37.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "rpds-py" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
 ]
 
 [[package]]
@@ -496,9 +806,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218 }
+sdist = { url = "https://files.pythonhosted.org/packages/63/70/2bf7780ad2d390a8d301ad0b550f1581eadbd9a20f896afe06353c2a2913/requests-2.32.3.tar.gz", hash = "sha256:55365417734eb18255590a9ff9eb97e9e1da868d4ccd6402399eaf68af20a760", size = 131218, upload-time = "2024-05-29T15:37:49.536Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928 },
+    { url = "https://files.pythonhosted.org/packages/f9/9b/335f9764261e915ed497fcdeb11df5dfd6f7bf257d4a6a2a686d80da4d54/requests-2.32.3-py3-none-any.whl", hash = "sha256:70761cfe03c773ceb22aa2f671b4757976145175cdfca038c02654d061d6dcc6", size = 64928, upload-time = "2024-05-29T15:37:47.027Z" },
 ]
 
 [[package]]
@@ -509,18 +819,140 @@ dependencies = [
     { name = "oauthlib" },
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650 }
+sdist = { url = "https://files.pythonhosted.org/packages/42/f2/05f29bc3913aea15eb670be136045bf5c5bbf4b99ecb839da9b422bb2c85/requests-oauthlib-2.0.0.tar.gz", hash = "sha256:b3dffaebd884d8cd778494369603a9e7b58d29111bf6b41bdc2dcd87203af4e9", size = 55650, upload-time = "2024-03-22T20:32:29.939Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179 },
+    { url = "https://files.pythonhosted.org/packages/3b/5d/63d4ae3b9daea098d5d6f5da83984853c1bbacd5dc826764b249fe119d24/requests_oauthlib-2.0.0-py2.py3-none-any.whl", hash = "sha256:7dd8a5c40426b779b0868c404bdef9768deccf22749cde15852df527e6269b36", size = 24179, upload-time = "2024-03-22T20:32:28.055Z" },
+]
+
+[[package]]
+name = "rpds-py"
+version = "0.30.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/20/af/3f2f423103f1113b36230496629986e0ef7e199d2aa8392452b484b38ced/rpds_py-0.30.0.tar.gz", hash = "sha256:dd8ff7cf90014af0c0f787eea34794ebf6415242ee1d6fa91eaba725cc441e84", size = 69469, upload-time = "2025-11-30T20:24:38.837Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/06/0c/0c411a0ec64ccb6d104dcabe0e713e05e153a9a2c3c2bd2b32ce412166fe/rpds_py-0.30.0-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:679ae98e00c0e8d68a7fda324e16b90fd5260945b45d3b824c892cec9eea3288", size = 370490, upload-time = "2025-11-30T20:21:33.256Z" },
+    { url = "https://files.pythonhosted.org/packages/19/6a/4ba3d0fb7297ebae71171822554abe48d7cab29c28b8f9f2c04b79988c05/rpds_py-0.30.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4cc2206b76b4f576934f0ed374b10d7ca5f457858b157ca52064bdfc26b9fc00", size = 359751, upload-time = "2025-11-30T20:21:34.591Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/7c/e4933565ef7f7a0818985d87c15d9d273f1a649afa6a52ea35ad011195ea/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:389a2d49eded1896c3d48b0136ead37c48e221b391c052fba3f4055c367f60a6", size = 389696, upload-time = "2025-11-30T20:21:36.122Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/01/6271a2511ad0815f00f7ed4390cf2567bec1d4b1da39e2c27a41e6e3b4de/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:32c8528634e1bf7121f3de08fa85b138f4e0dc47657866630611b03967f041d7", size = 403136, upload-time = "2025-11-30T20:21:37.728Z" },
+    { url = "https://files.pythonhosted.org/packages/55/64/c857eb7cd7541e9b4eee9d49c196e833128a55b89a9850a9c9ac33ccf897/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f207f69853edd6f6700b86efb84999651baf3789e78a466431df1331608e5324", size = 524699, upload-time = "2025-11-30T20:21:38.92Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/ed/94816543404078af9ab26159c44f9e98e20fe47e2126d5d32c9d9948d10a/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:67b02ec25ba7a9e8fa74c63b6ca44cf5707f2fbfadae3ee8e7494297d56aa9df", size = 412022, upload-time = "2025-11-30T20:21:40.407Z" },
+    { url = "https://files.pythonhosted.org/packages/61/b5/707f6cf0066a6412aacc11d17920ea2e19e5b2f04081c64526eb35b5c6e7/rpds_py-0.30.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c0e95f6819a19965ff420f65578bacb0b00f251fefe2c8b23347c37174271f3", size = 390522, upload-time = "2025-11-30T20:21:42.17Z" },
+    { url = "https://files.pythonhosted.org/packages/13/4e/57a85fda37a229ff4226f8cbcf09f2a455d1ed20e802ce5b2b4a7f5ed053/rpds_py-0.30.0-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:a452763cc5198f2f98898eb98f7569649fe5da666c2dc6b5ddb10fde5a574221", size = 404579, upload-time = "2025-11-30T20:21:43.769Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/da/c9339293513ec680a721e0e16bf2bac3db6e5d7e922488de471308349bba/rpds_py-0.30.0-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:e0b65193a413ccc930671c55153a03ee57cecb49e6227204b04fae512eb657a7", size = 421305, upload-time = "2025-11-30T20:21:44.994Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/be/522cb84751114f4ad9d822ff5a1aa3c98006341895d5f084779b99596e5c/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:858738e9c32147f78b3ac24dc0edb6610000e56dc0f700fd5f651d0a0f0eb9ff", size = 572503, upload-time = "2025-11-30T20:21:46.91Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/9b/de879f7e7ceddc973ea6e4629e9b380213a6938a249e94b0cdbcc325bb66/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_i686.whl", hash = "sha256:da279aa314f00acbb803da1e76fa18666778e8a8f83484fba94526da5de2cba7", size = 598322, upload-time = "2025-11-30T20:21:48.709Z" },
+    { url = "https://files.pythonhosted.org/packages/48/ac/f01fc22efec3f37d8a914fc1b2fb9bcafd56a299edbe96406f3053edea5a/rpds_py-0.30.0-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:7c64d38fb49b6cdeda16ab49e35fe0da2e1e9b34bc38bd78386530f218b37139", size = 560792, upload-time = "2025-11-30T20:21:50.024Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/da/4e2b19d0f131f35b6146425f846563d0ce036763e38913d917187307a671/rpds_py-0.30.0-cp310-cp310-win32.whl", hash = "sha256:6de2a32a1665b93233cde140ff8b3467bdb9e2af2b91079f0333a0974d12d464", size = 221901, upload-time = "2025-11-30T20:21:51.32Z" },
+    { url = "https://files.pythonhosted.org/packages/96/cb/156d7a5cf4f78a7cc571465d8aec7a3c447c94f6749c5123f08438bcf7bc/rpds_py-0.30.0-cp310-cp310-win_amd64.whl", hash = "sha256:1726859cd0de969f88dc8673bdd954185b9104e05806be64bcd87badbe313169", size = 235823, upload-time = "2025-11-30T20:21:52.505Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/6e/f964e88b3d2abee2a82c1ac8366da848fce1c6d834dc2132c3fda3970290/rpds_py-0.30.0-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a2bffea6a4ca9f01b3f8e548302470306689684e61602aa3d141e34da06cf425", size = 370157, upload-time = "2025-11-30T20:21:53.789Z" },
+    { url = "https://files.pythonhosted.org/packages/94/ba/24e5ebb7c1c82e74c4e4f33b2112a5573ddc703915b13a073737b59b86e0/rpds_py-0.30.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:dc4f992dfe1e2bc3ebc7444f6c7051b4bc13cd8e33e43511e8ffd13bf407010d", size = 359676, upload-time = "2025-11-30T20:21:55.475Z" },
+    { url = "https://files.pythonhosted.org/packages/84/86/04dbba1b087227747d64d80c3b74df946b986c57af0a9f0c98726d4d7a3b/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:422c3cb9856d80b09d30d2eb255d0754b23e090034e1deb4083f8004bd0761e4", size = 389938, upload-time = "2025-11-30T20:21:57.079Z" },
+    { url = "https://files.pythonhosted.org/packages/42/bb/1463f0b1722b7f45431bdd468301991d1328b16cffe0b1c2918eba2c4eee/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:07ae8a593e1c3c6b82ca3292efbe73c30b61332fd612e05abee07c79359f292f", size = 402932, upload-time = "2025-11-30T20:21:58.47Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ee/2520700a5c1f2d76631f948b0736cdf9b0acb25abd0ca8e889b5c62ac2e3/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:12f90dd7557b6bd57f40abe7747e81e0c0b119bef015ea7726e69fe550e394a4", size = 525830, upload-time = "2025-11-30T20:21:59.699Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ad/bd0331f740f5705cc555a5e17fdf334671262160270962e69a2bdef3bf76/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:99b47d6ad9a6da00bec6aabe5a6279ecd3c06a329d4aa4771034a21e335c3a97", size = 412033, upload-time = "2025-11-30T20:22:00.991Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/1e/372195d326549bb51f0ba0f2ecb9874579906b97e08880e7a65c3bef1a99/rpds_py-0.30.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:33f559f3104504506a44bb666b93a33f5d33133765b0c216a5bf2f1e1503af89", size = 390828, upload-time = "2025-11-30T20:22:02.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/2b/d88bb33294e3e0c76bc8f351a3721212713629ffca1700fa94979cb3eae8/rpds_py-0.30.0-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:946fe926af6e44f3697abbc305ea168c2c31d3e3ef1058cf68f379bf0335a78d", size = 404683, upload-time = "2025-11-30T20:22:04.367Z" },
+    { url = "https://files.pythonhosted.org/packages/50/32/c759a8d42bcb5289c1fac697cd92f6fe01a018dd937e62ae77e0e7f15702/rpds_py-0.30.0-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:495aeca4b93d465efde585977365187149e75383ad2684f81519f504f5c13038", size = 421583, upload-time = "2025-11-30T20:22:05.814Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/81/e729761dbd55ddf5d84ec4ff1f47857f4374b0f19bdabfcf929164da3e24/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:d9a0ca5da0386dee0655b4ccdf46119df60e0f10da268d04fe7cc87886872ba7", size = 572496, upload-time = "2025-11-30T20:22:07.713Z" },
+    { url = "https://files.pythonhosted.org/packages/14/f6/69066a924c3557c9c30baa6ec3a0aa07526305684c6f86c696b08860726c/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:8d6d1cc13664ec13c1b84241204ff3b12f9bb82464b8ad6e7a5d3486975c2eed", size = 598669, upload-time = "2025-11-30T20:22:09.312Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/48/905896b1eb8a05630d20333d1d8ffd162394127b74ce0b0784ae04498d32/rpds_py-0.30.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3896fa1be39912cf0757753826bc8bdc8ca331a28a7c4ae46b7a21280b06bb85", size = 561011, upload-time = "2025-11-30T20:22:11.309Z" },
+    { url = "https://files.pythonhosted.org/packages/22/16/cd3027c7e279d22e5eb431dd3c0fbc677bed58797fe7581e148f3f68818b/rpds_py-0.30.0-cp311-cp311-win32.whl", hash = "sha256:55f66022632205940f1827effeff17c4fa7ae1953d2b74a8581baaefb7d16f8c", size = 221406, upload-time = "2025-11-30T20:22:13.101Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/5b/e7b7aa136f28462b344e652ee010d4de26ee9fd16f1bfd5811f5153ccf89/rpds_py-0.30.0-cp311-cp311-win_amd64.whl", hash = "sha256:a51033ff701fca756439d641c0ad09a41d9242fa69121c7d8769604a0a629825", size = 236024, upload-time = "2025-11-30T20:22:14.853Z" },
+    { url = "https://files.pythonhosted.org/packages/14/a6/364bba985e4c13658edb156640608f2c9e1d3ea3c81b27aa9d889fff0e31/rpds_py-0.30.0-cp311-cp311-win_arm64.whl", hash = "sha256:47b0ef6231c58f506ef0b74d44e330405caa8428e770fec25329ed2cb971a229", size = 229069, upload-time = "2025-11-30T20:22:16.577Z" },
+    { url = "https://files.pythonhosted.org/packages/03/e7/98a2f4ac921d82f33e03f3835f5bf3a4a40aa1bfdc57975e74a97b2b4bdd/rpds_py-0.30.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:a161f20d9a43006833cd7068375a94d035714d73a172b681d8881820600abfad", size = 375086, upload-time = "2025-11-30T20:22:17.93Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/a1/bca7fd3d452b272e13335db8d6b0b3ecde0f90ad6f16f3328c6fb150c889/rpds_py-0.30.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6abc8880d9d036ecaafe709079969f56e876fcf107f7a8e9920ba6d5a3878d05", size = 359053, upload-time = "2025-11-30T20:22:19.297Z" },
+    { url = "https://files.pythonhosted.org/packages/65/1c/ae157e83a6357eceff62ba7e52113e3ec4834a84cfe07fa4b0757a7d105f/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ca28829ae5f5d569bb62a79512c842a03a12576375d5ece7d2cadf8abe96ec28", size = 390763, upload-time = "2025-11-30T20:22:21.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/36/eb2eb8515e2ad24c0bd43c3ee9cd74c33f7ca6430755ccdb240fd3144c44/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:a1010ed9524c73b94d15919ca4d41d8780980e1765babf85f9a2f90d247153dd", size = 408951, upload-time = "2025-11-30T20:22:23.408Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/65/ad8dc1784a331fabbd740ef6f71ce2198c7ed0890dab595adb9ea2d775a1/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f8d1736cfb49381ba528cd5baa46f82fdc65c06e843dab24dd70b63d09121b3f", size = 514622, upload-time = "2025-11-30T20:22:25.16Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8e/0cfa7ae158e15e143fe03993b5bcd743a59f541f5952e1546b1ac1b5fd45/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d948b135c4693daff7bc2dcfc4ec57237a29bd37e60c2fabf5aff2bbacf3e2f1", size = 414492, upload-time = "2025-11-30T20:22:26.505Z" },
+    { url = "https://files.pythonhosted.org/packages/60/1b/6f8f29f3f995c7ffdde46a626ddccd7c63aefc0efae881dc13b6e5d5bb16/rpds_py-0.30.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47f236970bccb2233267d89173d3ad2703cd36a0e2a6e92d0560d333871a3d23", size = 394080, upload-time = "2025-11-30T20:22:27.934Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/d5/a266341051a7a3ca2f4b750a3aa4abc986378431fc2da508c5034d081b70/rpds_py-0.30.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:2e6ecb5a5bcacf59c3f912155044479af1d0b6681280048b338b28e364aca1f6", size = 408680, upload-time = "2025-11-30T20:22:29.341Z" },
+    { url = "https://files.pythonhosted.org/packages/10/3b/71b725851df9ab7a7a4e33cf36d241933da66040d195a84781f49c50490c/rpds_py-0.30.0-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a8fa71a2e078c527c3e9dc9fc5a98c9db40bcc8a92b4e8858e36d329f8684b51", size = 423589, upload-time = "2025-11-30T20:22:31.469Z" },
+    { url = "https://files.pythonhosted.org/packages/00/2b/e59e58c544dc9bd8bd8384ecdb8ea91f6727f0e37a7131baeff8d6f51661/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73c67f2db7bc334e518d097c6d1e6fed021bbc9b7d678d6cc433478365d1d5f5", size = 573289, upload-time = "2025-11-30T20:22:32.997Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3e/a18e6f5b460893172a7d6a680e86d3b6bc87a54c1f0b03446a3c8c7b588f/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:5ba103fb455be00f3b1c2076c9d4264bfcb037c976167a6047ed82f23153f02e", size = 599737, upload-time = "2025-11-30T20:22:34.419Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/e2/714694e4b87b85a18e2c243614974413c60aa107fd815b8cbc42b873d1d7/rpds_py-0.30.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7cee9c752c0364588353e627da8a7e808a66873672bcb5f52890c33fd965b394", size = 563120, upload-time = "2025-11-30T20:22:35.903Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/d5d5e3bcedb0a77f4f613706b750e50a5a3ba1c15ccd3665ecc636c968fd/rpds_py-0.30.0-cp312-cp312-win32.whl", hash = "sha256:1ab5b83dbcf55acc8b08fc62b796ef672c457b17dbd7820a11d6c52c06839bdf", size = 223782, upload-time = "2025-11-30T20:22:37.271Z" },
+    { url = "https://files.pythonhosted.org/packages/39/3b/f786af9957306fdc38a74cef405b7b93180f481fb48453a114bb6465744a/rpds_py-0.30.0-cp312-cp312-win_amd64.whl", hash = "sha256:a090322ca841abd453d43456ac34db46e8b05fd9b3b4ac0c78bcde8b089f959b", size = 240463, upload-time = "2025-11-30T20:22:39.021Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d2/b91dc748126c1559042cfe41990deb92c4ee3e2b415f6b5234969ffaf0cc/rpds_py-0.30.0-cp312-cp312-win_arm64.whl", hash = "sha256:669b1805bd639dd2989b281be2cfd951c6121b65e729d9b843e9639ef1fd555e", size = 230868, upload-time = "2025-11-30T20:22:40.493Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/dc/d61221eb88ff410de3c49143407f6f3147acf2538c86f2ab7ce65ae7d5f9/rpds_py-0.30.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:f83424d738204d9770830d35290ff3273fbb02b41f919870479fab14b9d303b2", size = 374887, upload-time = "2025-11-30T20:22:41.812Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/32/55fb50ae104061dbc564ef15cc43c013dc4a9f4527a1f4d99baddf56fe5f/rpds_py-0.30.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e7536cd91353c5273434b4e003cbda89034d67e7710eab8761fd918ec6c69cf8", size = 358904, upload-time = "2025-11-30T20:22:43.479Z" },
+    { url = "https://files.pythonhosted.org/packages/58/70/faed8186300e3b9bdd138d0273109784eea2396c68458ed580f885dfe7ad/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:2771c6c15973347f50fece41fc447c054b7ac2ae0502388ce3b6738cd366e3d4", size = 389945, upload-time = "2025-11-30T20:22:44.819Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/a8/073cac3ed2c6387df38f71296d002ab43496a96b92c823e76f46b8af0543/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:0a59119fc6e3f460315fe9d08149f8102aa322299deaa5cab5b40092345c2136", size = 407783, upload-time = "2025-11-30T20:22:46.103Z" },
+    { url = "https://files.pythonhosted.org/packages/77/57/5999eb8c58671f1c11eba084115e77a8899d6e694d2a18f69f0ba471ec8b/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:76fec018282b4ead0364022e3c54b60bf368b9d926877957a8624b58419169b7", size = 515021, upload-time = "2025-11-30T20:22:47.458Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/af/5ab4833eadc36c0a8ed2bc5c0de0493c04f6c06de223170bd0798ff98ced/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:692bef75a5525db97318e8cd061542b5a79812d711ea03dbc1f6f8dbb0c5f0d2", size = 414589, upload-time = "2025-11-30T20:22:48.872Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/de/f7192e12b21b9e9a68a6d0f249b4af3fdcdff8418be0767a627564afa1f1/rpds_py-0.30.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9027da1ce107104c50c81383cae773ef5c24d296dd11c99e2629dbd7967a20c6", size = 394025, upload-time = "2025-11-30T20:22:50.196Z" },
+    { url = "https://files.pythonhosted.org/packages/91/c4/fc70cd0249496493500e7cc2de87504f5aa6509de1e88623431fec76d4b6/rpds_py-0.30.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:9cf69cdda1f5968a30a359aba2f7f9aa648a9ce4b580d6826437f2b291cfc86e", size = 408895, upload-time = "2025-11-30T20:22:51.87Z" },
+    { url = "https://files.pythonhosted.org/packages/58/95/d9275b05ab96556fefff73a385813eb66032e4c99f411d0795372d9abcea/rpds_py-0.30.0-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:a4796a717bf12b9da9d3ad002519a86063dcac8988b030e405704ef7d74d2d9d", size = 422799, upload-time = "2025-11-30T20:22:53.341Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c1/3088fc04b6624eb12a57eb814f0d4997a44b0d208d6cace713033ff1a6ba/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:5d4c2aa7c50ad4728a094ebd5eb46c452e9cb7edbfdb18f9e1221f597a73e1e7", size = 572731, upload-time = "2025-11-30T20:22:54.778Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/42/c612a833183b39774e8ac8fecae81263a68b9583ee343db33ab571a7ce55/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:ba81a9203d07805435eb06f536d95a266c21e5b2dfbf6517748ca40c98d19e31", size = 599027, upload-time = "2025-11-30T20:22:56.212Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/60/525a50f45b01d70005403ae0e25f43c0384369ad24ffe46e8d9068b50086/rpds_py-0.30.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:945dccface01af02675628334f7cf49c2af4c1c904748efc5cf7bbdf0b579f95", size = 563020, upload-time = "2025-11-30T20:22:58.2Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/5d/47c4655e9bcd5ca907148535c10e7d489044243cc9941c16ed7cd53be91d/rpds_py-0.30.0-cp313-cp313-win32.whl", hash = "sha256:b40fb160a2db369a194cb27943582b38f79fc4887291417685f3ad693c5a1d5d", size = 223139, upload-time = "2025-11-30T20:23:00.209Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/e1/485132437d20aa4d3e1d8b3fb5a5e65aa8139f1e097080c2a8443201742c/rpds_py-0.30.0-cp313-cp313-win_amd64.whl", hash = "sha256:806f36b1b605e2d6a72716f321f20036b9489d29c51c91f4dd29a3e3afb73b15", size = 240224, upload-time = "2025-11-30T20:23:02.008Z" },
+    { url = "https://files.pythonhosted.org/packages/24/95/ffd128ed1146a153d928617b0ef673960130be0009c77d8fbf0abe306713/rpds_py-0.30.0-cp313-cp313-win_arm64.whl", hash = "sha256:d96c2086587c7c30d44f31f42eae4eac89b60dabbac18c7669be3700f13c3ce1", size = 230645, upload-time = "2025-11-30T20:23:03.43Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/1b/b10de890a0def2a319a2626334a7f0ae388215eb60914dbac8a3bae54435/rpds_py-0.30.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:eb0b93f2e5c2189ee831ee43f156ed34e2a89a78a66b98cadad955972548be5a", size = 364443, upload-time = "2025-11-30T20:23:04.878Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/bf/27e39f5971dc4f305a4fb9c672ca06f290f7c4e261c568f3dea16a410d47/rpds_py-0.30.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:922e10f31f303c7c920da8981051ff6d8c1a56207dbdf330d9047f6d30b70e5e", size = 353375, upload-time = "2025-11-30T20:23:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/40/58/442ada3bba6e8e6615fc00483135c14a7538d2ffac30e2d933ccf6852232/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cdc62c8286ba9bf7f47befdcea13ea0e26bf294bda99758fd90535cbaf408000", size = 383850, upload-time = "2025-11-30T20:23:07.825Z" },
+    { url = "https://files.pythonhosted.org/packages/14/14/f59b0127409a33c6ef6f5c1ebd5ad8e32d7861c9c7adfa9a624fc3889f6c/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:47f9a91efc418b54fb8190a6b4aa7813a23fb79c51f4bb84e418f5476c38b8db", size = 392812, upload-time = "2025-11-30T20:23:09.228Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/66/e0be3e162ac299b3a22527e8913767d869e6cc75c46bd844aa43fb81ab62/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1f3587eb9b17f3789ad50824084fa6f81921bbf9a795826570bda82cb3ed91f2", size = 517841, upload-time = "2025-11-30T20:23:11.186Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/55/fa3b9cf31d0c963ecf1ba777f7cf4b2a2c976795ac430d24a1f43d25a6ba/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:39c02563fc592411c2c61d26b6c5fe1e51eaa44a75aa2c8735ca88b0d9599daa", size = 408149, upload-time = "2025-11-30T20:23:12.864Z" },
+    { url = "https://files.pythonhosted.org/packages/60/ca/780cf3b1a32b18c0f05c441958d3758f02544f1d613abf9488cd78876378/rpds_py-0.30.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:51a1234d8febafdfd33a42d97da7a43f5dcb120c1060e352a3fbc0c6d36e2083", size = 383843, upload-time = "2025-11-30T20:23:14.638Z" },
+    { url = "https://files.pythonhosted.org/packages/82/86/d5f2e04f2aa6247c613da0c1dd87fcd08fa17107e858193566048a1e2f0a/rpds_py-0.30.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:eb2c4071ab598733724c08221091e8d80e89064cd472819285a9ab0f24bcedb9", size = 396507, upload-time = "2025-11-30T20:23:16.105Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/9a/453255d2f769fe44e07ea9785c8347edaf867f7026872e76c1ad9f7bed92/rpds_py-0.30.0-cp313-cp313t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:6bdfdb946967d816e6adf9a3d8201bfad269c67efe6cefd7093ef959683c8de0", size = 414949, upload-time = "2025-11-30T20:23:17.539Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/31/622a86cdc0c45d6df0e9ccb6becdba5074735e7033c20e401a6d9d0e2ca0/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:c77afbd5f5250bf27bf516c7c4a016813eb2d3e116139aed0096940c5982da94", size = 565790, upload-time = "2025-11-30T20:23:19.029Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/5d/15bbf0fb4a3f58a3b1c67855ec1efcc4ceaef4e86644665fff03e1b66d8d/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:61046904275472a76c8c90c9ccee9013d70a6d0f73eecefd38c1ae7c39045a08", size = 590217, upload-time = "2025-11-30T20:23:20.885Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/61/21b8c41f68e60c8cc3b2e25644f0e3681926020f11d06ab0b78e3c6bbff1/rpds_py-0.30.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:4c5f36a861bc4b7da6516dbdf302c55313afa09b81931e8280361a4f6c9a2d27", size = 555806, upload-time = "2025-11-30T20:23:22.488Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/39/7e067bb06c31de48de3eb200f9fc7c58982a4d3db44b07e73963e10d3be9/rpds_py-0.30.0-cp313-cp313t-win32.whl", hash = "sha256:3d4a69de7a3e50ffc214ae16d79d8fbb0922972da0356dcf4d0fdca2878559c6", size = 211341, upload-time = "2025-11-30T20:23:24.449Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/4d/222ef0b46443cf4cf46764d9c630f3fe4abaa7245be9417e56e9f52b8f65/rpds_py-0.30.0-cp313-cp313t-win_amd64.whl", hash = "sha256:f14fc5df50a716f7ece6a80b6c78bb35ea2ca47c499e422aa4463455dd96d56d", size = 225768, upload-time = "2025-11-30T20:23:25.908Z" },
+    { url = "https://files.pythonhosted.org/packages/86/81/dad16382ebbd3d0e0328776d8fd7ca94220e4fa0798d1dc5e7da48cb3201/rpds_py-0.30.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:68f19c879420aa08f61203801423f6cd5ac5f0ac4ac82a2368a9fcd6a9a075e0", size = 362099, upload-time = "2025-11-30T20:23:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/60/19f7884db5d5603edf3c6bce35408f45ad3e97e10007df0e17dd57af18f8/rpds_py-0.30.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ec7c4490c672c1a0389d319b3a9cfcd098dcdc4783991553c332a15acf7249be", size = 353192, upload-time = "2025-11-30T20:23:29.151Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/c4/76eb0e1e72d1a9c4703c69607cec123c29028bff28ce41588792417098ac/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f251c812357a3fed308d684a5079ddfb9d933860fc6de89f2b7ab00da481e65f", size = 384080, upload-time = "2025-11-30T20:23:30.785Z" },
+    { url = "https://files.pythonhosted.org/packages/72/87/87ea665e92f3298d1b26d78814721dc39ed8d2c74b86e83348d6b48a6f31/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ac98b175585ecf4c0348fd7b29c3864bda53b805c773cbf7bfdaffc8070c976f", size = 394841, upload-time = "2025-11-30T20:23:32.209Z" },
+    { url = "https://files.pythonhosted.org/packages/77/ad/7783a89ca0587c15dcbf139b4a8364a872a25f861bdb88ed99f9b0dec985/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3e62880792319dbeb7eb866547f2e35973289e7d5696c6e295476448f5b63c87", size = 516670, upload-time = "2025-11-30T20:23:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/3c/2882bdac942bd2172f3da574eab16f309ae10a3925644e969536553cb4ee/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e7fc54e0900ab35d041b0601431b0a0eb495f0851a0639b6ef90f7741b39a18", size = 408005, upload-time = "2025-11-30T20:23:35.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/81/9a91c0111ce1758c92516a3e44776920b579d9a7c09b2b06b642d4de3f0f/rpds_py-0.30.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:47e77dc9822d3ad616c3d5759ea5631a75e5809d5a28707744ef79d7a1bcfcad", size = 382112, upload-time = "2025-11-30T20:23:36.842Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/8e/1da49d4a107027e5fbc64daeab96a0706361a2918da10cb41769244b805d/rpds_py-0.30.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:b4dc1a6ff022ff85ecafef7979a2c6eb423430e05f1165d6688234e62ba99a07", size = 399049, upload-time = "2025-11-30T20:23:38.343Z" },
+    { url = "https://files.pythonhosted.org/packages/df/5a/7ee239b1aa48a127570ec03becbb29c9d5a9eb092febbd1699d567cae859/rpds_py-0.30.0-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4559c972db3a360808309e06a74628b95eaccbf961c335c8fe0d590cf587456f", size = 415661, upload-time = "2025-11-30T20:23:40.263Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ea/caa143cf6b772f823bc7929a45da1fa83569ee49b11d18d0ada7f5ee6fd6/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:0ed177ed9bded28f8deb6ab40c183cd1192aa0de40c12f38be4d59cd33cb5c65", size = 565606, upload-time = "2025-11-30T20:23:42.186Z" },
+    { url = "https://files.pythonhosted.org/packages/64/91/ac20ba2d69303f961ad8cf55bf7dbdb4763f627291ba3d0d7d67333cced9/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:ad1fa8db769b76ea911cb4e10f049d80bf518c104f15b3edb2371cc65375c46f", size = 591126, upload-time = "2025-11-30T20:23:44.086Z" },
+    { url = "https://files.pythonhosted.org/packages/21/20/7ff5f3c8b00c8a95f75985128c26ba44503fb35b8e0259d812766ea966c7/rpds_py-0.30.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:46e83c697b1f1c72b50e5ee5adb4353eef7406fb3f2043d64c33f20ad1c2fc53", size = 553371, upload-time = "2025-11-30T20:23:46.004Z" },
+    { url = "https://files.pythonhosted.org/packages/72/c7/81dadd7b27c8ee391c132a6b192111ca58d866577ce2d9b0ca157552cce0/rpds_py-0.30.0-cp314-cp314-win32.whl", hash = "sha256:ee454b2a007d57363c2dfd5b6ca4a5d7e2c518938f8ed3b706e37e5d470801ed", size = 215298, upload-time = "2025-11-30T20:23:47.696Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/1aaac33287e8cfb07aab2e6b8ac1deca62f6f65411344f1433c55e6f3eb8/rpds_py-0.30.0-cp314-cp314-win_amd64.whl", hash = "sha256:95f0802447ac2d10bcc69f6dc28fe95fdf17940367b21d34e34c737870758950", size = 228604, upload-time = "2025-11-30T20:23:49.501Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/95/ab005315818cc519ad074cb7784dae60d939163108bd2b394e60dc7b5461/rpds_py-0.30.0-cp314-cp314-win_arm64.whl", hash = "sha256:613aa4771c99f03346e54c3f038e4cc574ac09a3ddfb0e8878487335e96dead6", size = 222391, upload-time = "2025-11-30T20:23:50.96Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/68/154fe0194d83b973cdedcdcc88947a2752411165930182ae41d983dcefa6/rpds_py-0.30.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:7e6ecfcb62edfd632e56983964e6884851786443739dbfe3582947e87274f7cb", size = 364868, upload-time = "2025-11-30T20:23:52.494Z" },
+    { url = "https://files.pythonhosted.org/packages/83/69/8bbc8b07ec854d92a8b75668c24d2abcb1719ebf890f5604c61c9369a16f/rpds_py-0.30.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a1d0bc22a7cdc173fedebb73ef81e07faef93692b8c1ad3733b67e31e1b6e1b8", size = 353747, upload-time = "2025-11-30T20:23:54.036Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/00/ba2e50183dbd9abcce9497fa5149c62b4ff3e22d338a30d690f9af970561/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0d08f00679177226c4cb8c5265012eea897c8ca3b93f429e546600c971bcbae7", size = 383795, upload-time = "2025-11-30T20:23:55.556Z" },
+    { url = "https://files.pythonhosted.org/packages/05/6f/86f0272b84926bcb0e4c972262f54223e8ecc556b3224d281e6598fc9268/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5965af57d5848192c13534f90f9dd16464f3c37aaf166cc1da1cae1fd5a34898", size = 393330, upload-time = "2025-11-30T20:23:57.033Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/e9/0e02bb2e6dc63d212641da45df2b0bf29699d01715913e0d0f017ee29438/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9a4e86e34e9ab6b667c27f3211ca48f73dba7cd3d90f8d5b11be56e5dbc3fb4e", size = 518194, upload-time = "2025-11-30T20:23:58.637Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/ca/be7bca14cf21513bdf9c0606aba17d1f389ea2b6987035eb4f62bd923f25/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e5d3e6b26f2c785d65cc25ef1e5267ccbe1b069c5c21b8cc724efee290554419", size = 408340, upload-time = "2025-11-30T20:24:00.2Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/c7/736e00ebf39ed81d75544c0da6ef7b0998f8201b369acf842f9a90dc8fce/rpds_py-0.30.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:626a7433c34566535b6e56a1b39a7b17ba961e97ce3b80ec62e6f1312c025551", size = 383765, upload-time = "2025-11-30T20:24:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/3f/da50dfde9956aaf365c4adc9533b100008ed31aea635f2b8d7b627e25b49/rpds_py-0.30.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:acd7eb3f4471577b9b5a41baf02a978e8bdeb08b4b355273994f8b87032000a8", size = 396834, upload-time = "2025-11-30T20:24:03.687Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/00/34bcc2565b6020eab2623349efbdec810676ad571995911f1abdae62a3a0/rpds_py-0.30.0-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fe5fa731a1fa8a0a56b0977413f8cacac1768dad38d16b3a296712709476fbd5", size = 415470, upload-time = "2025-11-30T20:24:05.232Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/28/882e72b5b3e6f718d5453bd4d0d9cf8df36fddeb4ddbbab17869d5868616/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:74a3243a411126362712ee1524dfc90c650a503502f135d54d1b352bd01f2404", size = 565630, upload-time = "2025-11-30T20:24:06.878Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/97/04a65539c17692de5b85c6e293520fd01317fd878ea1995f0367d4532fb1/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:3e8eeb0544f2eb0d2581774be4c3410356eba189529a6b3e36bbbf9696175856", size = 591148, upload-time = "2025-11-30T20:24:08.445Z" },
+    { url = "https://files.pythonhosted.org/packages/85/70/92482ccffb96f5441aab93e26c4d66489eb599efdcf96fad90c14bbfb976/rpds_py-0.30.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:dbd936cde57abfee19ab3213cf9c26be06d60750e60a8e4dd85d1ab12c8b1f40", size = 556030, upload-time = "2025-11-30T20:24:10.956Z" },
+    { url = "https://files.pythonhosted.org/packages/20/53/7c7e784abfa500a2b6b583b147ee4bb5a2b3747a9166bab52fec4b5b5e7d/rpds_py-0.30.0-cp314-cp314t-win32.whl", hash = "sha256:dc824125c72246d924f7f796b4f63c1e9dc810c7d9e2355864b3c3a73d59ade0", size = 211570, upload-time = "2025-11-30T20:24:12.735Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/02/fa464cdfbe6b26e0600b62c528b72d8608f5cc49f96b8d6e38c95d60c676/rpds_py-0.30.0-cp314-cp314t-win_amd64.whl", hash = "sha256:27f4b0e92de5bfbc6f86e43959e6edd1425c33b5e69aab0984a72047f2bcf1e3", size = 226532, upload-time = "2025-11-30T20:24:14.634Z" },
+    { url = "https://files.pythonhosted.org/packages/69/71/3f34339ee70521864411f8b6992e7ab13ac30d8e4e3309e07c7361767d91/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:c2262bdba0ad4fc6fb5545660673925c2d2a5d9e2e0fb603aad545427be0fc58", size = 372292, upload-time = "2025-11-30T20:24:16.537Z" },
+    { url = "https://files.pythonhosted.org/packages/57/09/f183df9b8f2d66720d2ef71075c59f7e1b336bec7ee4c48f0a2b06857653/rpds_py-0.30.0-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:ee6af14263f25eedc3bb918a3c04245106a42dfd4f5c2285ea6f997b1fc3f89a", size = 362128, upload-time = "2025-11-30T20:24:18.086Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/68/5c2594e937253457342e078f0cc1ded3dd7b2ad59afdbf2d354869110a02/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3adbb8179ce342d235c31ab8ec511e66c73faa27a47e076ccc92421add53e2bb", size = 391542, upload-time = "2025-11-30T20:24:20.092Z" },
+    { url = "https://files.pythonhosted.org/packages/49/5c/31ef1afd70b4b4fbdb2800249f34c57c64beb687495b10aec0365f53dfc4/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:250fa00e9543ac9b97ac258bd37367ff5256666122c2d0f2bc97577c60a1818c", size = 404004, upload-time = "2025-11-30T20:24:22.231Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/63/0cfbea38d05756f3440ce6534d51a491d26176ac045e2707adc99bb6e60a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9854cf4f488b3d57b9aaeb105f06d78e5529d3145b1e4a41750167e8c213c6d3", size = 527063, upload-time = "2025-11-30T20:24:24.302Z" },
+    { url = "https://files.pythonhosted.org/packages/42/e6/01e1f72a2456678b0f618fc9a1a13f882061690893c192fcad9f2926553a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:993914b8e560023bc0a8bf742c5f303551992dcb85e247b1e5c7f4a7d145bda5", size = 413099, upload-time = "2025-11-30T20:24:25.916Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/25/8df56677f209003dcbb180765520c544525e3ef21ea72279c98b9aa7c7fb/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58edca431fb9b29950807e301826586e5bbf24163677732429770a697ffe6738", size = 392177, upload-time = "2025-11-30T20:24:27.834Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/b4/0a771378c5f16f8115f796d1f437950158679bcd2a7c68cf251cfb00ed5b/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_31_riscv64.whl", hash = "sha256:dea5b552272a944763b34394d04577cf0f9bd013207bc32323b5a89a53cf9c2f", size = 406015, upload-time = "2025-11-30T20:24:29.457Z" },
+    { url = "https://files.pythonhosted.org/packages/36/d8/456dbba0af75049dc6f63ff295a2f92766b9d521fa00de67a2bd6427d57a/rpds_py-0.30.0-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:ba3af48635eb83d03f6c9735dfb21785303e73d22ad03d489e88adae6eab8877", size = 423736, upload-time = "2025-11-30T20:24:31.22Z" },
+    { url = "https://files.pythonhosted.org/packages/13/64/b4d76f227d5c45a7e0b796c674fd81b0a6c4fbd48dc29271857d8219571c/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_aarch64.whl", hash = "sha256:dff13836529b921e22f15cb099751209a60009731a68519630a24d61f0b1b30a", size = 573981, upload-time = "2025-11-30T20:24:32.934Z" },
+    { url = "https://files.pythonhosted.org/packages/20/91/092bacadeda3edf92bf743cc96a7be133e13a39cdbfd7b5082e7ab638406/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_i686.whl", hash = "sha256:1b151685b23929ab7beec71080a8889d4d6d9fa9a983d213f07121205d48e2c4", size = 599782, upload-time = "2025-11-30T20:24:35.169Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/b7/b95708304cd49b7b6f82fdd039f1748b66ec2b21d6a45180910802f1abf1/rpds_py-0.30.0-pp311-pypy311_pp73-musllinux_1_2_x86_64.whl", hash = "sha256:ac37f9f516c51e5753f27dfdef11a88330f04de2d564be3991384b2f3535d02e", size = 562191, upload-time = "2025-11-30T20:24:36.853Z" },
 ]
 
 [[package]]
 name = "sniffio"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372 }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235 },
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -531,9 +963,9 @@ dependencies = [
     { name = "anyio" },
     { name = "starlette" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376 }
+sdist = { url = "https://files.pythonhosted.org/packages/71/a4/80d2a11af59fe75b48230846989e93979c892d3a20016b42bb44edb9e398/sse_starlette-2.2.1.tar.gz", hash = "sha256:54470d5f19274aeed6b2d473430b08b4b379ea851d953b11d7f1c4a2c118b419", size = 17376, upload-time = "2024-12-25T09:09:30.616Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120 },
+    { url = "https://files.pythonhosted.org/packages/d9/e0/5b8bd393f27f4a62461c5cf2479c75a2cc2ffa330976f9f00f5f6e4f50eb/sse_starlette-2.2.1-py3-none-any.whl", hash = "sha256:6410a3d3ba0c89e7675d4c273a301d64649c03a5ef1ca101f10b47f895fd0e99", size = 10120, upload-time = "2024-12-25T09:09:26.761Z" },
 ]
 
 [[package]]
@@ -543,76 +975,88 @@ source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102 }
+sdist = { url = "https://files.pythonhosted.org/packages/04/1b/52b27f2e13ceedc79a908e29eac426a63465a1a01248e5f24aa36a62aeb3/starlette-0.46.1.tar.gz", hash = "sha256:3c88d58ee4bd1bb807c0d1acb381838afc7752f9ddaec81bbe4383611d833230", size = 2580102, upload-time = "2025-03-08T10:55:34.504Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995 },
+    { url = "https://files.pythonhosted.org/packages/a0/4b/528ccf7a982216885a1ff4908e886b8fb5f19862d1962f56a3fce2435a70/starlette-0.46.1-py3-none-any.whl", hash = "sha256:77c74ed9d2720138b25875133f3a2dae6d854af2ec37dceb56aef370c1d8a227", size = 71995, upload-time = "2025-03-08T10:55:32.662Z" },
 ]
 
 [[package]]
 name = "tomli"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392 }
+sdist = { url = "https://files.pythonhosted.org/packages/52/ed/3f73f72945444548f33eba9a87fc7a6e969915e7b1acc8260b30e1f76a2f/tomli-2.3.0.tar.gz", hash = "sha256:64be704a875d2a59753d80ee8a533c3fe183e3f06807ff7dc2232938ccb01549", size = 17392, upload-time = "2025-10-08T22:01:47.119Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/2e/299f62b401438d5fe1624119c723f5d877acc86a4c2492da405626665f12/tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45", size = 153236 },
-    { url = "https://files.pythonhosted.org/packages/86/7f/d8fffe6a7aefdb61bced88fcb5e280cfd71e08939da5894161bd71bea022/tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba", size = 148084 },
-    { url = "https://files.pythonhosted.org/packages/47/5c/24935fb6a2ee63e86d80e4d3b58b222dafaf438c416752c8b58537c8b89a/tomli-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1381caf13ab9f300e30dd8feadb3de072aeb86f1d34a8569453ff32a7dea4bf", size = 234832 },
-    { url = "https://files.pythonhosted.org/packages/89/da/75dfd804fc11e6612846758a23f13271b76d577e299592b4371a4ca4cd09/tomli-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0e285d2649b78c0d9027570d4da3425bdb49830a6156121360b3f8511ea3441", size = 242052 },
-    { url = "https://files.pythonhosted.org/packages/70/8c/f48ac899f7b3ca7eb13af73bacbc93aec37f9c954df3c08ad96991c8c373/tomli-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a154a9ae14bfcf5d8917a59b51ffd5a3ac1fd149b71b47a3a104ca4edcfa845", size = 239555 },
-    { url = "https://files.pythonhosted.org/packages/ba/28/72f8afd73f1d0e7829bfc093f4cb98ce0a40ffc0cc997009ee1ed94ba705/tomli-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:74bf8464ff93e413514fefd2be591c3b0b23231a77f901db1eb30d6f712fc42c", size = 245128 },
-    { url = "https://files.pythonhosted.org/packages/b6/eb/a7679c8ac85208706d27436e8d421dfa39d4c914dcf5fa8083a9305f58d9/tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456", size = 96445 },
-    { url = "https://files.pythonhosted.org/packages/0a/fe/3d3420c4cb1ad9cb462fb52967080575f15898da97e21cb6f1361d505383/tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be", size = 107165 },
-    { url = "https://files.pythonhosted.org/packages/ff/b7/40f36368fcabc518bb11c8f06379a0fd631985046c038aca08c6d6a43c6e/tomli-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7d86942e56ded512a594786a5ba0a5e521d02529b3826e7761a05138341a2ac", size = 154891 },
-    { url = "https://files.pythonhosted.org/packages/f9/3f/d9dd692199e3b3aab2e4e4dd948abd0f790d9ded8cd10cbaae276a898434/tomli-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73ee0b47d4dad1c5e996e3cd33b8a76a50167ae5f96a2607cbe8cc773506ab22", size = 148796 },
-    { url = "https://files.pythonhosted.org/packages/60/83/59bff4996c2cf9f9387a0f5a3394629c7efa5ef16142076a23a90f1955fa/tomli-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:792262b94d5d0a466afb5bc63c7daa9d75520110971ee269152083270998316f", size = 242121 },
-    { url = "https://files.pythonhosted.org/packages/45/e5/7c5119ff39de8693d6baab6c0b6dcb556d192c165596e9fc231ea1052041/tomli-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f195fe57ecceac95a66a75ac24d9d5fbc98ef0962e09b2eddec5d39375aae52", size = 250070 },
-    { url = "https://files.pythonhosted.org/packages/45/12/ad5126d3a278f27e6701abde51d342aa78d06e27ce2bb596a01f7709a5a2/tomli-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e31d432427dcbf4d86958c184b9bfd1e96b5b71f8eb17e6d02531f434fd335b8", size = 245859 },
-    { url = "https://files.pythonhosted.org/packages/fb/a1/4d6865da6a71c603cfe6ad0e6556c73c76548557a8d658f9e3b142df245f/tomli-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b0882799624980785240ab732537fcfc372601015c00f7fc367c55308c186f6", size = 250296 },
-    { url = "https://files.pythonhosted.org/packages/a0/b7/a7a7042715d55c9ba6e8b196d65d2cb662578b4d8cd17d882d45322b0d78/tomli-2.3.0-cp312-cp312-win32.whl", hash = "sha256:ff72b71b5d10d22ecb084d345fc26f42b5143c5533db5e2eaba7d2d335358876", size = 97124 },
-    { url = "https://files.pythonhosted.org/packages/06/1e/f22f100db15a68b520664eb3328fb0ae4e90530887928558112c8d1f4515/tomli-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:1cb4ed918939151a03f33d4242ccd0aa5f11b3547d0cf30f7c74a408a5b99878", size = 107698 },
-    { url = "https://files.pythonhosted.org/packages/89/48/06ee6eabe4fdd9ecd48bf488f4ac783844fd777f547b8d1b61c11939974e/tomli-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5192f562738228945d7b13d4930baffda67b69425a7f0da96d360b0a3888136b", size = 154819 },
-    { url = "https://files.pythonhosted.org/packages/f1/01/88793757d54d8937015c75dcdfb673c65471945f6be98e6a0410fba167ed/tomli-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be71c93a63d738597996be9528f4abe628d1adf5e6eb11607bc8fe1a510b5dae", size = 148766 },
-    { url = "https://files.pythonhosted.org/packages/42/17/5e2c956f0144b812e7e107f94f1cc54af734eb17b5191c0bbfb72de5e93e/tomli-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4665508bcbac83a31ff8ab08f424b665200c0e1e645d2bd9ab3d3e557b6185b", size = 240771 },
-    { url = "https://files.pythonhosted.org/packages/d5/f4/0fbd014909748706c01d16824eadb0307115f9562a15cbb012cd9b3512c5/tomli-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4021923f97266babc6ccab9f5068642a0095faa0a51a246a6a02fccbb3514eaf", size = 248586 },
-    { url = "https://files.pythonhosted.org/packages/30/77/fed85e114bde5e81ecf9bc5da0cc69f2914b38f4708c80ae67d0c10180c5/tomli-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4ea38c40145a357d513bffad0ed869f13c1773716cf71ccaa83b0fa0cc4e42f", size = 244792 },
-    { url = "https://files.pythonhosted.org/packages/55/92/afed3d497f7c186dc71e6ee6d4fcb0acfa5f7d0a1a2878f8beae379ae0cc/tomli-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad805ea85eda330dbad64c7ea7a4556259665bdf9d2672f5dccc740eb9d3ca05", size = 248909 },
-    { url = "https://files.pythonhosted.org/packages/f8/84/ef50c51b5a9472e7265ce1ffc7f24cd4023d289e109f669bdb1553f6a7c2/tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606", size = 96946 },
-    { url = "https://files.pythonhosted.org/packages/b2/b7/718cd1da0884f281f95ccfa3a6cc572d30053cba64603f79d431d3c9b61b/tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999", size = 107705 },
-    { url = "https://files.pythonhosted.org/packages/19/94/aeafa14a52e16163008060506fcb6aa1949d13548d13752171a755c65611/tomli-2.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cebc6fe843e0733ee827a282aca4999b596241195f43b4cc371d64fc6639da9e", size = 154244 },
-    { url = "https://files.pythonhosted.org/packages/db/e4/1e58409aa78eefa47ccd19779fc6f36787edbe7d4cd330eeeedb33a4515b/tomli-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c2ef0244c75aba9355561272009d934953817c49f47d768070c3c94355c2aa3", size = 148637 },
-    { url = "https://files.pythonhosted.org/packages/26/b6/d1eccb62f665e44359226811064596dd6a366ea1f985839c566cd61525ae/tomli-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c22a8bf253bacc0cf11f35ad9808b6cb75ada2631c2d97c971122583b129afbc", size = 241925 },
-    { url = "https://files.pythonhosted.org/packages/70/91/7cdab9a03e6d3d2bb11beae108da5bdc1c34bdeb06e21163482544ddcc90/tomli-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eea8cc5c5e9f89c9b90c4896a8deefc74f518db5927d0e0e8d4a80953d774d0", size = 249045 },
-    { url = "https://files.pythonhosted.org/packages/15/1b/8c26874ed1f6e4f1fcfeb868db8a794cbe9f227299402db58cfcc858766c/tomli-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b74a0e59ec5d15127acdabd75ea17726ac4c5178ae51b85bfe39c4f8a278e879", size = 245835 },
-    { url = "https://files.pythonhosted.org/packages/fd/42/8e3c6a9a4b1a1360c1a2a39f0b972cef2cc9ebd56025168c4137192a9321/tomli-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b5870b50c9db823c595983571d1296a6ff3e1b88f734a4c8f6fc6188397de005", size = 253109 },
-    { url = "https://files.pythonhosted.org/packages/22/0c/b4da635000a71b5f80130937eeac12e686eefb376b8dee113b4a582bba42/tomli-2.3.0-cp314-cp314-win32.whl", hash = "sha256:feb0dacc61170ed7ab602d3d972a58f14ee3ee60494292d384649a3dc38ef463", size = 97930 },
-    { url = "https://files.pythonhosted.org/packages/b9/74/cb1abc870a418ae99cd5c9547d6bce30701a954e0e721821df483ef7223c/tomli-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:b273fcbd7fc64dc3600c098e39136522650c49bca95df2d11cf3b626422392c8", size = 107964 },
-    { url = "https://files.pythonhosted.org/packages/54/78/5c46fff6432a712af9f792944f4fcd7067d8823157949f4e40c56b8b3c83/tomli-2.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:940d56ee0410fa17ee1f12b817b37a4d4e4dc4d27340863cc67236c74f582e77", size = 163065 },
-    { url = "https://files.pythonhosted.org/packages/39/67/f85d9bd23182f45eca8939cd2bc7050e1f90c41f4a2ecbbd5963a1d1c486/tomli-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f85209946d1fe94416debbb88d00eb92ce9cd5266775424ff81bc959e001acaf", size = 159088 },
-    { url = "https://files.pythonhosted.org/packages/26/5a/4b546a0405b9cc0659b399f12b6adb750757baf04250b148d3c5059fc4eb/tomli-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a56212bdcce682e56b0aaf79e869ba5d15a6163f88d5451cbde388d48b13f530", size = 268193 },
-    { url = "https://files.pythonhosted.org/packages/42/4f/2c12a72ae22cf7b59a7fe75b3465b7aba40ea9145d026ba41cb382075b0e/tomli-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5f3ffd1e098dfc032d4d3af5c0ac64f6d286d98bc148698356847b80fa4de1b", size = 275488 },
-    { url = "https://files.pythonhosted.org/packages/92/04/a038d65dbe160c3aa5a624e93ad98111090f6804027d474ba9c37c8ae186/tomli-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e01decd096b1530d97d5d85cb4dff4af2d8347bd35686654a004f8dea20fc67", size = 272669 },
-    { url = "https://files.pythonhosted.org/packages/be/2f/8b7c60a9d1612a7cbc39ffcca4f21a73bf368a80fc25bccf8253e2563267/tomli-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8a35dd0e643bb2610f156cca8db95d213a90015c11fee76c946aa62b7ae7e02f", size = 279709 },
-    { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563 },
-    { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756 },
-    { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408 },
+    { url = "https://files.pythonhosted.org/packages/b3/2e/299f62b401438d5fe1624119c723f5d877acc86a4c2492da405626665f12/tomli-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:88bd15eb972f3664f5ed4b57c1634a97153b4bac4479dcb6a495f41921eb7f45", size = 153236, upload-time = "2025-10-08T22:01:00.137Z" },
+    { url = "https://files.pythonhosted.org/packages/86/7f/d8fffe6a7aefdb61bced88fcb5e280cfd71e08939da5894161bd71bea022/tomli-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:883b1c0d6398a6a9d29b508c331fa56adbcdff647f6ace4dfca0f50e90dfd0ba", size = 148084, upload-time = "2025-10-08T22:01:01.63Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/24935fb6a2ee63e86d80e4d3b58b222dafaf438c416752c8b58537c8b89a/tomli-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d1381caf13ab9f300e30dd8feadb3de072aeb86f1d34a8569453ff32a7dea4bf", size = 234832, upload-time = "2025-10-08T22:01:02.543Z" },
+    { url = "https://files.pythonhosted.org/packages/89/da/75dfd804fc11e6612846758a23f13271b76d577e299592b4371a4ca4cd09/tomli-2.3.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a0e285d2649b78c0d9027570d4da3425bdb49830a6156121360b3f8511ea3441", size = 242052, upload-time = "2025-10-08T22:01:03.836Z" },
+    { url = "https://files.pythonhosted.org/packages/70/8c/f48ac899f7b3ca7eb13af73bacbc93aec37f9c954df3c08ad96991c8c373/tomli-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:0a154a9ae14bfcf5d8917a59b51ffd5a3ac1fd149b71b47a3a104ca4edcfa845", size = 239555, upload-time = "2025-10-08T22:01:04.834Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/28/72f8afd73f1d0e7829bfc093f4cb98ce0a40ffc0cc997009ee1ed94ba705/tomli-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:74bf8464ff93e413514fefd2be591c3b0b23231a77f901db1eb30d6f712fc42c", size = 245128, upload-time = "2025-10-08T22:01:05.84Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/eb/a7679c8ac85208706d27436e8d421dfa39d4c914dcf5fa8083a9305f58d9/tomli-2.3.0-cp311-cp311-win32.whl", hash = "sha256:00b5f5d95bbfc7d12f91ad8c593a1659b6387b43f054104cda404be6bda62456", size = 96445, upload-time = "2025-10-08T22:01:06.896Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/fe/3d3420c4cb1ad9cb462fb52967080575f15898da97e21cb6f1361d505383/tomli-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:4dc4ce8483a5d429ab602f111a93a6ab1ed425eae3122032db7e9acf449451be", size = 107165, upload-time = "2025-10-08T22:01:08.107Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/b7/40f36368fcabc518bb11c8f06379a0fd631985046c038aca08c6d6a43c6e/tomli-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d7d86942e56ded512a594786a5ba0a5e521d02529b3826e7761a05138341a2ac", size = 154891, upload-time = "2025-10-08T22:01:09.082Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/3f/d9dd692199e3b3aab2e4e4dd948abd0f790d9ded8cd10cbaae276a898434/tomli-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:73ee0b47d4dad1c5e996e3cd33b8a76a50167ae5f96a2607cbe8cc773506ab22", size = 148796, upload-time = "2025-10-08T22:01:10.266Z" },
+    { url = "https://files.pythonhosted.org/packages/60/83/59bff4996c2cf9f9387a0f5a3394629c7efa5ef16142076a23a90f1955fa/tomli-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:792262b94d5d0a466afb5bc63c7daa9d75520110971ee269152083270998316f", size = 242121, upload-time = "2025-10-08T22:01:11.332Z" },
+    { url = "https://files.pythonhosted.org/packages/45/e5/7c5119ff39de8693d6baab6c0b6dcb556d192c165596e9fc231ea1052041/tomli-2.3.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f195fe57ecceac95a66a75ac24d9d5fbc98ef0962e09b2eddec5d39375aae52", size = 250070, upload-time = "2025-10-08T22:01:12.498Z" },
+    { url = "https://files.pythonhosted.org/packages/45/12/ad5126d3a278f27e6701abde51d342aa78d06e27ce2bb596a01f7709a5a2/tomli-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e31d432427dcbf4d86958c184b9bfd1e96b5b71f8eb17e6d02531f434fd335b8", size = 245859, upload-time = "2025-10-08T22:01:13.551Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a1/4d6865da6a71c603cfe6ad0e6556c73c76548557a8d658f9e3b142df245f/tomli-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b0882799624980785240ab732537fcfc372601015c00f7fc367c55308c186f6", size = 250296, upload-time = "2025-10-08T22:01:14.614Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/b7/a7a7042715d55c9ba6e8b196d65d2cb662578b4d8cd17d882d45322b0d78/tomli-2.3.0-cp312-cp312-win32.whl", hash = "sha256:ff72b71b5d10d22ecb084d345fc26f42b5143c5533db5e2eaba7d2d335358876", size = 97124, upload-time = "2025-10-08T22:01:15.629Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/f22f100db15a68b520664eb3328fb0ae4e90530887928558112c8d1f4515/tomli-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:1cb4ed918939151a03f33d4242ccd0aa5f11b3547d0cf30f7c74a408a5b99878", size = 107698, upload-time = "2025-10-08T22:01:16.51Z" },
+    { url = "https://files.pythonhosted.org/packages/89/48/06ee6eabe4fdd9ecd48bf488f4ac783844fd777f547b8d1b61c11939974e/tomli-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:5192f562738228945d7b13d4930baffda67b69425a7f0da96d360b0a3888136b", size = 154819, upload-time = "2025-10-08T22:01:17.964Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/01/88793757d54d8937015c75dcdfb673c65471945f6be98e6a0410fba167ed/tomli-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:be71c93a63d738597996be9528f4abe628d1adf5e6eb11607bc8fe1a510b5dae", size = 148766, upload-time = "2025-10-08T22:01:18.959Z" },
+    { url = "https://files.pythonhosted.org/packages/42/17/5e2c956f0144b812e7e107f94f1cc54af734eb17b5191c0bbfb72de5e93e/tomli-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c4665508bcbac83a31ff8ab08f424b665200c0e1e645d2bd9ab3d3e557b6185b", size = 240771, upload-time = "2025-10-08T22:01:20.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/f4/0fbd014909748706c01d16824eadb0307115f9562a15cbb012cd9b3512c5/tomli-2.3.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4021923f97266babc6ccab9f5068642a0095faa0a51a246a6a02fccbb3514eaf", size = 248586, upload-time = "2025-10-08T22:01:21.164Z" },
+    { url = "https://files.pythonhosted.org/packages/30/77/fed85e114bde5e81ecf9bc5da0cc69f2914b38f4708c80ae67d0c10180c5/tomli-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4ea38c40145a357d513bffad0ed869f13c1773716cf71ccaa83b0fa0cc4e42f", size = 244792, upload-time = "2025-10-08T22:01:22.417Z" },
+    { url = "https://files.pythonhosted.org/packages/55/92/afed3d497f7c186dc71e6ee6d4fcb0acfa5f7d0a1a2878f8beae379ae0cc/tomli-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:ad805ea85eda330dbad64c7ea7a4556259665bdf9d2672f5dccc740eb9d3ca05", size = 248909, upload-time = "2025-10-08T22:01:23.859Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/84/ef50c51b5a9472e7265ce1ffc7f24cd4023d289e109f669bdb1553f6a7c2/tomli-2.3.0-cp313-cp313-win32.whl", hash = "sha256:97d5eec30149fd3294270e889b4234023f2c69747e555a27bd708828353ab606", size = 96946, upload-time = "2025-10-08T22:01:24.893Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/b7/718cd1da0884f281f95ccfa3a6cc572d30053cba64603f79d431d3c9b61b/tomli-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:0c95ca56fbe89e065c6ead5b593ee64b84a26fca063b5d71a1122bf26e533999", size = 107705, upload-time = "2025-10-08T22:01:26.153Z" },
+    { url = "https://files.pythonhosted.org/packages/19/94/aeafa14a52e16163008060506fcb6aa1949d13548d13752171a755c65611/tomli-2.3.0-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:cebc6fe843e0733ee827a282aca4999b596241195f43b4cc371d64fc6639da9e", size = 154244, upload-time = "2025-10-08T22:01:27.06Z" },
+    { url = "https://files.pythonhosted.org/packages/db/e4/1e58409aa78eefa47ccd19779fc6f36787edbe7d4cd330eeeedb33a4515b/tomli-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:4c2ef0244c75aba9355561272009d934953817c49f47d768070c3c94355c2aa3", size = 148637, upload-time = "2025-10-08T22:01:28.059Z" },
+    { url = "https://files.pythonhosted.org/packages/26/b6/d1eccb62f665e44359226811064596dd6a366ea1f985839c566cd61525ae/tomli-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c22a8bf253bacc0cf11f35ad9808b6cb75ada2631c2d97c971122583b129afbc", size = 241925, upload-time = "2025-10-08T22:01:29.066Z" },
+    { url = "https://files.pythonhosted.org/packages/70/91/7cdab9a03e6d3d2bb11beae108da5bdc1c34bdeb06e21163482544ddcc90/tomli-2.3.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0eea8cc5c5e9f89c9b90c4896a8deefc74f518db5927d0e0e8d4a80953d774d0", size = 249045, upload-time = "2025-10-08T22:01:31.98Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/8c26874ed1f6e4f1fcfeb868db8a794cbe9f227299402db58cfcc858766c/tomli-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b74a0e59ec5d15127acdabd75ea17726ac4c5178ae51b85bfe39c4f8a278e879", size = 245835, upload-time = "2025-10-08T22:01:32.989Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/42/8e3c6a9a4b1a1360c1a2a39f0b972cef2cc9ebd56025168c4137192a9321/tomli-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:b5870b50c9db823c595983571d1296a6ff3e1b88f734a4c8f6fc6188397de005", size = 253109, upload-time = "2025-10-08T22:01:34.052Z" },
+    { url = "https://files.pythonhosted.org/packages/22/0c/b4da635000a71b5f80130937eeac12e686eefb376b8dee113b4a582bba42/tomli-2.3.0-cp314-cp314-win32.whl", hash = "sha256:feb0dacc61170ed7ab602d3d972a58f14ee3ee60494292d384649a3dc38ef463", size = 97930, upload-time = "2025-10-08T22:01:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/74/cb1abc870a418ae99cd5c9547d6bce30701a954e0e721821df483ef7223c/tomli-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:b273fcbd7fc64dc3600c098e39136522650c49bca95df2d11cf3b626422392c8", size = 107964, upload-time = "2025-10-08T22:01:36.057Z" },
+    { url = "https://files.pythonhosted.org/packages/54/78/5c46fff6432a712af9f792944f4fcd7067d8823157949f4e40c56b8b3c83/tomli-2.3.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:940d56ee0410fa17ee1f12b817b37a4d4e4dc4d27340863cc67236c74f582e77", size = 163065, upload-time = "2025-10-08T22:01:37.27Z" },
+    { url = "https://files.pythonhosted.org/packages/39/67/f85d9bd23182f45eca8939cd2bc7050e1f90c41f4a2ecbbd5963a1d1c486/tomli-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:f85209946d1fe94416debbb88d00eb92ce9cd5266775424ff81bc959e001acaf", size = 159088, upload-time = "2025-10-08T22:01:38.235Z" },
+    { url = "https://files.pythonhosted.org/packages/26/5a/4b546a0405b9cc0659b399f12b6adb750757baf04250b148d3c5059fc4eb/tomli-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a56212bdcce682e56b0aaf79e869ba5d15a6163f88d5451cbde388d48b13f530", size = 268193, upload-time = "2025-10-08T22:01:39.712Z" },
+    { url = "https://files.pythonhosted.org/packages/42/4f/2c12a72ae22cf7b59a7fe75b3465b7aba40ea9145d026ba41cb382075b0e/tomli-2.3.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c5f3ffd1e098dfc032d4d3af5c0ac64f6d286d98bc148698356847b80fa4de1b", size = 275488, upload-time = "2025-10-08T22:01:40.773Z" },
+    { url = "https://files.pythonhosted.org/packages/92/04/a038d65dbe160c3aa5a624e93ad98111090f6804027d474ba9c37c8ae186/tomli-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:5e01decd096b1530d97d5d85cb4dff4af2d8347bd35686654a004f8dea20fc67", size = 272669, upload-time = "2025-10-08T22:01:41.824Z" },
+    { url = "https://files.pythonhosted.org/packages/be/2f/8b7c60a9d1612a7cbc39ffcca4f21a73bf368a80fc25bccf8253e2563267/tomli-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:8a35dd0e643bb2610f156cca8db95d213a90015c11fee76c946aa62b7ae7e02f", size = 279709, upload-time = "2025-10-08T22:01:43.177Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/46/cc36c679f09f27ded940281c38607716c86cf8ba4a518d524e349c8b4874/tomli-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:a1f7f282fe248311650081faafa5f4732bdbfef5d45fe3f2e702fbc6f2d496e0", size = 107563, upload-time = "2025-10-08T22:01:44.233Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ff/426ca8683cf7b753614480484f6437f568fd2fda2edbdf57a2d3d8b27a0b/tomli-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:70a251f8d4ba2d9ac2542eecf008b3c8a9fc5c3f9f02c56a9d7952612be2fdba", size = 119756, upload-time = "2025-10-08T22:01:45.234Z" },
+    { url = "https://files.pythonhosted.org/packages/77/b8/0135fadc89e73be292b473cb820b4f5a08197779206b33191e801feeae40/tomli-2.3.0-py3-none-any.whl", hash = "sha256:e95b1af3c5b07d9e643909b5abbec77cd9f1217e6d0bca72b0234736b9fb1f1b", size = 14408, upload-time = "2025-10-08T22:01:46.04Z" },
 ]
 
 [[package]]
 name = "typing-extensions"
-version = "4.12.2"
+version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/df/db/f35a00659bc03fec321ba8bce9420de607a1d37f8342eee1863174c69557/typing_extensions-4.12.2.tar.gz", hash = "sha256:1a7ead55c7e559dd4dee8856e3a88b41225abfe1ce8df57b7c13915fe121ffb8", size = 85321 }
+sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/9f/ad63fc0248c5379346306f8668cda6e2e2e9c95e01216d2b8ffd9ff037d0/typing_extensions-4.12.2-py3-none-any.whl", hash = "sha256:04e5ca0351e0f3f85c6853954072df659d0d13fac324d0072316b67d7794700d", size = 37438 },
+    { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]
 name = "urllib3"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268 }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/63/e53da845320b757bf29ef6a9062f5c669fe997973f966045cb019c3f4b66/urllib3-2.3.0.tar.gz", hash = "sha256:f8c5449b3cf0861679ce7e0503c7b44b5ec981bec0d1d3795a07f1ba96f0204d", size = 307268, upload-time = "2024-12-22T07:47:30.032Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369 },
+    { url = "https://files.pythonhosted.org/packages/c8/19/4ec628951a74043532ca2cf5d97b7b14863931476d117c471e8e2b1eb39f/urllib3-2.3.0-py3-none-any.whl", hash = "sha256:1cee9ad369867bfdbbb48b7dd50374c0967a0bb7710050facf0dd6911440e3df", size = 128369, upload-time = "2024-12-22T07:47:28.074Z" },
 ]
 
 [[package]]
@@ -624,7 +1068,7 @@ dependencies = [
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568 }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/4d/938bd85e5bf2edeec766267a5015ad969730bb91e31b44021dfe8b22df6c/uvicorn-0.34.0.tar.gz", hash = "sha256:404051050cd7e905de2c9a7e61790943440b3416f49cb409f965d9dcd0fa73e9", size = 76568, upload-time = "2024-12-15T13:33:30.42Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315 },
+    { url = "https://files.pythonhosted.org/packages/61/14/33a3a1352cfa71812a3a21e8c9bfb83f60b0011f5e36f2b1399d51928209/uvicorn-0.34.0-py3-none-any.whl", hash = "sha256:023dc038422502fa28a09c7a30bf2b6991512da7dcdb8fd35fe57cfc154126f4", size = 62315, upload-time = "2024-12-15T13:33:27.467Z" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -300,7 +300,7 @@ wheels = [
 
 [[package]]
 name = "garmin-mcp"
-version = "0.1.0"
+version = "0.1.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },


### PR DESCRIPTION
Summary
This PR makes the Garmin MCP server easier to use in Claude Desktop and remote mode. Users can log in with Garmin directly, handle MFA or OTP when Garmin asks, save tokens, and reuse them later. It also adds DXT packaging, MCP auth tools, smart analytics tools, and saved custom reports.

Note
This branch includes the earlier remote direct-login work from PR #43, plus the new DXT auth and analytics work.

Tools added
- `check_garmin_auth`: checks whether saved Garmin tokens exist and still work.
- `login_to_garmin`: logs in to Garmin, asks for OTP only when Garmin requires it, saves tokens, and activates the running server.
- `get_health_baselines`: compares recent Garmin health metrics with personal rolling baselines.
- `get_wellness_anomalies`: finds unusual days compared with recent personal history.
- `get_lagged_health_correlations`: finds delayed relationships between training, sleep, stress, HRV, readiness, and recovery.
- `get_weekly_health_review`: compares the last week with the prior week and includes anomalies and delayed relationships.
- `list_health_report_metrics`: lists metric keys, groups, aggregations, and the saved report store.
- `run_custom_health_report`: runs an ad hoc or saved grouped historical health report.
- `save_custom_health_report`: saves a reusable custom health report definition locally.
- `list_saved_health_reports`: lists locally saved custom health reports.

Authentication changes
- Remote OAuth2 login uses Garmin credentials directly.
- Stdio and DXT mode can start even when Garmin tokens are missing.
- `login_to_garmin` supports email, password, OTP, token paths, and forced reauth.
- macOS can prompt locally for missing email, password, and OTP so secrets do not need to be pasted in chat.
- Token path handling now expands user paths, supports persistent token directories, and avoids hardcoded local paths.
- Empty token directories no longer block password login before Garmin can request OTP.

DXT changes
- Adds a valid DXT manifest with `server.type` set to `python`.
- Adds `scripts/build_dxt.sh` to validate and package the extension.
- Adds DXT user settings for token path, optional Garmin credentials, optional MFA code, and saved report path.
- Keeps generated DXT build output out of git.

Analytics and reports
- Adds bounded historical analytics with a default 90 day window and a hard 180 day cap.
- Adds baselines, anomaly detection, lagged correlations, and weekly review summaries.
- Adds custom grouped reports by date, week, or month.
- Adds aggregations: avg, sum, min, max, and latest.
- Adds optional compact daily rows for raw report data.
- Saves report definitions to `~/.garmin_mcp_reports.json` by default, or `GARMIN_REPORTS_PATH` when set.

Docs
- Documents DXT setup and build steps.
- Documents the auth flow, token directory behavior, MFA handling, and credential options.
- Documents the new auth, analytics, and custom report tools in the README.
- Updates test counts and coverage notes.

Validation
- `rtk uv run pytest tests/unit tests/integration tests/test_mcp_debug.py -q`
- Result: 175 passed
- `rtk ./scripts/build_dxt.sh`
- Result: DXT manifest validation and package validation passed
