### PR TITLE
feat: add opencode project config for local Garmin MCP

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,6 +439,57 @@ args = [
 
 Restart your MCP client after saving the file.
 
+### With opencode
+
+[opencode](https://opencode.ai) auto-loads a project-level `opencode.json` when launched from a repository root, so contributors who clone this repo get the Garmin MCP wired up against the local source with no extra config.
+
+#### From a clone of this repository (recommended for development)
+
+This repo ships an [`opencode.json`](./opencode.json) that runs the MCP via `uv run garmin-mcp`, so it always tracks the working tree.
+
+```bash
+git clone https://github.com/Taxuspt/garmin_mcp.git
+cd garmin_mcp
+uv sync                # install dependencies
+garmin-mcp-auth        # one-time Garmin login (skip if ~/.garminconnect already exists)
+opencode               # launches with the garmin MCP attached
+```
+
+Verify the server is connected:
+
+```bash
+opencode mcp list
+# ●  ✓ garmin   connected
+#       uv run garmin-mcp
+```
+
+#### From any other directory (GitHub install)
+
+Add the server to your global opencode config at `~/.config/opencode/opencode.json` after running `garmin-mcp-auth`:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "garmin": {
+      "type": "local",
+      "command": [
+        "uvx",
+        "--python",
+        "3.12",
+        "--from",
+        "git+https://github.com/Taxuspt/garmin_mcp",
+        "garmin-mcp"
+      ],
+      "enabled": true,
+      "timeout": 30000
+    }
+  }
+}
+```
+
+Restart opencode after saving the file. The first `uvx` invocation downloads and caches the package, so the initial startup may take a few seconds.
+
 ### With Docker
 
 Docker provides an isolated and consistent environment for running the MCP server.

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "garmin": {
+      "type": "local",
+      "command": ["uv", "run", "garmin-mcp"],
+      "enabled": true,
+      "timeout": 30000
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds a project-level [`opencode.json`](./opencode.json) so contributors who launch [opencode](https://opencode.ai) from a clone of this repo get the Garmin MCP wired up against the local source automatically — no manual config edits required.

opencode walks up from the cwd looking for `opencode.json` at the worktree root, so the file only takes effect when opencode is started inside this repo. It does not affect existing Claude Desktop / Codex / Docker users.

## Changes

- **`opencode.json`** (new): registers the `garmin` MCP as a local stdio server invoking `uv run garmin-mcp` from the project root, with a 30s request timeout to accommodate slower Garmin API calls (FIT analysis, paginated activity fetches, weekly aggregates).
- **`README.md`**: new `### With opencode` section under `Running the Server`, mirroring the existing Claude Desktop / Codex layout. Covers both the zero-config clone flow and a global `uvx`-based install for users running opencode from other directories.

## Verification

Tested locally on macOS with opencode 1.15.13 and uv 0.11.3:

```
$ opencode mcp list
●  ✓ garmin   connected
      uv run garmin-mcp
```

`opencode debug config` confirms the project config merges cleanly with any global opencode config the user may already have. The 110+ Garmin tools become available inside opencode immediately after launch.

## Notes

- Uses `uv run garmin-mcp` (project-relative) rather than an absolute `--directory` path so the file is portable across contributors.
- No secrets are committed; authentication still flows through `garmin-mcp-auth` and `~/.garminconnect` tokens, exactly like the Claude Desktop / Codex paths.