### PR TITLE
Validate workout end condition mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,6 +165,55 @@ schedule_workout(workout_id=1560092011, date="2026-05-06")
 
 After syncing your watch, the workout appears on the Forerunner 965 calendar.
 
+### Raw `upload_workout` end conditions
+
+When building custom workout JSON for `upload_workout` or `upload_workouts`, the
+`endCondition.conditionTypeId` and `endCondition.conditionTypeKey` must match
+Garmin's canonical mapping. Garmin treats the numeric `conditionTypeId` as the
+source of truth; if the key and ID conflict, Garmin stores the condition that
+matches the ID.
+
+For example, this is invalid for a heart-rate end condition because ID `4` is
+`calories`, not `heart.rate`:
+
+```json
+{
+  "endCondition": {
+    "conditionTypeId": 4,
+    "conditionTypeKey": "heart.rate"
+  },
+  "endConditionValue": 145
+}
+```
+
+Use ID `6` for heart rate:
+
+```json
+{
+  "endCondition": {
+    "conditionTypeId": 6,
+    "conditionTypeKey": "heart.rate"
+  },
+  "endConditionValue": 145
+}
+```
+
+Common end-condition IDs:
+
+| ID | Key |
+|---:|---|
+| 1 | `lap.button` |
+| 2 | `time` |
+| 3 | `distance` |
+| 4 | `calories` |
+| 5 | `power` |
+| 6 | `heart.rate` |
+| 7 | `iterations` |
+| 8 | `fixed.rest` |
+| 9 | `fixed.repetition` |
+| 10 | `reps` |
+| 11 | `training.peaks.tss` |
+
 ## One-click Install (Claude Desktop)
 
 The easiest way to add this server to Claude Desktop is via the `.dxt` Desktop Extension file — no JSON editing required.

--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -249,8 +249,14 @@ WORKOUT_STRUCTURE_REFERENCE = {
         "1": {"conditionTypeKey": "lap.button", "description": "Manual lap press (use for warmup/cooldown in strength workouts)"},
         "2": {"conditionTypeKey": "time", "description": "Duration in seconds"},
         "3": {"conditionTypeKey": "distance", "description": "Distance in meters"},
+        "4": {"conditionTypeKey": "calories", "description": "Calories in kcal"},
+        "5": {"conditionTypeKey": "power", "description": "Power in watts"},
+        "6": {"conditionTypeKey": "heart.rate", "description": "Heart rate in bpm"},
         "7": {"conditionTypeKey": "iterations", "description": "Number of iterations (used internally by RepeatGroupDTO)"},
-        "10": {"conditionTypeKey": "reps", "description": "Number of repetitions (use for strength exercises)"}
+        "8": {"conditionTypeKey": "fixed.rest", "description": "Fixed rest duration"},
+        "9": {"conditionTypeKey": "fixed.repetition", "description": "Fixed repetition count"},
+        "10": {"conditionTypeKey": "reps", "description": "Number of repetitions (use for strength exercises)"},
+        "11": {"conditionTypeKey": "training.peaks.tss", "description": "TrainingPeaks TSS"}
     },
     "targetType_values": {
         "1": {"workoutTargetTypeKey": "no.target", "description": "No specific target"},

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -8,6 +8,24 @@ from typing import Any, Dict, List, Optional, Union
 # The garmin_client will be set by the main file
 garmin_client = None
 
+END_CONDITION_TYPE_IDS = {
+    "lap.button": 1,
+    "time": 2,
+    "distance": 3,
+    "calories": 4,
+    "power": 5,
+    "heart.rate": 6,
+    "iterations": 7,
+    "fixed.rest": 8,
+    "fixed.repetition": 9,
+    "reps": 10,
+    "training.peaks.tss": 11,
+}
+END_CONDITION_TYPE_KEYS = {
+    condition_id: condition_key
+    for condition_key, condition_id in END_CONDITION_TYPE_IDS.items()
+}
+
 
 def configure(client):
     """Configure the module with the Garmin client instance"""
@@ -81,6 +99,47 @@ def _fix_hr_zone_steps(workout_data: dict) -> None:
         for step in segment.get('workoutSteps', []):
             _fix_hr_zone_step(step)
             _fix_repeat_group_step(step)
+
+
+def _validate_end_condition_step(step: dict, path: str) -> None:
+    """Reject endCondition id/key pairs Garmin would silently reinterpret."""
+    end_condition = step.get('endCondition')
+    if isinstance(end_condition, dict):
+        condition_key = end_condition.get('conditionTypeKey')
+        condition_id = end_condition.get('conditionTypeId')
+
+        expected_id = END_CONDITION_TYPE_IDS.get(condition_key)
+        expected_key = END_CONDITION_TYPE_KEYS.get(condition_id)
+
+        if expected_id is not None:
+            if condition_id is None:
+                raise ValueError(
+                    f"{path}.endCondition conditionTypeKey '{condition_key}' "
+                    f"requires conditionTypeId {expected_id}"
+                )
+            if condition_id != expected_id:
+                actual = expected_key or "unknown"
+                raise ValueError(
+                    f"{path}.endCondition conditionTypeKey '{condition_key}' "
+                    f"requires conditionTypeId {expected_id}, got {condition_id} "
+                    f"({actual})"
+                )
+        elif expected_key is not None and condition_key is not None:
+            raise ValueError(
+                f"{path}.endCondition conditionTypeId {condition_id} "
+                f"requires conditionTypeKey '{expected_key}', got '{condition_key}'"
+            )
+
+    for index, nested in enumerate(step.get('workoutSteps', [])):
+        _validate_end_condition_step(nested, f"{path}.workoutSteps[{index}]")
+
+
+def _validate_end_condition_steps(workout_data: dict) -> None:
+    """Validate all workout step endCondition blocks before upload."""
+    for segment_index, segment in enumerate(workout_data.get('workoutSegments', [])):
+        for step_index, step in enumerate(segment.get('workoutSteps', [])):
+            path = f"workoutSegments[{segment_index}].workoutSteps[{step_index}]"
+            _validate_end_condition_step(step, path)
 
 
 def _curate_workout_summary(workout: dict) -> dict:
@@ -470,6 +529,13 @@ def register_tools(app):
         IMPORTANT: Sport type IDs for workouts (different from activity API!):
         - 1 = running, 2 = cycling, 5 = strength_training, 6 = cardio, 11 = walking
 
+        IMPORTANT: End condition IDs and keys must match Garmin's canonical mapping.
+        Garmin treats conditionTypeId as authoritative, so mismatches such as
+        {"conditionTypeId": 4, "conditionTypeKey": "heart.rate"} are rejected before
+        upload because Garmin would interpret them as "calories". Use
+        {"conditionTypeId": 6, "conditionTypeKey": "heart.rate"} for heart-rate
+        end conditions.
+
         **Available Templates:**
         Instead of building workout JSON from scratch, you can use these MCP resources as starting points:
         - workout://templates/simple-run - Basic warmup/run/cooldown structure
@@ -530,6 +596,7 @@ def register_tools(app):
         try:
             # Fix common mistake: HR zone targets using targetValueOne instead of zoneNumber
             _fix_hr_zone_steps(workout_data)
+            _validate_end_condition_steps(workout_data)
 
             # Pass dict directly - library handles conversion
             result = garmin_client.upload_workout(workout_data)
@@ -566,6 +633,9 @@ def register_tools(app):
 
         IMPORTANT: For heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
 
+        IMPORTANT: End condition IDs and keys must match Garmin's canonical mapping.
+        Garmin treats conditionTypeId as authoritative, so mismatches are rejected before upload.
+
         Args:
             workouts: List of workout dictionaries, each containing workout structure
                       (name, sport type, segments, etc.) — same format as upload_workout.
@@ -574,6 +644,7 @@ def register_tools(app):
         for workout_data in workouts:
             try:
                 _fix_hr_zone_steps(workout_data)
+                _validate_end_condition_steps(workout_data)
                 result = garmin_client.upload_workout(workout_data)
                 if isinstance(result, dict):
                     entry = {

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -934,6 +934,7 @@ def register_tools(app):
                 if workout_data is not None:
                     # Upload the workout first, then use the returned ID to schedule
                     _fix_hr_zone_steps(workout_data)
+                    _validate_end_condition_steps(workout_data)
                     upload_result = garmin_client.upload_workout(workout_data)
                     if not isinstance(upload_result, dict) or upload_result.get('workoutId') is None:
                         results.append({

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -30,6 +30,18 @@ def app_with_workouts(mock_garmin_client):
     return app
 
 
+def _running_workout_with_steps(steps, name="Validation Workout"):
+    return {
+        "workoutName": name,
+        "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
+        "workoutSegments": [{
+            "segmentOrder": 1,
+            "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
+            "workoutSteps": steps,
+        }],
+    }
+
+
 @pytest.mark.asyncio
 async def test_get_workouts_tool(app_with_workouts, mock_garmin_client):
     """Test get_workouts tool returns all workouts"""
@@ -384,6 +396,117 @@ async def test_upload_workout_fixes_hr_zone_in_repeat_group(app_with_workouts, m
 
     result_data = json_module.loads(result[0][0].text)
     assert result_data["status"] == "success"
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_mismatched_end_condition_id(
+    app_with_workouts, mock_garmin_client
+):
+    """Reject payloads Garmin would reinterpret using conditionTypeId."""
+    workout_data = _running_workout_with_steps([{
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+        "endCondition": {"conditionTypeId": 4, "conditionTypeKey": "heart.rate"},
+        "endConditionValue": 145.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+    }])
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert result is not None
+    message = result[0][0].text
+    assert "Error uploading workout" in message
+    assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in message
+    assert "got 4 (calories)" in message
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_accepts_heart_rate_end_condition_id(
+    app_with_workouts, mock_garmin_client
+):
+    """Accept the canonical Garmin id/key pair for heart-rate end conditions."""
+    workout_data = _running_workout_with_steps([{
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+        "endCondition": {"conditionTypeId": 6, "conditionTypeKey": "heart.rate"},
+        "endConditionValue": 145.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+    }])
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123460,
+        "workoutName": "Validation Workout",
+    }
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert result is not None
+    mock_garmin_client.upload_workout.assert_called_once_with(workout_data)
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_nested_end_condition_mismatch(
+    app_with_workouts, mock_garmin_client
+):
+    """Validate nested RepeatGroupDTO workout steps before upload."""
+    workout_data = _running_workout_with_steps([{
+        "type": "RepeatGroupDTO",
+        "stepOrder": 1,
+        "numberOfIterations": 2,
+        "endCondition": {"conditionTypeId": 7, "conditionTypeKey": "iterations"},
+        "workoutSteps": [{
+            "type": "ExecutableStepDTO",
+            "stepOrder": 1,
+            "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+            "endCondition": {"conditionTypeId": 4, "conditionTypeKey": "heart.rate"},
+            "endConditionValue": 145.0,
+            "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+        }],
+    }])
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert result is not None
+    message = result[0][0].text
+    assert "workoutSegments[0].workoutSteps[0].workoutSteps[0]" in message
+    assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in message
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_missing_end_condition_id(
+    app_with_workouts, mock_garmin_client
+):
+    """Return a local validation error instead of Garmin's id=0 API error."""
+    workout_data = _running_workout_with_steps([{
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+        "endCondition": {"conditionTypeKey": "heart.rate"},
+        "endConditionValue": 145.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+    }])
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert result is not None
+    message = result[0][0].text
+    assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in message
+    mock_garmin_client.upload_workout.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -763,6 +886,52 @@ async def test_upload_workouts_partial_failure(app_with_workouts, mock_garmin_cl
     assert result_data["results"][1]["status"] == "error"
     assert "API error" in result_data["results"][1]["message"]
     assert result_data["results"][1]["name"] == "Bad Workout"
+
+
+@pytest.mark.asyncio
+async def test_upload_workouts_reports_end_condition_validation_error(
+    app_with_workouts, mock_garmin_client
+):
+    """Batch uploads reject only the invalid workout and keep valid uploads."""
+    import json as json_module
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 111,
+        "workoutName": "Valid HR Workout",
+    }
+
+    valid = _running_workout_with_steps([{
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+        "endCondition": {"conditionTypeId": 6, "conditionTypeKey": "heart.rate"},
+        "endConditionValue": 145.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+    }], name="Valid HR Workout")
+    invalid = _running_workout_with_steps([{
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+        "endCondition": {"conditionTypeId": 4, "conditionTypeKey": "heart.rate"},
+        "endConditionValue": 145.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+    }], name="Invalid HR Workout")
+
+    result = await app_with_workouts.call_tool(
+        "upload_workouts",
+        {"workouts": [valid, invalid]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 2
+    assert result_data["succeeded"] == 1
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "success"
+    assert result_data["results"][1]["status"] == "error"
+    assert result_data["results"][1]["name"] == "Invalid HR Workout"
+    assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in result_data["results"][1]["message"]
+    mock_garmin_client.upload_workout.assert_called_once_with(valid)
 
 
 # schedule_workouts tests

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -1139,6 +1139,38 @@ async def test_schedule_workouts_inline_upload(app_with_workouts, mock_garmin_cl
 
 
 @pytest.mark.asyncio
+async def test_schedule_workouts_inline_upload_rejects_end_condition_mismatch(
+    app_with_workouts, mock_garmin_client
+):
+    """Inline workout_data follows the same validation as upload_workout."""
+    import json as json_module
+
+    inline_data = _running_workout_with_steps([{
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+        "endCondition": {"conditionTypeId": 4, "conditionTypeKey": "heart.rate"},
+        "endConditionValue": 145.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+    }], name="Invalid Inline HR Workout")
+
+    result = await app_with_workouts.call_tool(
+        "schedule_workouts",
+        {"schedules": [{"workout_data": inline_data, "calendar_date": "2024-02-01"}]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 1
+    assert result_data["succeeded"] == 0
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "error"
+    assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in result_data["results"][0]["message"]
+    mock_garmin_client.upload_workout.assert_not_called()
+    mock_garmin_client.client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_schedule_workouts_mixed_inline_and_id(app_with_workouts, mock_garmin_client):
     """Test schedule_workouts mixing inline workout_data and existing workout_id"""
     import json as json_module


### PR DESCRIPTION
## Summary

Fixes #123 by validating workout `endCondition` id/key pairs before upload.

Garmin treats `conditionTypeId` as authoritative. A payload like:

```json
{"conditionTypeId": 4, "conditionTypeKey": "heart.rate"}
```

is accepted by Garmin, but it is stored as `calories` because id `4` maps to `calories`; `heart.rate` is id `6`.

This PR adds strict pre-upload validation so inconsistent payloads fail fast with a clear local error instead of silently creating a semantically wrong Garmin workout.

## Changes

- Added a canonical Garmin workout end-condition mapping for ids 1-11.
- Added recursive validation for all workout steps, including nested `RepeatGroupDTO` steps.
- Rejects mismatched `conditionTypeId` / `conditionTypeKey` pairs before `garmin_client.upload_workout(...)`.
- Rejects missing ids for known end-condition keys with a clear expected-id message.
- Preserves the existing repeat-group compatibility helper that backfills missing `iterations` ids.
- Updated the workout structure reference with the missing end-condition mappings.
- Added README guidance for raw `upload_workout` end-condition IDs, including the `heart.rate` example.
- Added focused integration coverage for single uploads, nested repeat groups, missing ids, valid `heart.rate`, batch upload partial failures, and inline `schedule_workouts` uploads.

## Why strict validation

Silent correction would hide bugs in callers and could make the MCP server upload a workout different from what the caller explicitly provided. Since Garmin uses the numeric id as the source of truth, accepting inconsistent payloads risks silent data corruption. Failing before upload gives clients a deterministic error and avoids creating incorrect workouts in Garmin Connect.

## Validation

- `uv run pytest tests/integration/test_workouts_tools.py` -> 44 passed
- `uv run pytest tests/integration tests/unit -v --tb=short` -> 298 passed
- `uv run pytest tests/e2e tests/integration tests/unit tests/test_mcp_debug.py` -> 308 passed

I also ran a live Garmin Connect repro/probe before implementing the fix and confirmed:

```text
4 -> calories
5 -> power
6 -> heart.rate
```

A temporary repro workout created during validation was deleted afterward.

Note: `uv run pytest` across the entire repo still hits existing setup errors in `tests/test_garmin.py` because that legacy live-test file references missing pytest fixtures (`client`, `activity_id`). The practical suite above excludes that pre-existing issue.
