### PR TITLE
feat: add tools to download activity files (.fit/.gpx/.tcx/.csv) to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,24 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
 - ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
+- ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
 > **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
+
+### Activity File Downloads
+
+Two tools let you download a raw activity file to disk:
+
+- **`download_activity_file(activity_id, format="fit", output_dir=None)`** — downloads the activity and saves it to the configured directory. `format` accepts `fit` (default), `gpx`, `tcx`, or `csv`.
+- **`set_fit_download_dir(path)`** — sets and persists the default download directory (written to the config file).
+
+**Where files are saved (precedence):**
+
+1. `output_dir` argument — one-off override, not persisted.
+2. `GARMIN_FIT_DOWNLOAD_DIR` environment variable.
+3. Persisted config set via `set_fit_download_dir`.
+
+**First-run behavior:** if no directory is configured, `download_activity_file` returns `status: "needs_setup"`. The assistant will ask where you want to save files (suggesting the current directory as default), call `set_fit_download_dir` to persist your choice, and then retry the download automatically.
 
 ### Intentionally Skipped Endpoints
 
@@ -289,6 +305,8 @@ Your Garmin Connect credentials are read from environment variables:
 - `GARMIN_PASSWORD`: Your Garmin Connect password
 - `GARMIN_PASSWORD_FILE`: Path to a file containing your Garmin Connect password
 - `GARMIN_IS_CN`: Set to `true` to use Garmin Connect China (garmin.cn) instead of the international version (default: `false`)
+- `GARMIN_FIT_DOWNLOAD_DIR`: Default directory for downloaded activity files. When set, skips the first-run setup prompt in `download_activity_file`.
+- `GARMIN_FIT_CONFIG`: Path to the persisted download-directory config file (default: `~/.garminconnect_fit_config.json`).
 
 File-based secrets are useful in certain environments, such as inside a Docker container. Note that you cannot set both `GARMIN_EMAIL` and `GARMIN_EMAIL_FILE`, similarly you cannot set both `GARMIN_PASSWORD` and `GARMIN_PASSWORD_FILE`.
 

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -142,8 +142,10 @@ def _write_fit_config(dir_path: str) -> None:
     parent = os.path.dirname(path)
     if parent:
         os.makedirs(parent, exist_ok=True)
+    cfg = _read_fit_config()
+    cfg["download_dir"] = dir_path
     with open(path, "w", encoding="utf-8") as f:
-        json.dump({"download_dir": dir_path}, f, indent=2)
+        json.dump(cfg, f, indent=2)
 
 
 def _resolve_download_dir(output_dir: Optional[str]) -> Optional[str]:

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -1213,4 +1213,29 @@ def register_tools(app):
         except Exception as e:
             return f"Error computing power duration curve: {str(e)}"
 
+    @app.tool()
+    async def set_fit_download_dir(path: str) -> str:
+        """Set and persist the default directory for downloaded activity files.
+
+        Stores the absolute path in a small JSON config file
+        (~/.garminconnect_fit_config.json, overridable via GARMIN_FIT_CONFIG) so
+        download_activity_file can save files without asking again.
+
+        Args:
+            path: Directory where activity files (.fit/.gpx/.tcx/.csv) are saved.
+                  Pass the current working directory to keep files where the
+                  server runs.
+        """
+        try:
+            abspath = os.path.abspath(os.path.expanduser(path))
+            os.makedirs(abspath, exist_ok=True)
+            _write_fit_config(abspath)
+            return json.dumps({
+                "download_dir": abspath,
+                "config_path": os.path.expanduser(_get_fit_config_path()),
+                "message": "Default FIT download directory configured.",
+            }, indent=2)
+        except Exception as e:
+            return f"Error setting FIT download directory: {str(e)}"
+
     return app

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -1214,6 +1214,106 @@ def register_tools(app):
             return f"Error computing power duration curve: {str(e)}"
 
     @app.tool()
+    async def download_activity_file(
+        activity_id: Union[int, str],
+        format: str = "fit",
+        output_dir: Optional[str] = None,
+    ) -> str:
+        """Download an activity and save it to disk as a file.
+
+        Saves the activity in the requested format. Defaults to the original .fit
+        file; Garmin also supports gpx, tcx, and csv.
+
+        Directory resolution (first match wins):
+          1. output_dir argument (one-off; not persisted)
+          2. GARMIN_FIT_DOWNLOAD_DIR environment variable
+          3. persisted config (set via set_fit_download_dir)
+        If none is configured, returns status "needs_setup" with a suggested
+        default (the server's current working directory). In that case, ask the
+        user where to save, call set_fit_download_dir(path), then call this tool
+        again.
+
+        Files are named "{activity_id}.{ext}" and overwrite any existing file.
+
+        Args:
+            activity_id: Garmin activity ID
+            format: One of fit, gpx, tcx, csv (default fit)
+            output_dir: Optional one-off directory override (not persisted)
+        """
+        try:
+            fmt = str(format).strip().lower()
+            from garminconnect import Garmin
+
+            format_map = {
+                "fit": Garmin.ActivityDownloadFormat.ORIGINAL,
+                "gpx": Garmin.ActivityDownloadFormat.GPX,
+                "tcx": Garmin.ActivityDownloadFormat.TCX,
+                "csv": Garmin.ActivityDownloadFormat.CSV,
+            }
+            if fmt not in format_map:
+                return json.dumps({
+                    "error": f"Invalid format '{format}'.",
+                    "valid_formats": list(format_map.keys()),
+                }, indent=2)
+
+            download_dir = _resolve_download_dir(output_dir)
+            if download_dir is None:
+                return json.dumps({
+                    "status": "needs_setup",
+                    "suggested_default": os.getcwd(),
+                    "config_path": os.path.expanduser(_get_fit_config_path()),
+                    "message": (
+                        "No download directory configured. Ask the user where to "
+                        "save activity files (offer the current working directory "
+                        "as the default), then call set_fit_download_dir(path) "
+                        "before downloading."
+                    ),
+                }, indent=2)
+
+            activity_id = int(activity_id)
+            os.makedirs(download_dir, exist_ok=True)
+
+            data = garmin_client.download_activity(
+                activity_id, dl_fmt=format_map[fmt]
+            )
+            if not data:
+                return f"No {fmt} data returned for activity {activity_id}"
+
+            raw = bytes(data)
+            if fmt == "fit":
+                try:
+                    payload = _extract_fit_bytes(raw)
+                except Exception as extract_err:
+                    return json.dumps({
+                        "error": str(extract_err),
+                        "debug": {
+                            "total_bytes": len(raw),
+                            "first_16_bytes_hex": raw[:16].hex(),
+                            "hint": (
+                                "1f8b = gzip, 504b = ZIP, 0e10/0c10 = raw FIT, "
+                                "3c or 7b = HTML/JSON error from Garmin"
+                            ),
+                        },
+                    }, indent=2)
+            else:
+                payload = raw
+
+            file_path = os.path.join(download_dir, f"{activity_id}.{fmt}")
+            with open(file_path, "wb") as f:
+                f.write(payload)
+
+            return json.dumps({
+                "activity_id": activity_id,
+                "format": fmt,
+                "file_path": os.path.abspath(file_path),
+                "size_bytes": len(payload),
+                "message": "Activity file saved.",
+            }, indent=2)
+
+        except Exception as e:
+            return f"Error downloading activity {activity_id}: {str(e)}"
+
+    @app.tool()
     async def set_fit_download_dir(path: str) -> str:
         """Set and persist the default directory for downloaded activity files.
 

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -14,6 +14,7 @@ Exposes data not available through the REST API:
 import gzip
 import io
 import json
+import os
 import zipfile
 from typing import Any, Dict, List, Optional, Union
 
@@ -110,6 +111,58 @@ def _extract_fit_bytes(raw: bytes) -> bytes:
         return gzip.decompress(raw)
 
     return raw
+
+
+# ---------------------------------------------------------------------------
+# Download directory config (for download_activity_file / set_fit_download_dir)
+# ---------------------------------------------------------------------------
+
+_DEFAULT_FIT_CONFIG = "~/.garminconnect_fit_config.json"
+
+
+def _get_fit_config_path() -> str:
+    """Path to the JSON config that stores the default download directory."""
+    return os.getenv("GARMIN_FIT_CONFIG") or _DEFAULT_FIT_CONFIG
+
+
+def _read_fit_config() -> dict:
+    """Read the FIT download config. Returns {} if missing or invalid."""
+    path = os.path.expanduser(_get_fit_config_path())
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else {}
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return {}
+
+
+def _write_fit_config(dir_path: str) -> None:
+    """Persist the default download directory to the JSON config."""
+    path = os.path.expanduser(_get_fit_config_path())
+    parent = os.path.dirname(path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump({"download_dir": dir_path}, f, indent=2)
+
+
+def _resolve_download_dir(output_dir: Optional[str]) -> Optional[str]:
+    """Resolve the directory for saving activity files (first match wins):
+
+    1. output_dir argument (one-off; not persisted)
+    2. GARMIN_FIT_DOWNLOAD_DIR environment variable
+    3. persisted config (download_dir)
+    Returns an absolute path, or None when nothing is configured.
+    """
+    if output_dir:
+        return os.path.abspath(os.path.expanduser(output_dir))
+    env_dir = os.getenv("GARMIN_FIT_DOWNLOAD_DIR")
+    if env_dir:
+        return os.path.abspath(os.path.expanduser(env_dir))
+    cfg_dir = _read_fit_config().get("download_dir")
+    if cfg_dir:
+        return os.path.abspath(os.path.expanduser(cfg_dir))
+    return None
 
 
 def _safe_avg(values: list) -> Optional[float]:

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -1095,4 +1095,26 @@ async def test_download_activity_file_none_response(
     )
     text = result[0][0].text
 
-    assert "No fit data" in text or "Error" in text
+    assert "No fit data returned" in text
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_fit_extraction_failure(
+    app_with_activity_analysis, mock_garmin_client, tmp_path
+):
+    # A ZIP with no .fit entry makes _extract_fit_bytes raise; the tool should
+    # return a debug JSON payload and write nothing.
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("notes.txt", b"no fit here")
+    mock_garmin_client.download_activity.return_value = buf.getvalue()
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert "error" in data
+    assert "first_16_bytes_hex" in data["debug"]
+    assert not (tmp_path / f"{ACTIVITY_ID}.fit").exists()

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -4,6 +4,7 @@ Integration tests for activity_analysis module MCP tools
 Tests the get_activity_fit_data tool using mocked Garmin API and fitparse responses.
 """
 import json
+import os
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from mcp.server.fastmcp import FastMCP
@@ -909,3 +910,38 @@ async def test_fit_hrv_lap_below_minimum_gets_no_hrv(app_with_activity_analysis,
     assert len(data["laps"]) == 2
     assert "hrv" in data["laps"][0]
     assert "hrv" not in data["laps"][1]
+
+
+# ---------------------------------------------------------------------------
+# Download config / directory resolution helpers
+# ---------------------------------------------------------------------------
+
+def test_resolve_download_dir_prefers_output_dir_arg(monkeypatch, tmp_path):
+    monkeypatch.setenv("GARMIN_FIT_DOWNLOAD_DIR", str(tmp_path / "env"))
+    result = activity_analysis._resolve_download_dir(str(tmp_path / "arg"))
+    assert result == os.path.abspath(str(tmp_path / "arg"))
+
+
+def test_resolve_download_dir_uses_env_var(monkeypatch, tmp_path):
+    monkeypatch.setenv("GARMIN_FIT_DOWNLOAD_DIR", str(tmp_path / "env"))
+    result = activity_analysis._resolve_download_dir(None)
+    assert result == os.path.abspath(str(tmp_path / "env"))
+
+
+def test_resolve_download_dir_uses_config_file(monkeypatch, tmp_path):
+    monkeypatch.delenv("GARMIN_FIT_DOWNLOAD_DIR", raising=False)
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(tmp_path / "fit_config.json"))
+    activity_analysis._write_fit_config(str(tmp_path / "saved"))
+    result = activity_analysis._resolve_download_dir(None)
+    assert result == os.path.abspath(str(tmp_path / "saved"))
+
+
+def test_resolve_download_dir_returns_none_when_unconfigured(monkeypatch, tmp_path):
+    monkeypatch.delenv("GARMIN_FIT_DOWNLOAD_DIR", raising=False)
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(tmp_path / "missing.json"))
+    assert activity_analysis._resolve_download_dir(None) is None
+
+
+def test_read_fit_config_missing_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(tmp_path / "missing.json"))
+    assert activity_analysis._read_fit_config() == {}

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -962,3 +962,23 @@ def test_read_fit_config_non_dict_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("GARMIN_FIT_CONFIG", str(cfg))
     cfg.write_text("[1, 2, 3]")
     assert activity_analysis._read_fit_config() == {}
+
+
+# ---------------------------------------------------------------------------
+# set_fit_download_dir tool
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_set_fit_download_dir_persists(app_with_activity_analysis, monkeypatch, tmp_path):
+    cfg = tmp_path / "fit_config.json"
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(cfg))
+    target = tmp_path / "downloads"
+
+    result = await app_with_activity_analysis.call_tool(
+        "set_fit_download_dir", {"path": str(target)}
+    )
+    data = json.loads(result[0][0].text)
+
+    assert data["download_dir"] == os.path.abspath(str(target))
+    assert os.path.isdir(str(target))  # directory was created
+    assert json.loads(cfg.read_text())["download_dir"] == os.path.abspath(str(target))

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -918,6 +918,8 @@ async def test_fit_hrv_lap_below_minimum_gets_no_hrv(app_with_activity_analysis,
 
 def test_resolve_download_dir_prefers_output_dir_arg(monkeypatch, tmp_path):
     monkeypatch.setenv("GARMIN_FIT_DOWNLOAD_DIR", str(tmp_path / "env"))
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(tmp_path / "fit_config.json"))
+    activity_analysis._write_fit_config(str(tmp_path / "cfg"))
     result = activity_analysis._resolve_download_dir(str(tmp_path / "arg"))
     assert result == os.path.abspath(str(tmp_path / "arg"))
 
@@ -944,4 +946,19 @@ def test_resolve_download_dir_returns_none_when_unconfigured(monkeypatch, tmp_pa
 
 def test_read_fit_config_missing_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setenv("GARMIN_FIT_CONFIG", str(tmp_path / "missing.json"))
+    assert activity_analysis._read_fit_config() == {}
+
+
+def test_resolve_download_dir_config_missing_key_returns_none(monkeypatch, tmp_path):
+    monkeypatch.delenv("GARMIN_FIT_DOWNLOAD_DIR", raising=False)
+    cfg = tmp_path / "cfg.json"
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(cfg))
+    cfg.write_text('{"other": "value"}')
+    assert activity_analysis._resolve_download_dir(None) is None
+
+
+def test_read_fit_config_non_dict_returns_empty(monkeypatch, tmp_path):
+    cfg = tmp_path / "cfg.json"
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(cfg))
+    cfg.write_text("[1, 2, 3]")
     assert activity_analysis._read_fit_config() == {}

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -3,8 +3,10 @@ Integration tests for activity_analysis module MCP tools
 
 Tests the get_activity_fit_data tool using mocked Garmin API and fitparse responses.
 """
+import io
 import json
 import os
+import zipfile
 import pytest
 from unittest.mock import Mock, patch, MagicMock
 from mcp.server.fastmcp import FastMCP
@@ -982,3 +984,115 @@ async def test_set_fit_download_dir_persists(app_with_activity_analysis, monkeyp
     assert data["download_dir"] == os.path.abspath(str(target))
     assert os.path.isdir(str(target))  # directory was created
     assert json.loads(cfg.read_text())["download_dir"] == os.path.abspath(str(target))
+
+
+# ---------------------------------------------------------------------------
+# download_activity_file tool
+# ---------------------------------------------------------------------------
+
+def _make_fit_zip(fit_bytes: bytes) -> bytes:
+    """Build an in-memory ZIP containing a single .fit file (as Garmin returns)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("activity.fit", fit_bytes)
+    return buf.getvalue()
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_fit_saves_file(
+    app_with_activity_analysis, mock_garmin_client, tmp_path
+):
+    from garminconnect import Garmin
+
+    fit_bytes = b"\x0e\x10FITDATA"
+    mock_garmin_client.download_activity.return_value = _make_fit_zip(fit_bytes)
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    expected = tmp_path / f"{ACTIVITY_ID}.fit"
+    assert expected.read_bytes() == fit_bytes
+    assert data["file_path"] == os.path.abspath(str(expected))
+    assert data["format"] == "fit"
+    assert data["size_bytes"] == len(fit_bytes)
+    mock_garmin_client.download_activity.assert_called_once_with(
+        ACTIVITY_ID, dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fmt,enum_attr", [
+    ("gpx", "GPX"),
+    ("tcx", "TCX"),
+    ("csv", "CSV"),
+])
+async def test_download_activity_file_other_formats_write_raw_bytes(
+    app_with_activity_analysis, mock_garmin_client, tmp_path, fmt, enum_attr
+):
+    from garminconnect import Garmin
+
+    payload = f"<{fmt}>data</{fmt}>".encode()
+    mock_garmin_client.download_activity.return_value = payload
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "format": fmt, "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    expected = tmp_path / f"{ACTIVITY_ID}.{fmt}"
+    assert expected.read_bytes() == payload
+    assert data["format"] == fmt
+    mock_garmin_client.download_activity.assert_called_once_with(
+        ACTIVITY_ID, dl_fmt=getattr(Garmin.ActivityDownloadFormat, enum_attr)
+    )
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_invalid_format(
+    app_with_activity_analysis, mock_garmin_client, tmp_path
+):
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "format": "pdf", "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert "Invalid format" in data["error"]
+    assert "fit" in data["valid_formats"]
+    mock_garmin_client.download_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_needs_setup(
+    app_with_activity_analysis, mock_garmin_client, monkeypatch, tmp_path
+):
+    monkeypatch.delenv("GARMIN_FIT_DOWNLOAD_DIR", raising=False)
+    monkeypatch.setenv("GARMIN_FIT_CONFIG", str(tmp_path / "missing.json"))
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file", {"activity_id": ACTIVITY_ID}
+    )
+    data = json.loads(result[0][0].text)
+
+    assert data["status"] == "needs_setup"
+    assert "suggested_default" in data
+    mock_garmin_client.download_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_none_response(
+    app_with_activity_analysis, mock_garmin_client, tmp_path
+):
+    mock_garmin_client.download_activity.return_value = None
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "output_dir": str(tmp_path)},
+    )
+    text = result[0][0].text
+
+    assert "No fit data" in text or "Error" in text


### PR DESCRIPTION
## Summary

Adds the ability to **download an activity's file to disk** — something the server couldn't do before. The existing `get_activity_fit_data` parses a FIT file in memory and returns JSON, and `download_workout` only confirms the bytes exist; neither saves a file. This PR adds two tools to `activity_analysis.py`:

- **`download_activity_file(activity_id, format="fit", output_dir=None)`** — downloads an activity and writes it to disk. `format` is one of `fit` (default — Garmin's `ORIGINAL`), `gpx`, `tcx`, `csv`. FIT downloads arrive as a ZIP and are unwrapped with the existing `_extract_fit_bytes` helper; the other formats are written as-is. Files are named `{activity_id}.{ext}`.
- **`set_fit_download_dir(path)`** — persists the default download directory.

### First-run setup (no client elicitation required)

An MCP tool can't surface its own prompt, and the protocol's elicitation feature isn't widely supported by clients yet. So the first-run "where should I save?" question is handled with an agent-relay pattern: when no directory is configured, `download_activity_file` returns `status: "needs_setup"` with the current working directory as the suggested default. The assistant asks the user, calls `set_fit_download_dir(path)`, then retries the download. The choice is persisted to `~/.garminconnect_fit_config.json` so it's only asked once.

### Directory resolution (first match wins)

1. `output_dir` argument — one-off, not persisted
2. `GARMIN_FIT_DOWNLOAD_DIR` environment variable — when set, skips the first-run prompt (useful for headless/CI)
3. persisted config (set via `set_fit_download_dir`)

### New environment variables

- `GARMIN_FIT_DOWNLOAD_DIR` — default download directory
- `GARMIN_FIT_CONFIG` — path to the persisted config file (default `~/.garminconnect_fit_config.json`)

### Notes

- The config writer is non-destructive (read-merge-write), so it won't clobber other keys added later.
- These tools depend only on the standard library (`os`, `json`, `zipfile`) — no `fitparse` requirement — so they work even when `fitparse` isn't installed.
- `activity_id` is cast with `int()` before it's used in the filename, so a malicious string ID can't inject path separators.
- Scope is intentionally minimal: one activity per call, fixed `{activity_id}.{ext}` naming (no batch download, no custom filenames).

## Test plan

- [x] FIT download: ZIP unwrapped via `_extract_fit_bytes`, file written to disk, called with `dl_fmt=ORIGINAL`
- [x] GPX / TCX / CSV: raw bytes written with correct extension and `dl_fmt` (parametrized)
- [x] Invalid format rejected **before** any network call
- [x] `needs_setup` returned when nothing is configured (no download attempted)
- [x] `None` / empty download handled gracefully
- [x] FIT extraction failure (ZIP without a `.fit`) → debug payload returned, nothing written
- [x] Directory precedence (arg > env var > persisted config) and config persistence
- [x] `set_fit_download_dir` creates the directory and persists the absolute path
- [x] Existing tests pass (integration suite green). The 3 pre-existing errors in `tests/test_garmin.py` require live credentials and are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
