### PR TITLE
Validate workout target type mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,39 @@ Common end-condition IDs:
 | 10 | `reps` |
 | 11 | `training.peaks.tss` |
 
+### Raw `upload_workout` target types
+
+When building raw Garmin workout JSON, `targetType.workoutTargetTypeId` and
+`targetType.workoutTargetTypeKey` must use Garmin's canonical mapping. Garmin
+treats the numeric ID as authoritative: a mismatched payload such as
+`{"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"}` is stored as
+`pace.zone`, because ID `6` means `pace.zone`.
+
+For a custom heart-rate range, use target type ID `4` with `heart.rate.zone` and
+put the bpm range in `targetValueOne` / `targetValueTwo`:
+
+```json
+{
+  "targetType": {
+    "workoutTargetTypeId": 4,
+    "workoutTargetTypeKey": "heart.rate.zone"
+  },
+  "targetValueOne": 143,
+  "targetValueTwo": 157
+}
+```
+
+For a named Garmin HR zone, use the same target type with `zoneNumber` instead:
+
+```json
+{
+  "targetType": {
+    "workoutTargetTypeId": 4,
+    "workoutTargetTypeKey": "heart.rate.zone"
+  },
+  "zoneNumber": 3
+}
+```
 ## One-click Install (Claude Desktop)
 
 The easiest way to add this server to Claude Desktop is via the `.dxt` Desktop Extension file — no JSON editing required.

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -61,7 +61,7 @@ def _fix_hr_zone_step(step: dict) -> None:
     Custom HR bpm ranges (e.g. targetValueOne=105, targetValueTwo=143) are left
     unchanged — these are legitimate custom heart rate targets in Garmin Connect.
     """
-    target_type = step.get('targetType', {})
+    target_type = step.get('targetType') or {}
     target_key = target_type.get('workoutTargetTypeKey', '')
 
     if target_key == 'heart.rate.zone' and 'zoneNumber' not in step:

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -160,9 +160,9 @@ def _validate_end_condition_steps(workout_data: dict) -> None:
             _validate_end_condition_step(step, path)
 
 
-def _validate_target_type_step(step: dict, path: str) -> None:
-    """Reject targetType id/key pairs Garmin would silently reinterpret."""
-    target_type = step.get('targetType')
+def _validate_target_type_block(step: dict, path: str, target_field: str) -> None:
+    """Reject a target type id/key pair Garmin would silently reinterpret."""
+    target_type = step.get(target_field)
     if isinstance(target_type, dict):
         target_key = target_type.get('workoutTargetTypeKey')
         target_id = target_type.get('workoutTargetTypeId')
@@ -171,21 +171,27 @@ def _validate_target_type_step(step: dict, path: str) -> None:
             try:
                 target_id = int(target_id)
             except (TypeError, ValueError):
-                raise ValueError(f"{path}.targetType.workoutTargetTypeId must be numeric")
+                raise ValueError(f"{path}.{target_field}.workoutTargetTypeId must be numeric")
 
         expected_key = KNOWN_TARGET_TYPE_IDS.get(target_id)
         if expected_key is not None and target_key is not None and target_key != expected_key:
             raise ValueError(
-                f"{path}.targetType mismatch: workoutTargetTypeId {target_id} is "
+                f"{path}.{target_field} mismatch: workoutTargetTypeId {target_id} is "
                 f"{expected_key!r}, not {target_key!r}"
             )
 
         expected_id = KNOWN_TARGET_TYPE_KEYS.get(target_key)
         if expected_id is not None and target_id is not None and target_id != expected_id:
             raise ValueError(
-                f"{path}.targetType mismatch: workoutTargetTypeKey {target_key!r} "
+                f"{path}.{target_field} mismatch: workoutTargetTypeKey {target_key!r} "
                 f"requires workoutTargetTypeId {expected_id}, not {target_id}"
             )
+
+
+def _validate_target_type_step(step: dict, path: str) -> None:
+    """Reject targetType id/key pairs Garmin would silently reinterpret."""
+    _validate_target_type_block(step, path, 'targetType')
+    _validate_target_type_block(step, path, 'secondaryTargetType')
 
     for index, nested in enumerate(step.get('workoutSteps', [])):
         _validate_target_type_step(nested, f"{path}.workoutSteps[{index}]")

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -34,13 +34,16 @@ END_CONDITION_TYPE_KEYS = {
     for condition_key, condition_id in END_CONDITION_TYPE_IDS.items()
 }
 
-TARGET_TYPE_IDS = {
+# Verified from Garmin-created workouts and live upload/fetch probes. Unknown
+# target type IDs are allowed so we do not block valid Garmin targets that are
+# not in this partial mapping yet.
+KNOWN_TARGET_TYPE_IDS = {
     1: "no.target",
     4: "heart.rate.zone",
     6: "pace.zone",
 }
 
-TARGET_TYPE_KEYS = {key: target_id for target_id, key in TARGET_TYPE_IDS.items()}
+KNOWN_TARGET_TYPE_KEYS = {key: target_id for target_id, key in KNOWN_TARGET_TYPE_IDS.items()}
 
 def configure(client):
     """Configure the module with the Garmin client instance"""
@@ -170,14 +173,14 @@ def _validate_target_type_step(step: dict, path: str) -> None:
             except (TypeError, ValueError):
                 raise ValueError(f"{path}.targetType.workoutTargetTypeId must be numeric")
 
-        expected_key = TARGET_TYPE_IDS.get(target_id)
+        expected_key = KNOWN_TARGET_TYPE_IDS.get(target_id)
         if expected_key is not None and target_key is not None and target_key != expected_key:
             raise ValueError(
                 f"{path}.targetType mismatch: workoutTargetTypeId {target_id} is "
                 f"{expected_key!r}, not {target_key!r}"
             )
 
-        expected_id = TARGET_TYPE_KEYS.get(target_key)
+        expected_id = KNOWN_TARGET_TYPE_KEYS.get(target_key)
         if expected_id is not None and target_id is not None and target_id != expected_id:
             raise ValueError(
                 f"{path}.targetType mismatch: workoutTargetTypeKey {target_key!r} "

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -34,6 +34,13 @@ END_CONDITION_TYPE_KEYS = {
     for condition_key, condition_id in END_CONDITION_TYPE_IDS.items()
 }
 
+TARGET_TYPE_IDS = {
+    1: "no.target",
+    4: "heart.rate.zone",
+    6: "pace.zone",
+}
+
+TARGET_TYPE_KEYS = {key: target_id for target_id, key in TARGET_TYPE_IDS.items()}
 
 def configure(client):
     """Configure the module with the Garmin client instance"""
@@ -148,6 +155,45 @@ def _validate_end_condition_steps(workout_data: dict) -> None:
         for step_index, step in enumerate(segment.get('workoutSteps', [])):
             path = f"workoutSegments[{segment_index}].workoutSteps[{step_index}]"
             _validate_end_condition_step(step, path)
+
+
+def _validate_target_type_step(step: dict, path: str) -> None:
+    """Reject targetType id/key pairs Garmin would silently reinterpret."""
+    target_type = step.get('targetType')
+    if isinstance(target_type, dict):
+        target_key = target_type.get('workoutTargetTypeKey')
+        target_id = target_type.get('workoutTargetTypeId')
+
+        if target_id is not None:
+            try:
+                target_id = int(target_id)
+            except (TypeError, ValueError):
+                raise ValueError(f"{path}.targetType.workoutTargetTypeId must be numeric")
+
+        expected_key = TARGET_TYPE_IDS.get(target_id)
+        if expected_key is not None and target_key is not None and target_key != expected_key:
+            raise ValueError(
+                f"{path}.targetType mismatch: workoutTargetTypeId {target_id} is "
+                f"{expected_key!r}, not {target_key!r}"
+            )
+
+        expected_id = TARGET_TYPE_KEYS.get(target_key)
+        if expected_id is not None and target_id is not None and target_id != expected_id:
+            raise ValueError(
+                f"{path}.targetType mismatch: workoutTargetTypeKey {target_key!r} "
+                f"requires workoutTargetTypeId {expected_id}, not {target_id}"
+            )
+
+    for index, nested in enumerate(step.get('workoutSteps', [])):
+        _validate_target_type_step(nested, f"{path}.workoutSteps[{index}]")
+
+
+def _validate_target_type_steps(workout_data: dict) -> None:
+    """Walk all workout steps and validate known targetType id/key pairs."""
+    for segment_index, segment in enumerate(workout_data.get('workoutSegments', [])):
+        for step_index, step in enumerate(segment.get('workoutSteps', [])):
+            path = f"workoutSegments[{segment_index}].workoutSteps[{step_index}]"
+            _validate_target_type_step(step, path)
 
 
 def _curate_workout_summary(workout: dict) -> dict:
@@ -535,6 +581,13 @@ def register_tools(app):
         to catch the common mistake of putting a zone index in targetValueOne. Typical bpm values
         (e.g. 105, 143) are not affected.
 
+        IMPORTANT: Target type IDs and keys must match Garmin's canonical mapping.
+        Garmin treats workoutTargetTypeId as authoritative, so mismatches such as
+        {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"} are rejected
+        before upload because Garmin would interpret them as "pace.zone". Use
+        {"workoutTargetTypeId": 4, "workoutTargetTypeKey": "heart.rate.zone"} with
+        targetValueOne/targetValueTwo for custom heart-rate ranges.
+
         IMPORTANT: Sport type IDs for workouts (different from activity API!):
         - 1 = running, 2 = cycling, 5 = strength_training, 6 = cardio, 11 = walking
 
@@ -606,6 +659,7 @@ def register_tools(app):
             # Fix common mistake: HR zone targets using targetValueOne instead of zoneNumber
             _fix_hr_zone_steps(workout_data)
             _validate_end_condition_steps(workout_data)
+            _validate_target_type_steps(workout_data)
 
             # Pass dict directly - library handles conversion
             result = garmin_client.upload_workout(workout_data)
@@ -640,7 +694,10 @@ def register_tools(app):
           "iterations"; omitting conditionTypeId causes the API to silently corrupt
           the repeat count.
 
-        IMPORTANT: For heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
+        IMPORTANT: For named heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
+        For custom heart-rate ranges, use targetType {"workoutTargetTypeId": 4,
+        "workoutTargetTypeKey": "heart.rate.zone"} with targetValueOne/targetValueTwo.
+        Target type IDs and keys must match Garmin's canonical mapping.
 
         IMPORTANT: End condition IDs and keys must match Garmin's canonical mapping.
         Garmin treats conditionTypeId as authoritative, so mismatches are rejected before upload.
@@ -654,6 +711,7 @@ def register_tools(app):
             try:
                 _fix_hr_zone_steps(workout_data)
                 _validate_end_condition_steps(workout_data)
+                _validate_target_type_steps(workout_data)
                 result = garmin_client.upload_workout(workout_data)
                 if isinstance(result, dict):
                     entry = {
@@ -947,6 +1005,7 @@ def register_tools(app):
                     # Upload the workout first, then use the returned ID to schedule
                     _fix_hr_zone_steps(workout_data)
                     _validate_end_condition_steps(workout_data)
+                    _validate_target_type_steps(workout_data)
                     upload_result = garmin_client.upload_workout(workout_data)
                     if not isinstance(upload_result, dict) or upload_result.get('workoutId') is None:
                         results.append({

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -594,6 +594,57 @@ async def test_upload_workout_rejects_missing_end_condition_id(
 
 
 @pytest.mark.asyncio
+async def test_upload_workout_rejects_secondary_target_type_mismatch(app_with_workouts, mock_garmin_client):
+    """Reject mismatched secondaryTargetType blocks before Garmin reinterprets them."""
+    step = _timed_interval_step({"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"})
+    step["secondaryTargetType"] = {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"}
+    step["secondaryTargetValueOne"] = 143
+    step["secondaryTargetValueTwo"] = 157
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Bad Secondary HR Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert "secondaryTargetType mismatch" in result[0][0].text
+    assert "workoutTargetTypeId 6 is 'pace.zone', not 'heart.rate'" in result[0][0].text
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_nested_secondary_target_type_mismatch(
+    app_with_workouts, mock_garmin_client
+):
+    """Reject mismatched secondaryTargetType blocks inside RepeatGroupDTO steps."""
+    bad_step = _timed_interval_step({"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"})
+    bad_step["secondaryTargetType"] = {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"}
+    workout_data = _running_workout_with_steps(
+        [{
+            "type": "RepeatGroupDTO",
+            "stepOrder": 1,
+            "numberOfIterations": 2,
+            "workoutSteps": [bad_step],
+        }],
+        name="Nested Bad Secondary HR Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert (
+        "workoutSegments[0].workoutSteps[0].workoutSteps[0].secondaryTargetType mismatch"
+        in result[0][0].text
+    )
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_get_scheduled_workouts_tool(app_with_workouts, mock_garmin_client):
     """Test get_scheduled_workouts tool - uses GraphQL query"""
     import json as json_module

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -596,7 +596,7 @@ async def test_upload_workout_rejects_missing_end_condition_id(
 @pytest.mark.asyncio
 async def test_upload_workout_rejects_secondary_target_type_mismatch(app_with_workouts, mock_garmin_client):
     """Reject mismatched secondaryTargetType blocks before Garmin reinterprets them."""
-    step = _timed_interval_step({"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"})
+    step = _timed_interval_step(None)
     step["secondaryTargetType"] = {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"}
     step["secondaryTargetValueOne"] = 143
     step["secondaryTargetValueTwo"] = 157
@@ -616,11 +616,42 @@ async def test_upload_workout_rejects_secondary_target_type_mismatch(app_with_wo
 
 
 @pytest.mark.asyncio
+async def test_upload_workout_accepts_secondary_target_type_with_null_primary(
+    app_with_workouts, mock_garmin_client
+):
+    """Swim-style secondary targets may use targetType null."""
+    import json as json_module
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123461,
+        "workoutName": "Secondary Pace Target",
+    }
+    step = _timed_interval_step(None)
+    step["secondaryTargetType"] = {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
+    step["secondaryTargetValueOne"] = 0.45
+    step["secondaryTargetValueTwo"] = 0.6916667
+    workout_data = _running_workout_with_steps("Secondary Pace Target", [step])
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    called_data = mock_garmin_client.upload_workout.call_args[0][0]
+    called_step = called_data["workoutSegments"][0]["workoutSteps"][0]
+    assert called_step["targetType"] is None
+    assert called_step["secondaryTargetType"]["workoutTargetTypeKey"] == "pace.zone"
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "success"
+
+
+@pytest.mark.asyncio
 async def test_upload_workout_rejects_nested_secondary_target_type_mismatch(
     app_with_workouts, mock_garmin_client
 ):
     """Reject mismatched secondaryTargetType blocks inside RepeatGroupDTO steps."""
-    bad_step = _timed_interval_step({"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"})
+    bad_step = _timed_interval_step(None)
     bad_step["secondaryTargetType"] = {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"}
     workout_data = _running_workout_with_steps(
         [{

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -42,6 +42,20 @@ def _running_workout_with_steps(steps, name="Validation Workout"):
     }
 
 
+def _timed_interval_step(target_type):
+    return {
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+        "endConditionValue": 300,
+        "targetType": target_type,
+        "targetValueOne": 143,
+        "targetValueTwo": 157,
+    }
+
+
+
 @pytest.mark.asyncio
 async def test_get_workouts_tool(app_with_workouts, mock_garmin_client):
     """Test get_workouts tool returns all workouts"""
@@ -426,6 +440,24 @@ async def test_upload_workout_rejects_mismatched_end_condition_id(
 
 
 @pytest.mark.asyncio
+async def test_upload_workout_rejects_target_type_mismatch(app_with_workouts, mock_garmin_client):
+    """Reject targetType IDs that Garmin would reinterpret as another target."""
+    workout_data = _running_workout_with_steps(
+        [_timed_interval_step({"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"})],
+        name="Bad HR Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert "targetType mismatch" in result[0][0].text
+    assert "workoutTargetTypeId 6 is 'pace.zone', not 'heart.rate'" in result[0][0].text
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_upload_workout_accepts_heart_rate_end_condition_id(
     app_with_workouts, mock_garmin_client
 ):
@@ -450,6 +482,35 @@ async def test_upload_workout_accepts_heart_rate_end_condition_id(
 
     assert result is not None
     mock_garmin_client.upload_workout.assert_called_once_with(workout_data)
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_accepts_custom_hr_range(app_with_workouts, mock_garmin_client):
+    """Custom HR bpm ranges use heart.rate.zone with targetValueOne/targetValueTwo."""
+    import json as json_module
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123460,
+        "workoutName": "Custom HR Range",
+    }
+    workout_data = _running_workout_with_steps(
+        [_timed_interval_step({"workoutTargetTypeId": 4, "workoutTargetTypeKey": "heart.rate.zone"})],
+        name="Custom HR Range",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    called_data = mock_garmin_client.upload_workout.call_args[0][0]
+    step = called_data["workoutSegments"][0]["workoutSteps"][0]
+    assert step["targetValueOne"] == 143
+    assert step["targetValueTwo"] == 157
+    assert "zoneNumber" not in step
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "success"
 
 
 @pytest.mark.asyncio
@@ -481,6 +542,29 @@ async def test_upload_workout_rejects_nested_end_condition_mismatch(
     message = result[0][0].text
     assert "workoutSegments[0].workoutSteps[0].workoutSteps[0]" in message
     assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in message
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_nested_target_type_mismatch(app_with_workouts, mock_garmin_client):
+    """Reject mismatched targetType blocks inside RepeatGroupDTO steps."""
+    bad_step = _timed_interval_step({"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"})
+    workout_data = _running_workout_with_steps(
+        [{
+            "type": "RepeatGroupDTO",
+            "stepOrder": 1,
+            "numberOfIterations": 2,
+            "workoutSteps": [bad_step],
+        }],
+        name="Nested Bad HR Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data}
+    )
+
+    assert "workoutSegments[0].workoutSteps[0].workoutSteps[0].targetType mismatch" in result[0][0].text
     mock_garmin_client.upload_workout.assert_not_called()
 
 
@@ -934,6 +1018,39 @@ async def test_upload_workouts_reports_end_condition_validation_error(
     mock_garmin_client.upload_workout.assert_called_once_with(valid)
 
 
+@pytest.mark.asyncio
+async def test_upload_workouts_rejects_target_type_mismatch(app_with_workouts, mock_garmin_client):
+    """Batch uploads reject malformed targetType blocks before calling Garmin."""
+    import json as json_module
+
+    good_workout = _running_workout_with_steps(
+        [_timed_interval_step({"workoutTargetTypeId": 4, "workoutTargetTypeKey": "heart.rate.zone"})],
+        name="Good HR Range",
+    )
+    bad_workout = _running_workout_with_steps(
+        [_timed_interval_step({"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"})],
+        name="Bad HR Target",
+    )
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 111,
+        "workoutName": "Good HR Range",
+    }
+
+    result = await app_with_workouts.call_tool(
+        "upload_workouts",
+        {"workouts": [good_workout, bad_workout]},
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 2
+    assert result_data["succeeded"] == 1
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "success"
+    assert result_data["results"][1]["status"] == "error"
+    assert "targetType mismatch" in result_data["results"][1]["message"]
+    mock_garmin_client.upload_workout.assert_called_once_with(good_workout)
+
+
 # schedule_workouts tests
 @pytest.mark.asyncio
 async def test_schedule_workouts_single(app_with_workouts, mock_garmin_client):
@@ -1166,6 +1283,31 @@ async def test_schedule_workouts_inline_upload_rejects_end_condition_mismatch(
     assert result_data["failed"] == 1
     assert result_data["results"][0]["status"] == "error"
     assert "conditionTypeKey 'heart.rate' requires conditionTypeId 6" in result_data["results"][0]["message"]
+    mock_garmin_client.upload_workout.assert_not_called()
+    mock_garmin_client.client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_workouts_rejects_inline_target_type_mismatch(app_with_workouts, mock_garmin_client):
+    """Inline workout_data uses the same targetType validation as upload_workout."""
+    import json as json_module
+
+    inline_data = _running_workout_with_steps(
+        [_timed_interval_step({"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"})],
+        name="Bad Inline HR Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "schedule_workouts",
+        {"schedules": [{"workout_data": inline_data, "calendar_date": "2024-02-01"}]},
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 1
+    assert result_data["succeeded"] == 0
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "error"
+    assert "targetType mismatch" in result_data["results"][0]["message"]
     mock_garmin_client.upload_workout.assert_not_called()
     mock_garmin_client.client.post.assert_not_called()
 


### PR DESCRIPTION
## Summary

Fixes #129.

This PR adds pre-upload validation for Garmin workout `targetType` ID/key pairs. Garmin treats `workoutTargetTypeId` as authoritative, so a payload such as:

```json
{"workoutTargetTypeId": 6, "workoutTargetTypeKey": "heart.rate"}
```

is stored by Garmin as `pace.zone`, because ID `6` is the canonical `pace.zone` target type. The validator now rejects known ID/key mismatches before upload instead of allowing Garmin to silently create the wrong workout target.

## Reproduction

I reproduced the issue against Garmin Connect before changing the code:

- Uploaded a running workout step with `workoutTargetTypeId: 6` and `workoutTargetTypeKey: "heart.rate"`, with `targetValueOne: 143` and `targetValueTwo: 157`.
- Fetched the workout back via `get_workout_by_id`.
- Garmin returned `workoutTargetTypeId: 6` with `workoutTargetTypeKey: "pace.zone"`; the numeric values were preserved as `143.0` and `157.0`.
- Uploaded a control workout using `workoutTargetTypeId: 4` and `workoutTargetTypeKey: "heart.rate.zone"` with the same `targetValueOne` / `targetValueTwo` values.
- Garmin returned `heart.rate.zone` and preserved the custom HR range.
- Both temporary repro workouts were deleted successfully.

## Technical choices

I chose strict validation rather than silently rewriting mismatched payloads because the malformed payload is ambiguous. If a caller sends ID `6` and a heart-rate key, we cannot safely know whether they intended pace or heart rate. Rewriting the request could hide a client-side bug and still produce a workout that behaves differently from what the caller requested.

This does not conflict with the existing HR-zone compatibility fix from #49. That fix handles a narrower, non-ambiguous case: `heart.rate.zone` with `targetValueOne` set to a small integer `1..5`, which is almost certainly a named zone number and is normalized to `zoneNumber`. Custom HR bpm ranges like `143..157` are still valid and are left unchanged. The new validation runs after that normalization, preserving the old behavior while rejecting true ID/key mismatches.

The canonical custom HR range form is:

```json
{
  "targetType": {
    "workoutTargetTypeId": 4,
    "workoutTargetTypeKey": "heart.rate.zone"
  },
  "targetValueOne": 143,
  "targetValueTwo": 157
}
```

Named Garmin HR zones continue to use the same target type with `zoneNumber` instead of `targetValueOne` / `targetValueTwo`.

## Changes

- Added known `targetType` canonical mappings and recursive pre-upload validation.
- Applied validation in `upload_workout`, `upload_workouts`, and inline `schedule_workouts` uploads.
- Kept the existing HR-zone normalization behavior intact.
- Documented raw `upload_workout` target type mapping and custom HR range usage in the README.
- Added integration coverage for invalid mismatch rejection, valid custom HR ranges, nested repeat groups, batch uploads, and inline scheduled uploads.

## Test plan

- [x] `uv run pytest tests/integration/test_workouts_tools.py` - 43 passed
- [x] `uv run pytest tests/e2e tests/integration tests/unit tests/test_mcp_debug.py` - 307 passed
