### PR TITLE
feat: add unschedule_workout and unschedule_workouts tools

### DIFF
--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -410,6 +410,9 @@ def _curate_scheduled_workout(scheduled: dict) -> dict:
 
     summary = {
         "date": scheduled.get('scheduleDate'),
+        # Calendar-entry id (distinct from workout_id). Pass this to
+        # unschedule_workout to remove the entry from the calendar.
+        "scheduled_workout_id": scheduled.get('scheduledWorkoutId'),
         "workout_uuid": scheduled.get('workoutUuid'),
         "workout_id": scheduled.get('workoutId'),
         "name": scheduled.get('workoutName'),
@@ -1069,6 +1072,82 @@ def register_tools(app):
                     "workout_id": workout_id,
                     "scheduled_date": calendar_date,
                     "message": f"Error scheduling workout: {str(e)}"
+                })
+
+        total = len(results)
+        succeeded = sum(1 for r in results if r["status"] == "success")
+        return json.dumps({
+            "total": total,
+            "succeeded": succeeded,
+            "failed": total - succeeded,
+            "results": results
+        }, indent=2)
+
+    @app.tool()
+    async def unschedule_workout(scheduled_workout_id: int) -> str:
+        """Remove a scheduled workout from the Garmin Connect calendar
+
+        Deletes a calendar entry without deleting the underlying workout
+        template — the workout stays in your library and can be re-scheduled.
+
+        IMPORTANT: scheduled_workout_id is the calendar-entry id, which is
+        different from the workout's id. Get it from get_scheduled_workouts
+        (the "scheduled_workout_id" field), not from get_workouts.
+
+        Note: the scheduled-workouts listing is an eventually-consistent index.
+        If you just scheduled this workout, allow a moment before unscheduling
+        so the id is available.
+
+        Args:
+            scheduled_workout_id: Calendar-entry id from get_scheduled_workouts
+        """
+        try:
+            # Delegate to the high-level garminconnect method. Its client.delete
+            # returns a dict ({}), not a Response, so we rely on exceptions to
+            # signal failure rather than checking a status code — same pattern
+            # as delete_workout.
+            garmin_client.unschedule_workout(scheduled_workout_id)
+            return json.dumps({
+                "status": "success",
+                "scheduled_workout_id": scheduled_workout_id,
+                "message": f"Scheduled workout {scheduled_workout_id} removed from calendar"
+            }, indent=2)
+        except Exception as e:
+            return json.dumps({
+                "status": "failed",
+                "scheduled_workout_id": scheduled_workout_id,
+                "message": f"Failed to unschedule workout: {str(e)}"
+            }, indent=2)
+
+    @app.tool()
+    async def unschedule_workouts(scheduled_workout_ids: list[int]) -> str:
+        """Remove multiple scheduled workouts from the Garmin Connect calendar
+
+        Deletes multiple calendar entries in a single call. The underlying
+        workout templates are left intact in your library.
+
+        IMPORTANT: each id is a calendar-entry id (the "scheduled_workout_id"
+        field from get_scheduled_workouts), not a workout id.
+
+        Args:
+            scheduled_workout_ids: List of calendar-entry ids from get_scheduled_workouts
+        """
+        results = []
+        for scheduled_workout_id in scheduled_workout_ids:
+            try:
+                # See note in unschedule_workout: high-level call returns a dict,
+                # so rely on exceptions to signal failure.
+                garmin_client.unschedule_workout(scheduled_workout_id)
+                results.append({
+                    "status": "success",
+                    "scheduled_workout_id": scheduled_workout_id,
+                    "message": f"Scheduled workout {scheduled_workout_id} removed from calendar"
+                })
+            except Exception as e:
+                results.append({
+                    "status": "error",
+                    "scheduled_workout_id": scheduled_workout_id,
+                    "message": f"Error unscheduling workout: {str(e)}"
                 })
 
         total = len(results)

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -1536,3 +1536,125 @@ def test_fix_repeat_group_recurses_into_nested_repeat_groups():
     }
     _fix_repeat_group_step(outer)
     assert inner["endCondition"]["conditionTypeId"] == 7
+
+
+# unschedule_workout tests
+@pytest.mark.asyncio
+async def test_unschedule_workout_success(app_with_workouts, mock_garmin_client):
+    """Test unschedule_workout tool when the library call succeeds"""
+    import json as json_module
+
+    # The SDK's unschedule_workout returns {} (a dict), not a Response;
+    # success is signalled by the absence of an exception.
+    mock_garmin_client.unschedule_workout.return_value = {}
+
+    scheduled_workout_id = 1677275789
+    result = await app_with_workouts.call_tool(
+        "unschedule_workout",
+        {"scheduled_workout_id": scheduled_workout_id}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "success"
+    assert result_data["scheduled_workout_id"] == scheduled_workout_id
+    assert "removed from calendar" in result_data["message"]
+    mock_garmin_client.unschedule_workout.assert_called_once_with(scheduled_workout_id)
+
+
+@pytest.mark.asyncio
+async def test_unschedule_workout_error(app_with_workouts, mock_garmin_client):
+    """Test unschedule_workout tool surfaces failures from the library"""
+    import json as json_module
+
+    mock_garmin_client.unschedule_workout.side_effect = Exception("Network error")
+
+    result = await app_with_workouts.call_tool(
+        "unschedule_workout",
+        {"scheduled_workout_id": 999}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "failed"
+    assert result_data["scheduled_workout_id"] == 999
+    assert "Network error" in result_data["message"]
+
+
+# unschedule_workouts (batch) tests
+@pytest.mark.asyncio
+async def test_unschedule_workouts_multiple(app_with_workouts, mock_garmin_client):
+    """Test unschedule_workouts batch tool with multiple ids"""
+    import json as json_module
+
+    mock_garmin_client.unschedule_workout.return_value = {}
+
+    result = await app_with_workouts.call_tool(
+        "unschedule_workouts",
+        {"scheduled_workout_ids": [111, 222, 333]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 3
+    assert result_data["succeeded"] == 3
+    assert result_data["failed"] == 0
+    assert mock_garmin_client.unschedule_workout.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_unschedule_workouts_partial_failure(app_with_workouts, mock_garmin_client):
+    """Test unschedule_workouts batch tool when some calls fail"""
+    import json as json_module
+
+    mock_garmin_client.unschedule_workout.side_effect = [
+        {},
+        Exception("API Error 404"),
+    ]
+
+    result = await app_with_workouts.call_tool(
+        "unschedule_workouts",
+        {"scheduled_workout_ids": [111, 999]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 2
+    assert result_data["succeeded"] == 1
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "success"
+    assert result_data["results"][1]["status"] == "error"
+    assert "404" in result_data["results"][1]["message"]
+
+
+@pytest.mark.asyncio
+async def test_get_scheduled_workouts_exposes_scheduled_id(app_with_workouts, mock_garmin_client):
+    """get_scheduled_workouts surfaces the calendar-entry id for unscheduling"""
+    import json as json_module
+
+    graphql_response = {
+        "data": {
+            "workoutScheduleSummariesScalar": [
+                {
+                    "scheduledWorkoutId": 555,
+                    "workoutUuid": None,
+                    "workoutId": 123456,
+                    "workoutName": "5K Tempo Run",
+                    "workoutType": "running",
+                    "scheduleDate": "2024-01-15",
+                    "associatedActivityId": None,
+                }
+            ]
+        }
+    }
+    mock_garmin_client.query_garmin_graphql.return_value = graphql_response
+
+    result = await app_with_workouts.call_tool(
+        "get_scheduled_workouts",
+        {"start_date": "2024-01-08", "end_date": "2024-01-15"}
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    workout = result_data["scheduled_workouts"][0]
+    assert workout["scheduled_workout_id"] == 555
+    assert workout["workout_id"] == 123456


### PR DESCRIPTION
## Summary

Partially addresses #132.

Adds the ability to remove a scheduled workout from the Garmin Connect
calendar, completing the schedule/unschedule pair. The workout template is
left untouched in the library — only the calendar entry is removed.

## Changes

1. **`get_scheduled_workouts` now exposes `scheduled_workout_id`** — the
   calendar-entry id from the GraphQL `workoutScheduleSummariesScalar`
   response. This is distinct from `workout_id` and is the id required to
   unschedule.
2. **`unschedule_workout(scheduled_workout_id)`** — removes a single calendar
   entry, leaving the workout template in the library intact.
3. **`unschedule_workouts(scheduled_workout_ids)`** — batch variant, same
   aggregate result shape as `delete_workouts`.

Both delegate to the high-level `garminconnect.unschedule_workout`, which
returns a dict (not a `Response`), so failure is signalled via exceptions —
the same pattern used by `delete_workout`.

## Scope relative to #132

This PR covers the core ask (an explicit calendar-level unschedule, single +
batch) but intentionally differs from the issue's proposed shape in one place,
and leaves the nice-to-have for a follow-up:

- **Identified by `scheduled_workout_id`, not `(workout_id, calendar_date)`.**
  The same workout can be scheduled multiple times (even on the same date), so
  the calendar-entry id is the unambiguous identifier. It is surfaced directly
  by `get_scheduled_workouts`, so the natural flow is *list → unschedule by id*,
  mirroring the existing `get_workouts` → `delete_workout` pattern. A
  `(workout_id, calendar_date)` convenience wrapper that resolves the id could
  be layered on top later if preferred.
- **`replace_scheduled_workout` is not included.** With `schedule_workout`
  (idempotent) and `unschedule_workout` now available, replace is composable;
  a dedicated higher-level tool can follow in a separate PR.

### Follow-ups (happy to do these in separate PRs)

- **`unschedule_workout_on_date(workout_id, calendar_date)`** — a convenience
  wrapper matching the signature proposed in #132. It would resolve the
  `scheduled_workout_id` (e.g. via the calendar lookup) and then delete, so
  callers that only have `workout_id` + date don't need a prior
  `get_scheduled_workouts` call. This is a nicer ergonomic for LLM-driven
  flows and I'm keen to add it.
- **`replace_scheduled_workout(calendar_date, new_workout_id, ...)`** — the
  higher-level replace from #132, built on unschedule + schedule.

## Live verification (real account)

- Scheduled a workout, then `get_scheduled_workouts` returned a matching
  `scheduled_workout_id` equal to the calendar entry id.
- `unschedule_workout` removed the entry; the calendar was empty afterward and
  the workout template still appeared in `get_workouts`.
- Note: the GraphQL summaries index is eventually consistent — right after a
  write it can briefly lag; the normal "list then remove" flow is unaffected,
  and this is documented in the tool docstring.

## Tests

- Added 5 integration tests: `unschedule_workout` success/error,
  `unschedule_workouts` batch/partial-failure, and `get_scheduled_workouts`
  exposing `scheduled_workout_id`.
- 252 integration tests pass. One pre-existing failure
  (`test_upload_workout_accepts_secondary_target_type_with_null_primary`) is
  unrelated to this PR — it fails identically on `main` with these changes
  stashed.