### PR TITLE
fix(tests): correct _running_workout_with_steps call signature in secondary target type test

### DIFF
--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -630,7 +630,7 @@ async def test_upload_workout_accepts_secondary_target_type_with_null_primary(
     step["secondaryTargetType"] = {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
     step["secondaryTargetValueOne"] = 0.45
     step["secondaryTargetValueTwo"] = 0.6916667
-    workout_data = _running_workout_with_steps("Secondary Pace Target", [step])
+    workout_data = _running_workout_with_steps([step], name="Secondary Pace Target")
 
     result = await app_with_workouts.call_tool(
         "upload_workout",


### PR DESCRIPTION
## Summary

- The squashed merge of PR #133 retained one test helper call with the old `(name, steps)` argument order in `test_upload_workout_accepts_secondary_target_type_with_null_primary`
- The `_running_workout_with_steps` helper on `main` uses `(steps, name="Validation Workout")` — name first caused the test to fail because `"Secondary Pace Target"` was passed as `steps` instead of a list
- This one-line fix corrects the call to `_running_workout_with_steps([step], name="Secondary Pace Target")`

## Test plan

- [ ] `uv run pytest tests/integration/test_workouts_tools.py -v` — all 51 tests pass
- [ ] `uv run pytest tests/integration/ -q` — all 248 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)