### PR TITLE
fix(auth): fail loudly when saved tokens don't authenticate

### DIFF
--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -76,6 +76,36 @@ def get_credentials() -> tuple[str, str]:
     return email, password
 
 
+def _verify_saved_tokens(token_path: str, is_cn: bool = False) -> tuple[bool, str]:
+    """Independently confirm the freshly saved tokens actually authenticate.
+
+    Performs a clean token-based login (which loads the social profile and
+    raises on an unauthenticated session — unlike the ``return_on_mfa`` login
+    used to obtain the tokens, which skips that check). This is what turns a
+    silent "logged in as None" into a real failure.
+
+    Returns:
+        (True, full_name) on success, or (False, error_summary) on failure.
+    """
+    import io
+
+    print("\nVerifying tokens...")
+
+    old_stderr = sys.stderr
+    sys.stderr = io.StringIO()
+    try:
+        garmin = Garmin(is_cn=is_cn)
+        garmin.login(token_path)
+        name = garmin.get_full_name()
+        if not name:
+            return False, "session is not authenticated (no profile returned)"
+        return True, name
+    except Exception as e:
+        return False, str(e).split(":")[0].strip() or e.__class__.__name__
+    finally:
+        sys.stderr = old_stderr
+
+
 def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = False, is_cn: bool = False) -> bool:
     """Authenticate with Garmin Connect and save tokens.
 
@@ -146,17 +176,20 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
             token_file.write(token_base64)
         print(f"✓ OAuth tokens (base64) saved to: {expanded_base64_path}")
 
-        # Verify tokens work
-        print("\nVerifying tokens...")
-        try:
-            # Try to get user's full name as a simple verification
-            full_name = garmin.get_full_name()
-            print(f"✓ Authentication successful!")
-            print(f"  Logged in as: {full_name}")
-        except Exception:
-            # Fallback: just confirm tokens were saved
-            print(f"✓ Authentication successful!")
-            print(f"  OAuth tokens saved and ready to use.")
+        # Verify tokens work with an independent token-based login. The login
+        # above runs with return_on_mfa=True, which skips profile loading, so a
+        # rate-limited run can "succeed" with an unauthenticated session. Check
+        # rather than trust the dump, so a bad login fails loudly instead of
+        # printing "Logged in as: None" and exiting 0.
+        is_valid, name_or_err = _verify_saved_tokens(token_path, is_cn)
+        if not is_valid:
+            print(f"\n✗ Authentication failed: saved tokens do not authenticate", file=sys.stderr)
+            print(f"  {name_or_err}", file=sys.stderr)
+            print("  Garmin may be rate-limiting your IP — wait a few minutes and retry.", file=sys.stderr)
+            return False
+
+        print(f"✓ Authentication successful!")
+        print(f"  Logged in as: {name_or_err}")
 
         print("\n" + "=" * 60)
         print("SUCCESS: You can now use the Garmin MCP server!")

--- a/tests/unit/test_auth_cli.py
+++ b/tests/unit/test_auth_cli.py
@@ -129,7 +129,8 @@ class TestAuthenticate:
     @patch("garmin_mcp.auth_cli.validate_tokens")
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
-    def test_existing_valid_tokens_with_force(self, mock_garmin, mock_get_creds, mock_validate, mock_exists):
+    @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
+    def test_existing_valid_tokens_with_force(self, mock_verify, mock_garmin, mock_get_creds, mock_validate, mock_exists):
         """Test that force flag re-authenticates even with valid tokens."""
         mock_exists.return_value = True
         mock_validate.return_value = (True, "")
@@ -138,7 +139,6 @@ class TestAuthenticate:
         mock_garmin_instance = Mock()
         mock_garmin_instance.login = Mock(return_value=(None, None))
         mock_garmin_instance.client = Mock()
-        mock_garmin_instance.get_full_name = Mock(return_value="Test User")
         mock_garmin.return_value = mock_garmin_instance
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -151,7 +151,8 @@ class TestAuthenticate:
     @patch("garmin_mcp.auth_cli.token_exists")
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
-    def test_successful_authentication(self, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
+    def test_successful_authentication(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Test successful authentication flow."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -159,7 +160,6 @@ class TestAuthenticate:
         mock_garmin_instance = Mock()
         mock_garmin_instance.login = Mock(return_value=(None, None))
         mock_garmin_instance.client = Mock()
-        mock_garmin_instance.get_full_name = Mock(return_value="Test User")
         mock_garmin.return_value = mock_garmin_instance
 
         token_data = '{"token": "test"}'
@@ -174,9 +174,32 @@ class TestAuthenticate:
         assert result is True
         mock_garmin_instance.login.assert_called_once()
         mock_garmin_instance.client.dump.assert_called_once_with(tmpdir)
-        mock_garmin_instance.get_full_name.assert_called_once()
+        # Tokens are verified by an independent token-based login
+        mock_verify.assert_called_once()
         # Verify base64-encoded token data was written to the base64 file
         m().write.assert_called_once_with(expected_b64)
+
+    @patch("garmin_mcp.auth_cli.token_exists")
+    @patch("garmin_mcp.auth_cli.get_credentials")
+    @patch("garmin_mcp.auth_cli.Garmin")
+    @patch("garmin_mcp.auth_cli._verify_saved_tokens")
+    def test_unverifiable_tokens_fail(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
+        """Login that produces unauthenticated tokens must fail, not report success."""
+        mock_exists.return_value = False
+        mock_get_creds.return_value = ("test@example.com", "secret")
+        # Login "succeeds" but the saved tokens don't actually authenticate.
+        mock_verify.return_value = (False, "session is not authenticated (no profile returned)")
+
+        mock_garmin_instance = Mock()
+        mock_garmin_instance.login = Mock(return_value=(None, None))
+        mock_garmin_instance.client = Mock()
+        mock_garmin.return_value = mock_garmin_instance
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            with patch("builtins.open", mock_open(read_data="{}")):
+                result = authenticate(tmpdir, f"{tmpdir}/base64", force_reauth=False)
+
+        assert result is False
 
     @patch("garmin_mcp.auth_cli.token_exists")
     @patch("garmin_mcp.auth_cli.get_credentials")
@@ -367,7 +390,8 @@ class TestAuthenticateIsCn:
     @patch("garmin_mcp.auth_cli.token_exists")
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
-    def test_authenticate_passes_is_cn_true(self, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
+    def test_authenticate_passes_is_cn_true(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Test that is_cn=True is passed to Garmin constructor."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -375,7 +399,6 @@ class TestAuthenticateIsCn:
         mock_garmin_instance = Mock()
         mock_garmin_instance.login = Mock(return_value=(None, None))
         mock_garmin_instance.client = Mock()
-        mock_garmin_instance.get_full_name = Mock(return_value="Test User")
         mock_garmin.return_value = mock_garmin_instance
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -383,7 +406,7 @@ class TestAuthenticateIsCn:
                 result = authenticate(tmpdir, f"{tmpdir}/base64", force_reauth=False, is_cn=True)
 
         assert result is True
-        # Verify Garmin was called with is_cn=True
+        # Verify Garmin was called with is_cn=True (verification login is mocked out)
         mock_garmin.assert_called_once_with(
             email="test@example.com",
             password="secret",
@@ -395,7 +418,8 @@ class TestAuthenticateIsCn:
     @patch("garmin_mcp.auth_cli.token_exists")
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
-    def test_authenticate_passes_is_cn_false(self, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
+    def test_authenticate_passes_is_cn_false(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Test that is_cn=False is passed to Garmin constructor by default."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -403,7 +427,6 @@ class TestAuthenticateIsCn:
         mock_garmin_instance = Mock()
         mock_garmin_instance.login = Mock(return_value=(None, None))
         mock_garmin_instance.client = Mock()
-        mock_garmin_instance.get_full_name = Mock(return_value="Test User")
         mock_garmin.return_value = mock_garmin_instance
 
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -411,7 +434,7 @@ class TestAuthenticateIsCn:
                 result = authenticate(tmpdir, f"{tmpdir}/base64", force_reauth=False)
 
         assert result is True
-        # Verify Garmin was called with is_cn=False
+        # Verify Garmin was called with is_cn=False (verification login is mocked out)
         mock_garmin.assert_called_once_with(
             email="test@example.com",
             password="secret",


### PR DESCRIPTION
## Problem
  `garmin-mcp-auth` could print SUCCESS with `Logged in as: None` and exit 0
  even when login was rate-limited and produced an unauthenticated session.
  Verification used `get_full_name()`, but the CLI logs in with
  `None`, and the `except Exception` fallback reported success regardless.

  ## Fix
  - Add `_verify_saved_tokens()`: an independent token-based login that loads
    the profile and raises on an unauthenticated session.
  - On failure: print the error, hint at IP rate-limiting, and return
    non-zero instead of saving a bogus success.
  - On success: show the real account name.
  
  ## Tests
  Updated success-path tests to mock the new verifier; added a test that an
  unverifiable session fails. 59 unit tests pass.