### PR TITLE
feat: serve MCP over HTTP (streamable-http/sse) transports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,8 +32,8 @@ COPY pytest.ini ./
 RUN mkdir -p /root/.garminconnect && \
     chmod 700 /root/.garminconnect
 
-# Expose the application (if needed for network communication)
-# Note: MCP servers typically communicate via stdio, so no port exposure is usually needed
+# Expose the HTTP port. The image defaults to stdio (Claude Desktop, Inspector);
+# set GARMIN_MCP_TRANSPORT=streamable-http to serve over this port (e.g. in k8s).
 # EXPOSE 8000
 
 # Set the entrypoint to run the MCP server

--- a/README.md
+++ b/README.md
@@ -392,6 +392,25 @@ Your Garmin Connect credentials are read from environment variables:
 
 File-based secrets are useful in certain environments, such as inside a Docker container. Note that you cannot set both `GARMIN_EMAIL` and `GARMIN_EMAIL_FILE`, similarly you cannot set both `GARMIN_PASSWORD` and `GARMIN_PASSWORD_FILE`.
 
+### Transport
+
+By default the server communicates over **stdio**, which is what Claude Desktop, the MCP Inspector, and most local clients expect. To serve over **HTTP** instead (e.g. when running in a container or Kubernetes), set the transport via environment variables:
+
+- `GARMIN_MCP_TRANSPORT`: `stdio` (default), `streamable-http`, or `sse`
+- `GARMIN_MCP_HOST`: bind address for HTTP transports (default `0.0.0.0`)
+- `GARMIN_MCP_PORT`: bind port for HTTP transports (default `8000`)
+
+```bash
+GARMIN_MCP_TRANSPORT=streamable-http garmin-mcp
+```
+
+When an HTTP transport is selected:
+
+- MCP clients connect to the **`/mcp`** path (e.g. `http://localhost:8000/mcp`).
+- A plain **`GET /healthz`** endpoint is exposed for liveness/readiness probes.
+
+The server itself performs **no authentication** on the HTTP endpoint — put it behind a reverse proxy (nginx, Traefik, Authelia, etc.) if it is reachable beyond localhost.
+
 ### Garmin Connect China (garmin.cn)
 
 If you use Garmin Connect China (garmin.cn) instead of the international version, set the `GARMIN_IS_CN` environment variable to `true`:

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -103,6 +103,24 @@ enabled_tools = _parse_tool_set(os.getenv("GARMIN_ENABLED_TOOLS"))
 disabled_tools = _parse_tool_set(os.getenv("GARMIN_DISABLED_TOOLS"))
 
 
+# --- Transport configuration ------------------------------------------------
+# By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
+# Set GARMIN_MCP_TRANSPORT=streamable-http (or sse) to serve over HTTP, e.g.
+# when running in Kubernetes behind a reverse proxy that handles auth.
+#   GARMIN_MCP_TRANSPORT - stdio (default) | streamable-http | sse
+#   GARMIN_MCP_HOST      - bind address for HTTP transports (default 0.0.0.0)
+#   GARMIN_MCP_PORT      - bind port for HTTP transports (default 8000)
+_VALID_TRANSPORTS = ("stdio", "streamable-http", "sse")
+transport = os.getenv("GARMIN_MCP_TRANSPORT", "stdio").strip().lower()
+if transport not in _VALID_TRANSPORTS:
+    raise ValueError(
+        f"Invalid GARMIN_MCP_TRANSPORT {transport!r}; "
+        f"expected one of {', '.join(_VALID_TRANSPORTS)}"
+    )
+http_host = os.getenv("GARMIN_MCP_HOST", "0.0.0.0")
+http_port = int(os.getenv("GARMIN_MCP_PORT", "8000"))
+
+
 class _ToolFilter:
     """Wraps a FastMCP app to conditionally register tools by function name.
 
@@ -303,8 +321,10 @@ def main():
     courses.configure(garmin_client)
     activity_analysis.configure(garmin_client)
 
-    # Create the MCP app, wrapped so the env-var filter can drop tools
-    app = _ToolFilter(FastMCP("Garmin Connect v1.0"), enabled_tools, disabled_tools)
+    # Create the MCP app, wrapped so the env-var filter can drop tools.
+    # host/port only matter for the HTTP transports; stdio ignores them.
+    fastmcp = FastMCP("Garmin Connect v1.0", host=http_host, port=http_port)
+    app = _ToolFilter(fastmcp, enabled_tools, disabled_tools)
     if enabled_tools:
         print(f"Tool filter: allowlist of {len(enabled_tools)} tool(s).", file=sys.stderr)
     elif disabled_tools:
@@ -338,8 +358,23 @@ def main():
             file=sys.stderr,
         )
 
+    # When serving over HTTP, expose a plain health endpoint for k8s probes.
+    # The MCP endpoint itself requires a handshake and isn't probe-friendly.
+    if transport != "stdio":
+        from starlette.requests import Request
+        from starlette.responses import PlainTextResponse
+
+        @fastmcp.custom_route("/healthz", methods=["GET"])
+        async def healthz(_request: "Request") -> "PlainTextResponse":
+            return PlainTextResponse("ok")
+
+        print(
+            f"Serving MCP over {transport} on {http_host}:{http_port}",
+            file=sys.stderr,
+        )
+
     # Run the MCP server
-    app.run()
+    app.run(transport=transport)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION

  Adds an HTTP transport so the MCP server can run over the network
  (containers, Kubernetes, behind a reverse proxy) instead of only stdio.

  - `GARMIN_MCP_TRANSPORT` = `stdio` (default) | `streamable-http` | `sse`
  - `GARMIN_MCP_HOST` (default `0.0.0.0`) / `GARMIN_MCP_PORT` (default `8000`)
    for the HTTP transports
  - `GET /healthz` endpoint for liveness/readiness probes (HTTP transports only)
  - Invalid transport values fail fast with a clear error

  stdio remains the default, so existing Claude Desktop / Inspector setups are
  unaffected. The server performs no auth on the HTTP endpoint — front it with a
  reverse proxy if exposed beyond localhost.