### PR TITLE
Surface activity description and event type in get_activity

### DIFF
--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -203,8 +203,9 @@ def register_tools(app):
             curated = {
                 "id": activity.get('activityId'),
                 "name": activity.get('activityName'),
+                "description": activity.get('description'),
                 "type": activity_type.get('typeKey'),
-                "event_type": (activity.get('eventType') or {}).get('typeKey'),
+                "event_type": (activity.get('eventTypeDTO') or {}).get('typeKey'),
                 "parent_type": activity_type.get('parentTypeId'),
 
                 # Timing

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -38,8 +38,10 @@ MOCK_ACTIVITIES = [
 MOCK_ACTIVITY_DETAILS = {
     "activityId": 12345678901,
     "activityName": "Morning Run",
+    "description": "Felt strong throughout. New shoes.",
     "activityType": {"typeKey": "running", "typeId": 1},
-    "eventType": {"typeKey": "race", "typeId": 1},
+    "activityTypeDTO": {"typeKey": "running", "typeId": 1, "parentTypeId": 17},
+    "eventTypeDTO": {"typeKey": "race", "typeId": 1, "sortOrder": 5},
     "startTimeLocal": "2024-01-15 07:00:00",
     "distance": 5000.0,
     "duration": 1800.0,

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -516,6 +516,52 @@ async def test_get_activity_includes_event_type(app_with_activity_management, mo
     assert data["event_type"] == "race"
 
 
+@pytest.mark.asyncio
+async def test_get_activity_includes_description(app_with_activity_management, mock_garmin_client):
+    """Test get_activity surfaces the free-text description field.
+
+    Regression: the detail view previously never extracted 'description', so a
+    description set via set_activity_description could be written but not read
+    back through this tool.
+    """
+    mock_garmin_client.get_activity.return_value = MOCK_ACTIVITY_DETAILS
+
+    result = await app_with_activity_management.call_tool(
+        "get_activity",
+        {"activity_id": 12345678901}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["description"] == "Felt strong throughout. New shoes."
+
+
+@pytest.mark.asyncio
+async def test_get_activity_event_type_uses_event_type_dto(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test get_activity reads event type from eventTypeDTO, not eventType.
+
+    Regression: the single-activity detail endpoint returns eventTypeDTO (the
+    list endpoint returns eventType). The detail tool read the wrong key, so
+    event_type was always missing from get_activity against the real API.
+    """
+    mock_garmin_client.get_activity.return_value = {
+        "activityId": 1,
+        "activityName": "Race",
+        "eventTypeDTO": {"typeKey": "race", "typeId": 1},
+        "eventType": None,  # the wrong key the detail API does not populate
+        "summaryDTO": {},
+    }
+
+    result = await app_with_activity_management.call_tool(
+        "get_activity",
+        {"activity_id": 1}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["event_type"] == "race"
+
+
 # Error handling tests
 @pytest.mark.asyncio
 async def test_get_activities_by_date_no_data(app_with_activity_management, mock_garmin_client):


### PR DESCRIPTION
## Summary

`get_activity` returns a curated summary of an activity, but two fields
never made it into that summary. The free-text **description** was never
extracted, so a note added in the Garmin apps could not be read back
through this server at all. And **event type** was read from the key
`eventType`, whereas the single-activity endpoint returns `eventTypeDTO`
— only the activity *list* endpoints use `eventType`. So `event_type`
was always absent from the detail view when run against the live API.

This surfaces `description` and reads the event type from `eventTypeDTO`.

The existing test suite didn't catch the event-type bug because the
`MOCK_ACTIVITY_DETAILS` fixture mirrored the buggy key rather than the
real API response, effectively asserting the bug. The fixture is
corrected to match production (`eventTypeDTO`, plus a `description`), and
tests now cover both fields.

Verified against the live Garmin API: a real activity's description and
event type now come back through `get_activity`.

## Test plan

- [ ] `get_activity` on an activity with a description returns it
- [ ] `get_activity` returns `event_type` sourced from `eventTypeDTO`