### PR TITLE
Add tools to edit activity type, notes, event type, effort and feel

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 
 - List recent activities with pagination support
 - Get detailed activity information
-- Manage activity names
+- Edit activities: name, type, description/notes, event type, perceived effort (RPE), and feel
 - Access health metrics (steps, heart rate, sleep, stress, respiration)
 - View body composition data
 - Track training status and readiness
@@ -27,7 +27,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 
 This MCP server implements **110+ tools** covering ~90% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.3.2):
 
-- ✅ Activity Management (15 tools)
+- ✅ Activity Management (20 tools) - includes write tools for type, description, event type, perceived effort, and feel
 - ✅ Health & Wellness (31 tools) - includes custom lightweight summary tools
 - ✅ Training & Performance (13 tools) - includes CTL/ATL/TSB, HRV, VO2 max, and respiration trends
 - ✅ Workouts (8 tools)

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -15,6 +15,34 @@ def configure(client):
     garmin_client = client
 
 
+def _put_activity_update(activity_id: int, payload: Dict[str, Any]) -> Any:
+    """Send a partial activity update via PUT to the activity-service endpoint.
+
+    Garmin's activity endpoint accepts a partial ActivityDTO keyed by
+    activityId, so callers only include the top-level fields they want to
+    change. This mirrors how the library's set_activity_name works.
+    """
+    url = f"{garmin_client.garmin_connect_activity}/{activity_id}"
+    body = {"activityId": activity_id, **payload}
+    return garmin_client.client.put("connectapi", url, json=body, api=True)
+
+
+def _update_activity_summary(activity_id: int, fields: Dict[str, Any]) -> Any:
+    """Update fields nested in an activity's summaryDTO.
+
+    Garmin merges a partial summaryDTO into the stored summary, so we send only
+    the fields being changed and the other recorded metrics are preserved.
+
+    We deliberately avoid a read-modify-write. The full summaryDTO returned by
+    get_activity contains a complete GPS coordinate pair (startLatitude and
+    startLongitude); PUTting both halves of a coordinate together is rejected by
+    the endpoint with a 400. Each field is individually writable, so it is the
+    coordinate pair specifically that trips validation, and a minimal update
+    sidesteps it.
+    """
+    return _put_activity_update(activity_id, {"summaryDTO": fields})
+
+
 def register_tools(app):
     """Register all activity management tools with the MCP server app"""
 
@@ -305,6 +333,204 @@ def register_tools(app):
             )
         except Exception as e:
             return f"Error updating activity name: {str(e)}"
+
+    @app.tool()
+    async def set_activity_type(activity_id: Union[int, str], type_key: str) -> str:
+        """Change the activity type (sport) of an activity.
+
+        Useful for reclassifying a mislabelled activity, e.g. flipping a run
+        logged as 'trail_running' to 'running', or a 'treadmill_running' walk to
+        'treadmill_walking'. Call get_activity_types to see all valid type keys.
+
+        Args:
+            activity_id: ID of the activity to update
+            type_key: Target activity type key (e.g. 'running', 'trail_running',
+                'treadmill_running', 'cycling', 'lap_swimming')
+        """
+        try:
+            activity_id = int(activity_id)
+            type_key = type_key.strip()
+
+            types = garmin_client.get_activity_types() or []
+            match = next((t for t in types if t.get("typeKey") == type_key), None)
+            if not match:
+                valid = ", ".join(
+                    sorted(t.get("typeKey") for t in types if t.get("typeKey"))
+                )
+                return f"Unknown activity type '{type_key}'. Valid type keys: {valid}"
+
+            garmin_client.set_activity_type(
+                activity_id,
+                match["typeId"],
+                match["typeKey"],
+                match.get("parentTypeId"),
+            )
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "activity_id": activity_id,
+                    "type_key": match["typeKey"],
+                    "type_id": match["typeId"],
+                    "message": "Activity type successfully updated",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error updating activity type: {str(e)}"
+
+    @app.tool()
+    async def set_activity_description(
+        activity_id: Union[int, str], description: str
+    ) -> str:
+        """Set or update the free-text description (notes) of an activity.
+
+        This is the notes field shown on the activity page — useful for
+        recording how a session felt, kit used, conditions, niggles, etc.
+        Pass an empty string to clear an existing description.
+
+        Args:
+            activity_id: ID of the activity to update
+            description: New description text (empty string clears it)
+        """
+        try:
+            activity_id = int(activity_id)
+            _put_activity_update(activity_id, {"description": description})
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "activity_id": activity_id,
+                    "description": description,
+                    "message": "Activity description successfully updated",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error updating activity description: {str(e)}"
+
+    @app.tool()
+    async def set_activity_event_type(
+        activity_id: Union[int, str], event_type: str
+    ) -> str:
+        """Set the event type of an activity.
+
+        Event type categorises the activity's purpose. Valid keys:
+        race, recreation, specialEvent, training, transportation, touring,
+        geocaching, fitness, uncategorized.
+
+        Args:
+            activity_id: ID of the activity to update
+            event_type: Target event type key (e.g. 'race', 'training')
+        """
+        try:
+            activity_id = int(activity_id)
+            event_type = event_type.strip()
+
+            event_types = (
+                garmin_client.connectapi("/activity-service/activity/eventTypes") or []
+            )
+            match = next(
+                (e for e in event_types if e.get("typeKey") == event_type), None
+            )
+            if not match:
+                valid = ", ".join(e.get("typeKey") for e in event_types if e.get("typeKey"))
+                return f"Unknown event type '{event_type}'. Valid event types: {valid}"
+
+            _put_activity_update(
+                activity_id,
+                {
+                    "eventTypeDTO": {
+                        "typeId": match["typeId"],
+                        "typeKey": match["typeKey"],
+                        "sortOrder": match.get("sortOrder"),
+                    }
+                },
+            )
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "activity_id": activity_id,
+                    "event_type": match["typeKey"],
+                    "message": "Activity event type successfully updated",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error updating activity event type: {str(e)}"
+
+    @app.tool()
+    async def set_perceived_effort(
+        activity_id: Union[int, str], rpe: float
+    ) -> str:
+        """Set the perceived effort (RPE) for an activity.
+
+        Mirrors Garmin Connect's 'Perceived Effort' rating on a 0-10 scale,
+        where 0 clears the rating. Internally Garmin stores this multiplied by
+        10 (so RPE 7 is stored as 70); this tool handles the conversion.
+
+        Args:
+            activity_id: ID of the activity to update
+            rpe: Perceived effort from 0 to 10 (0 clears the rating)
+        """
+        try:
+            activity_id = int(activity_id)
+            rpe = float(rpe)
+            if not 0 <= rpe <= 10:
+                return "rpe must be between 0 and 10"
+
+            _update_activity_summary(
+                activity_id, {"directWorkoutRpe": int(round(rpe * 10))}
+            )
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "activity_id": activity_id,
+                    "rpe": rpe,
+                    "message": "Perceived effort successfully updated",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error updating perceived effort: {str(e)}"
+
+    @app.tool()
+    async def set_activity_feel(activity_id: Union[int, str], feel: int) -> str:
+        """Set how an activity felt ('How did you feel?').
+
+        Mirrors Garmin Connect's 5-point feel rating, stored as one of:
+          0   = very tired / poor
+          25  = tired
+          50  = normal
+          75  = good
+          100 = strong
+        Higher is better.
+
+        Args:
+            activity_id: ID of the activity to update
+            feel: One of 0, 25, 50, 75, 100
+        """
+        try:
+            activity_id = int(activity_id)
+            feel = int(feel)
+            if feel not in (0, 25, 50, 75, 100):
+                return "feel must be one of 0, 25, 50, 75, 100"
+
+            _update_activity_summary(activity_id, {"directWorkoutFeel": feel})
+
+            return json.dumps(
+                {
+                    "success": True,
+                    "activity_id": activity_id,
+                    "feel": feel,
+                    "message": "Activity feel successfully updated",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error updating activity feel: {str(e)}"
 
     @app.tool()
     async def get_activity_splits(activity_id: Union[int, str]) -> str:

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -168,6 +168,194 @@ async def test_set_activity_name_tool_rejects_blank_name(
     assert result[0][0].text == "Activity name cannot be empty"
 
 
+# ── Activity write tools ──────────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_set_activity_type_tool(app_with_activity_management, mock_garmin_client):
+    """Test set_activity_type resolves the type key and calls the library"""
+    mock_garmin_client.get_activity_types.return_value = MOCK_ACTIVITY_TYPES
+    mock_garmin_client.set_activity_type.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_type",
+        {"activity_id": 12345678901, "type_key": "hiking"},
+    )
+
+    mock_garmin_client.set_activity_type.assert_called_once_with(
+        12345678901, 3, "hiking", 17
+    )
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert data["type_key"] == "hiking"
+
+
+@pytest.mark.asyncio
+async def test_set_activity_type_rejects_unknown_key(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_activity_type rejects an unknown type key without calling the API"""
+    mock_garmin_client.get_activity_types.return_value = MOCK_ACTIVITY_TYPES
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_type",
+        {"activity_id": 12345678901, "type_key": "moonwalking"},
+    )
+
+    mock_garmin_client.set_activity_type.assert_not_called()
+    assert "Unknown activity type 'moonwalking'" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_set_activity_description_tool(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_activity_description PUTs the description in a partial DTO"""
+    mock_garmin_client.garmin_connect_activity = "/activity-service/activity"
+    mock_garmin_client.client.put.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_description",
+        {"activity_id": 12345678901, "description": "Felt strong. New shoes."},
+    )
+
+    mock_garmin_client.client.put.assert_called_once_with(
+        "connectapi",
+        "/activity-service/activity/12345678901",
+        json={"activityId": 12345678901, "description": "Felt strong. New shoes."},
+        api=True,
+    )
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert data["description"] == "Felt strong. New shoes."
+
+
+@pytest.mark.asyncio
+async def test_set_activity_event_type_tool(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_activity_event_type resolves the key and PUTs eventTypeDTO"""
+    mock_garmin_client.garmin_connect_activity = "/activity-service/activity"
+    mock_garmin_client.connectapi.return_value = [
+        {"typeId": 1, "typeKey": "race", "sortOrder": 5},
+        {"typeId": 4, "typeKey": "training", "sortOrder": 7},
+    ]
+    mock_garmin_client.client.put.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_event_type",
+        {"activity_id": 12345678901, "event_type": "race"},
+    )
+
+    mock_garmin_client.client.put.assert_called_once_with(
+        "connectapi",
+        "/activity-service/activity/12345678901",
+        json={
+            "activityId": 12345678901,
+            "eventTypeDTO": {"typeId": 1, "typeKey": "race", "sortOrder": 5},
+        },
+        api=True,
+    )
+    data = json.loads(result[0][0].text)
+    assert data["event_type"] == "race"
+
+
+@pytest.mark.asyncio
+async def test_set_activity_event_type_rejects_unknown(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_activity_event_type rejects an unknown event type"""
+    mock_garmin_client.connectapi.return_value = [
+        {"typeId": 1, "typeKey": "race", "sortOrder": 5},
+    ]
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_event_type",
+        {"activity_id": 12345678901, "event_type": "wedding"},
+    )
+
+    mock_garmin_client.client.put.assert_not_called()
+    assert "Unknown event type 'wedding'" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_set_perceived_effort_tool(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_perceived_effort sends a partial summaryDTO with RPE×10"""
+    mock_garmin_client.garmin_connect_activity = "/activity-service/activity"
+    mock_garmin_client.client.put.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "set_perceived_effort",
+        {"activity_id": 12345678901, "rpe": 7},
+    )
+
+    # Only the changed field is sent; Garmin merges it (7 -> 70)
+    mock_garmin_client.client.put.assert_called_once_with(
+        "connectapi",
+        "/activity-service/activity/12345678901",
+        json={
+            "activityId": 12345678901,
+            "summaryDTO": {"directWorkoutRpe": 70},
+        },
+        api=True,
+    )
+    data = json.loads(result[0][0].text)
+    assert data["rpe"] == 7
+
+
+@pytest.mark.asyncio
+async def test_set_perceived_effort_rejects_out_of_range(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_perceived_effort rejects values outside 0-10"""
+    result = await app_with_activity_management.call_tool(
+        "set_perceived_effort",
+        {"activity_id": 12345678901, "rpe": 11},
+    )
+
+    mock_garmin_client.client.put.assert_not_called()
+    assert result[0][0].text == "rpe must be between 0 and 10"
+
+
+@pytest.mark.asyncio
+async def test_set_activity_feel_tool(app_with_activity_management, mock_garmin_client):
+    """Test set_activity_feel sends a partial summaryDTO with the feel value"""
+    mock_garmin_client.garmin_connect_activity = "/activity-service/activity"
+    mock_garmin_client.client.put.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "set_activity_feel",
+        {"activity_id": 12345678901, "feel": 75},
+    )
+
+    mock_garmin_client.client.put.assert_called_once_with(
+        "connectapi",
+        "/activity-service/activity/12345678901",
+        json={
+            "activityId": 12345678901,
+            "summaryDTO": {"directWorkoutFeel": 75},
+        },
+        api=True,
+    )
+    data = json.loads(result[0][0].text)
+    assert data["feel"] == 75
+
+
+@pytest.mark.asyncio
+async def test_set_activity_feel_rejects_invalid_value(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test set_activity_feel rejects values not on the 5-point scale"""
+    result = await app_with_activity_management.call_tool(
+        "set_activity_feel",
+        {"activity_id": 12345678901, "feel": 60},
+    )
+
+    mock_garmin_client.client.put.assert_not_called()
+    assert result[0][0].text == "feel must be one of 0, 25, 50, 75, 100"
+
+
 @pytest.mark.asyncio
 async def test_get_activity_splits_tool(app_with_activity_management, mock_garmin_client):
     """Test get_activity_splits tool returns activity splits"""


### PR DESCRIPTION
## Summary

The server could read rich activity detail but the only writable field
was the activity name. The fields most worth editing after a session —
the sport/type, the free-text description, the event type, and the
subjective perceived effort and feel — were all read-only.

This adds five tools: `set_activity_type`, `set_activity_description`,
`set_activity_event_type`, `set_perceived_effort` and `set_activity_feel`.
All drive the same `activity-service` PUT endpoint that `set_activity_name`
already uses. `set_activity_type` wraps the library's existing
`set_activity_type` after resolving the type key to its IDs; the rest
issue partial updates.

One decision is worth reviewers' attention. Perceived effort and feel
live inside `summaryDTO`. The intuitive approach — read the activity,
merge the field, and PUT the whole `summaryDTO` back — is rejected by the
API with a 400. The full object carries a complete GPS coordinate pair
(`startLatitude` + `startLongitude`), and sending both halves together
trips a server-side location validation; each field is individually
writable, so it is the pair specifically that fails. The tools therefore
send a minimal partial `summaryDTO` containing only the changed field,
which Garmin merges into the stored summary. This is called out in a code
comment because the "obvious" read-modify-write refactor would silently
reintroduce the 400.

Verified end-to-end against the live Garmin API with a write-and-revert
on a real activity; all five fields round-trip and recorded metrics are
preserved.

Pairs with #148, which makes the description and event type readable back
through `get_activity`. The two are independent but touch the same files,
so whichever merges second will need a trivial rebase.

## Test plan

- [ ] Set each field, then confirm via `get_activity` (reading description
      and event type back relies on #148)
- [ ] Confirm recorded metrics are unchanged after RPE/feel writes