### PR TITLE
feat: add create_manual_activity tool

### DIFF
--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -3,6 +3,8 @@ Activity Management functions for Garmin Connect MCP Server
 """
 import json
 import datetime
+import re
+import zoneinfo
 from typing import Any, Dict, List, Optional, Union
 
 # The garmin_client will be set by the main file
@@ -640,5 +642,107 @@ def register_tools(app):
             return json.dumps(curated, indent=2)
         except Exception as e:
             return f"Error retrieving activity types: {str(e)}"
+
+    @app.tool()
+    async def create_manual_activity(
+        activity_type: str,
+        date: str,
+        duration_minutes: int,
+        activity_name: str = "",
+        distance_km: float = 0.0,
+        start_time: str = "09:00",
+        time_zone: str = "UTC",
+    ) -> str:
+        """Create a manual activity in Garmin Connect (for activities done without a watch).
+
+        Use get_activity_types to find valid activity_type values. Common ones:
+        yoga, strength_training, indoor_cycling, pilates, breathwork, meditation.
+
+        Args:
+            activity_type: Garmin type_key (e.g. "yoga", "strength_training"). Use get_activity_types to list valid values.
+            date: Date the activity was done, YYYY-MM-DD format
+            duration_minutes: Duration in minutes (1-600)
+            activity_name: Optional display name (defaults to the activity type)
+            distance_km: Distance in km (default 0, ignored for non-distance activities)
+            start_time: Time the activity started, HH:MM in 24h format (default "09:00")
+            time_zone: IANA timezone (default UTC)
+        """
+        try:
+            activity_type = activity_type.strip()
+            if not activity_type:
+                return "Error: activity_type is required"
+            if not re.match(r'^[a-z][a-z0-9_]{0,63}$', activity_type):
+                return (
+                    "Error: activity_type must be a lowercase alphanumeric "
+                    "type_key (e.g. 'yoga', 'strength_training'). "
+                    "Use get_activity_types to list valid values."
+                )
+
+            if not re.match(r'^\d{4}-\d{2}-\d{2}$', date):
+                return "Error: date must be in YYYY-MM-DD format"
+            try:
+                parsed_date = datetime.date.fromisoformat(date)
+            except ValueError:
+                return f"Error: invalid date '{date}'"
+            if parsed_date > datetime.date.today() + datetime.timedelta(days=1):
+                return "Error: date cannot be in the future"
+            if parsed_date < datetime.date(2000, 1, 1):
+                return "Error: date must be after 2000-01-01"
+
+            if duration_minutes < 1 or duration_minutes > 600:
+                return "Error: duration_minutes must be between 1 and 600"
+
+            if distance_km < 0 or distance_km > 1000:
+                return "Error: distance_km must be between 0 and 1000"
+
+            time_zone = time_zone.strip()
+            if time_zone not in zoneinfo.available_timezones():
+                return f"Error: invalid timezone '{time_zone}'"
+
+            activity_name = activity_name.strip()
+            if not activity_name:
+                activity_name = activity_type.replace("_", " ").title()
+            if len(activity_name) > 140:
+                return "Error: activity_name must be 140 characters or fewer"
+
+            start_time = start_time.strip()
+            if not re.match(r'^\d{2}:\d{2}$', start_time):
+                return "Error: start_time must be in HH:MM format (e.g. '07:30')"
+            try:
+                datetime.time.fromisoformat(start_time)
+            except ValueError:
+                return f"Error: invalid start_time '{start_time}'"
+
+            start_datetime = f"{date}T{start_time}:00.000"
+
+            result = garmin_client.create_manual_activity(
+                start_datetime=start_datetime,
+                time_zone=time_zone,
+                type_key=activity_type,
+                distance_km=distance_km,
+                duration_min=duration_minutes,
+                activity_name=activity_name,
+            )
+
+            activity_id = None
+            if isinstance(result, dict):
+                activity_id = result.get("activityId")
+
+            response = {
+                "success": True,
+                "activity_name": activity_name,
+                "activity_type": activity_type,
+                "date": date,
+                "start_time": start_time,
+                "duration_minutes": duration_minutes,
+                "distance_km": distance_km,
+                "time_zone": time_zone,
+            }
+            if activity_id:
+                response["activity_id"] = activity_id
+
+            return json.dumps(response, indent=2)
+        except Exception as e:
+            return f"Error creating manual activity: {str(e)}"
 
     return app

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -697,3 +697,227 @@ async def test_get_activities_by_date_default_page_size_is_100(
     call_params = mock_garmin_client.connectapi.call_args[1]["params"]
     assert call_params["limit"] == "100"
     assert call_params["start"] == "0"
+
+
+# ── create_manual_activity tests ─────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_success(app_with_activity_management, mock_garmin_client):
+    """Test successful manual activity creation with minimal args"""
+    mock_garmin_client.create_manual_activity.return_value = {"activityId": 99887766}
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 45}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert data["activity_type"] == "yoga"
+    assert data["activity_name"] == "Yoga"
+    assert data["date"] == "2024-06-15"
+    assert data["duration_minutes"] == 45
+    assert data["activity_id"] == 99887766
+    assert data["time_zone"] == "UTC"
+
+    mock_garmin_client.create_manual_activity.assert_called_once_with(
+        start_datetime="2024-06-15T09:00:00.000",
+        time_zone="UTC",
+        type_key="yoga",
+        distance_km=0.0,
+        duration_min=45,
+        activity_name="Yoga",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_all_optional_args(app_with_activity_management, mock_garmin_client):
+    """Test manual activity creation with all optional args specified"""
+    mock_garmin_client.create_manual_activity.return_value = {"activityId": 12345}
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {
+            "activity_type": "strength_training",
+            "date": "2024-06-15",
+            "duration_minutes": 60,
+            "activity_name": "Morning Weights",
+            "distance_km": 0.0,
+            "start_time": "07:30",
+            "time_zone": "America/New_York",
+        }
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert data["activity_name"] == "Morning Weights"
+    assert data["start_time"] == "07:30"
+    assert data["time_zone"] == "America/New_York"
+
+    mock_garmin_client.create_manual_activity.assert_called_once_with(
+        start_datetime="2024-06-15T07:30:00.000",
+        time_zone="America/New_York",
+        type_key="strength_training",
+        distance_km=0.0,
+        duration_min=60,
+        activity_name="Morning Weights",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_auto_names_from_type(app_with_activity_management, mock_garmin_client):
+    """Test that activity_name defaults to a title-cased version of activity_type"""
+    mock_garmin_client.create_manual_activity.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "indoor_cycling", "date": "2024-06-15", "duration_minutes": 30}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["activity_name"] == "Indoor Cycling"
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_no_activity_id_in_response(app_with_activity_management, mock_garmin_client):
+    """Test response when Garmin API returns no activityId"""
+    mock_garmin_client.create_manual_activity.return_value = {}
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 30}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert "activity_id" not in data
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_api_exception(app_with_activity_management, mock_garmin_client):
+    """Test graceful handling of Garmin API exceptions"""
+    mock_garmin_client.create_manual_activity.side_effect = Exception("Connection timeout")
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 30}
+    )
+
+    assert "Error creating manual activity: Connection timeout" in result[0][0].text
+
+
+# ── create_manual_activity validation tests ──────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_empty_type(app_with_activity_management, mock_garmin_client):
+    """Test rejection of empty activity_type"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "   ", "date": "2024-06-15", "duration_minutes": 30}
+    )
+
+    assert "activity_type is required" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_invalid_type_key(app_with_activity_management, mock_garmin_client):
+    """Test rejection of activity_type that doesn't match type_key format"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "Yoga Class!", "date": "2024-06-15", "duration_minutes": 30}
+    )
+
+    assert "must be a lowercase alphanumeric" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_bad_date_format(app_with_activity_management, mock_garmin_client):
+    """Test rejection of incorrectly formatted date"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "06-15-2024", "duration_minutes": 30}
+    )
+
+    assert "YYYY-MM-DD" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_invalid_date(app_with_activity_management, mock_garmin_client):
+    """Test rejection of syntactically valid but impossible date"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-02-30", "duration_minutes": 30}
+    )
+
+    assert "invalid date" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_duration_out_of_range(app_with_activity_management, mock_garmin_client):
+    """Test rejection of duration outside valid range"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 0}
+    )
+
+    assert "between 1 and 600" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 601}
+    )
+
+    assert "between 1 and 600" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_negative_distance(app_with_activity_management, mock_garmin_client):
+    """Test rejection of negative distance"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "running", "date": "2024-06-15", "duration_minutes": 30, "distance_km": -1.0}
+    )
+
+    assert "between 0 and 1000" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_invalid_timezone(app_with_activity_management, mock_garmin_client):
+    """Test rejection of invalid timezone string"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 30, "time_zone": "Mars/Olympus"}
+    )
+
+    assert "invalid timezone" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_bad_start_time(app_with_activity_management, mock_garmin_client):
+    """Test rejection of invalid start_time format"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 30, "start_time": "9am"}
+    )
+
+    assert "HH:MM" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_long_name(app_with_activity_management, mock_garmin_client):
+    """Test rejection of activity_name exceeding 140 chars"""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"activity_type": "yoga", "date": "2024-06-15", "duration_minutes": 30, "activity_name": "A" * 141}
+    )
+
+    assert "140 characters" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a new `create_manual_activity` MCP tool for creating manual activities in Garmin Connect - useful for logging activities done without a watch (e.g., yoga, strength training, indoor cycling).

- Exposes `garminconnect`'s `create_manual_activity` method as an MCP tool
- Accepts activity type, date, duration, and optional distance/timezone/name parameters
- Input validation: activity type format, date range (2000-today), duration (1-600 min), distance (0-1000 km), IANA timezone, time format
- Auto-generates activity name from type key if not provided (e.g., `strength_training` -> `Strength Training`)
- 14 integration tests covering happy paths and validation edge cases

## Test plan

- [x] All 47 tests pass (33 existing + 14 new)
- [x] Happy path: minimal args, all optional args, auto-naming, missing activity ID in response, API exception handling
- [x] Validation: empty type, invalid type key, bad date format, invalid date, duration out of range, negative distance, invalid timezone, bad start time, long name

Fixes #137