### PR TITLE
feat: add runtime error-handling proxy for Garmin API calls

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -11,6 +11,46 @@ from mcp.server.fastmcp import FastMCP
 
 from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError, GarminConnectTooManyRequestsError
 
+
+class _GarminClientProxy:
+    """Wraps the Garmin client to translate API exceptions into actionable messages.
+
+    The login flow already has detailed error handling, but the same exceptions
+    at runtime (expired tokens, rate limits, connection drops) surface as raw
+    library tracebacks. This proxy catches them in one place so individual tool
+    functions don't need to distinguish error types.
+    """
+
+    def __init__(self, client):
+        self._client = client
+
+    def __getattr__(self, name):
+        attr = getattr(self._client, name)
+        if not callable(attr):
+            return attr
+
+        def wrapper(*args, **kwargs):
+            try:
+                return attr(*args, **kwargs)
+            except GarminConnectAuthenticationError as e:
+                raise RuntimeError(
+                    "Garmin authentication expired. Re-authenticate and restart "
+                    f"the server. (Original error: {e})"
+                ) from e
+            except GarminConnectTooManyRequestsError as e:
+                raise RuntimeError(
+                    "Garmin rate limit hit. Wait a few minutes before retrying. "
+                    f"(Original error: {e})"
+                ) from e
+            except GarminConnectConnectionError as e:
+                raise RuntimeError(
+                    "Garmin Connect unreachable. Check network or try again later. "
+                    f"(Original error: {e})"
+                ) from e
+
+        return wrapper
+
+
 # Import all modules
 from garmin_mcp import activity_management
 from garmin_mcp import health_wellness
@@ -279,12 +319,13 @@ def main():
     """Initialize the MCP server and register all tools"""
 
     # Initialize Garmin client
-    garmin_client = init_api(email, password)
-    if not garmin_client:
+    raw_client = init_api(email, password)
+    if not raw_client:
         print("Failed to initialize Garmin Connect client. Exiting.", file=sys.stderr)
         return
 
     print("Garmin Connect client initialized successfully.", file=sys.stderr)
+    garmin_client = _GarminClientProxy(raw_client)
 
     # Configure all modules with the Garmin client
     activity_management.configure(garmin_client)

--- a/tests/unit/test_client_proxy.py
+++ b/tests/unit/test_client_proxy.py
@@ -1,0 +1,94 @@
+"""Unit tests for the runtime error-handling proxy (_GarminClientProxy)."""
+
+import pytest
+from unittest.mock import Mock
+
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
+
+from garmin_mcp import _GarminClientProxy
+
+
+@pytest.fixture
+def client():
+    mock = Mock()
+    mock.some_attribute = "attr_value"
+    mock.get_stats = Mock(return_value={"steps": 10000})
+    return mock
+
+
+@pytest.fixture
+def proxy(client):
+    return _GarminClientProxy(client)
+
+
+def test_callable_methods_pass_through(proxy, client):
+    result = proxy.get_stats("2024-01-15")
+    client.get_stats.assert_called_once_with("2024-01-15")
+    assert result == {"steps": 10000}
+
+
+def test_non_callable_attributes_pass_through(proxy):
+    assert proxy.some_attribute == "attr_value"
+
+
+def test_kwargs_pass_through(proxy, client):
+    proxy.get_stats(date="2024-01-15", extra="value")
+    client.get_stats.assert_called_once_with(date="2024-01-15", extra="value")
+
+
+def test_auth_error_becomes_runtime_error(proxy, client):
+    client.get_stats.side_effect = GarminConnectAuthenticationError("token expired")
+    with pytest.raises(RuntimeError, match="authentication expired"):
+        proxy.get_stats("2024-01-15")
+
+
+def test_auth_error_preserves_original(proxy, client):
+    original = GarminConnectAuthenticationError("token expired")
+    client.get_stats.side_effect = original
+    with pytest.raises(RuntimeError) as exc_info:
+        proxy.get_stats("2024-01-15")
+    assert exc_info.value.__cause__ is original
+
+
+def test_rate_limit_error_becomes_runtime_error(proxy, client):
+    client.get_stats.side_effect = GarminConnectTooManyRequestsError("429")
+    with pytest.raises(RuntimeError, match="rate limit"):
+        proxy.get_stats("2024-01-15")
+
+
+def test_connection_error_becomes_runtime_error(proxy, client):
+    client.get_stats.side_effect = GarminConnectConnectionError("timeout")
+    with pytest.raises(RuntimeError, match="unreachable"):
+        proxy.get_stats("2024-01-15")
+
+
+def test_non_garmin_exceptions_propagate_unwrapped(proxy, client):
+    client.get_stats.side_effect = ValueError("bad argument")
+    with pytest.raises(ValueError, match="bad argument"):
+        proxy.get_stats("2024-01-15")
+
+
+def test_error_message_includes_original(proxy, client):
+    client.get_stats.side_effect = GarminConnectAuthenticationError("specific detail")
+    with pytest.raises(RuntimeError, match="specific detail"):
+        proxy.get_stats("2024-01-15")
+
+
+def test_missing_attribute_raises_attribute_error():
+    client = Mock(spec=["get_stats"])
+    proxy = _GarminClientProxy(client)
+    with pytest.raises(AttributeError):
+        proxy.nonexistent_method()
+
+
+def test_different_methods_wrapped_independently(proxy, client):
+    client.method_a = Mock(return_value="a")
+    client.method_b = Mock(return_value="b")
+    assert proxy.method_a() == "a"
+    assert proxy.method_b() == "b"
+    client.method_a.assert_called_once()
+    client.method_b.assert_called_once()


### PR DESCRIPTION
## Summary

- Adds a `_GarminClientProxy` that wraps the Garmin client and translates runtime API exceptions into actionable error messages
- `GarminConnectAuthenticationError` -> "Garmin authentication expired. Re-authenticate and restart the server."
- `GarminConnectTooManyRequestsError` -> "Garmin rate limit hit. Wait a few minutes before retrying."
- `GarminConnectConnectionError` -> "Garmin Connect unreachable. Check network or try again later."
- Non-Garmin exceptions propagate unwrapped
- Original error is preserved via exception chaining (`from e`) and included in the message

The login flow already has detailed error handling, but the same exceptions at runtime (expired tokens mid-session, rate limits during tool calls, connection drops) surface as raw library tracebacks. This proxy centralizes the translation so individual tool functions don't need to distinguish error types.

## Test plan

- [x] All 338 tests pass (327 existing + 11 new)
- [x] Unit tests cover: method pass-through, non-callable attribute pass-through, all three exception translations, exception chaining, non-Garmin exception propagation, missing attribute behavior, independent method wrapping
- [x] Verified proxy handles all access patterns used across modules: direct method calls, URL string attributes (`garmin_connect_activities`), nested object access (`garmin_client.client.post(...)`)

Fixes #139