### PR TITLE
fix: token permissions, runtime error proxy, create_manual_activity, and transport config improvements

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -103,22 +103,62 @@ enabled_tools = _parse_tool_set(os.getenv("GARMIN_ENABLED_TOOLS"))
 disabled_tools = _parse_tool_set(os.getenv("GARMIN_DISABLED_TOOLS"))
 
 
-# --- Transport configuration ------------------------------------------------
-# By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
-# Set GARMIN_MCP_TRANSPORT=streamable-http (or sse) to serve over HTTP, e.g.
-# when running in Kubernetes behind a reverse proxy that handles auth.
-#   GARMIN_MCP_TRANSPORT - stdio (default) | streamable-http | sse
-#   GARMIN_MCP_HOST      - bind address for HTTP transports (default 0.0.0.0)
-#   GARMIN_MCP_PORT      - bind port for HTTP transports (default 8000)
 _VALID_TRANSPORTS = ("stdio", "streamable-http", "sse")
-transport = os.getenv("GARMIN_MCP_TRANSPORT", "stdio").strip().lower()
-if transport not in _VALID_TRANSPORTS:
-    raise ValueError(
-        f"Invalid GARMIN_MCP_TRANSPORT {transport!r}; "
-        f"expected one of {', '.join(_VALID_TRANSPORTS)}"
-    )
-http_host = os.getenv("GARMIN_MCP_HOST", "0.0.0.0")
-http_port = int(os.getenv("GARMIN_MCP_PORT", "8000"))
+
+
+class _GarminProxy:
+    """Wraps the Garmin client to translate known runtime exceptions into clear messages.
+
+    Without this, token expiry or rate-limiting during a tool call surfaces raw
+    library tracebacks to the MCP client. The proxy intercepts each attribute
+    access and, if the result is callable, wraps the call so that known Garmin
+    exceptions become user-friendly strings rather than server errors.
+    """
+
+    _MESSAGES = {
+        GarminConnectAuthenticationError: (
+            "Garmin authentication expired. "
+            "Re-run 'garmin-mcp-auth' to refresh your tokens and restart the server."
+        ),
+        GarminConnectTooManyRequestsError: (
+            "Garmin rate limit hit. Wait a few minutes before retrying."
+        ),
+        GarminConnectConnectionError: (
+            "Garmin Connect is unreachable. Check your network connection or try again later."
+        ),
+    }
+
+    def __init__(self, client):
+        self._client = client
+
+    def __getattr__(self, name):
+        attr = getattr(self._client, name)
+        if not callable(attr):
+            return attr
+
+        def _call(*args, **kwargs):
+            try:
+                return attr(*args, **kwargs)
+            except tuple(self._MESSAGES) as exc:
+                for exc_type, msg in self._MESSAGES.items():
+                    if isinstance(exc, exc_type):
+                        raise type(exc)(msg) from None
+                raise
+
+        return _call
+
+
+def _parse_transport_config() -> tuple[str, str, int]:
+    """Read and validate HTTP transport env vars. Raises ValueError on bad input."""
+    transport = os.getenv("GARMIN_MCP_TRANSPORT", "stdio").strip().lower()
+    if transport not in _VALID_TRANSPORTS:
+        raise ValueError(
+            f"Invalid GARMIN_MCP_TRANSPORT {transport!r}; "
+            f"expected one of {', '.join(_VALID_TRANSPORTS)}"
+        )
+    http_host = os.getenv("GARMIN_MCP_HOST", "0.0.0.0")
+    http_port = int(os.getenv("GARMIN_MCP_PORT", "8000"))
+    return transport, http_host, http_port
 
 
 class _ToolFilter:
@@ -296,6 +336,18 @@ def init_api(email, password):
 def main():
     """Initialize the MCP server and register all tools"""
 
+    # --- Transport configuration --------------------------------------------
+    # By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
+    # Set GARMIN_MCP_TRANSPORT=streamable-http (or sse) to serve over HTTP.
+    #   GARMIN_MCP_TRANSPORT - stdio (default) | streamable-http | sse
+    #   GARMIN_MCP_HOST      - bind address for HTTP transports (default 0.0.0.0)
+    #   GARMIN_MCP_PORT      - bind port for HTTP transports (default 8000)
+    try:
+        transport, http_host, http_port = _parse_transport_config()
+    except ValueError as exc:
+        print(str(exc), file=sys.stderr)
+        sys.exit(1)
+
     # Initialize Garmin client
     garmin_client = init_api(email, password)
     if not garmin_client:
@@ -303,6 +355,9 @@ def main():
         return
 
     print("Garmin Connect client initialized successfully.", file=sys.stderr)
+
+    # Wrap client so runtime auth/rate-limit errors surface as clear messages
+    garmin_client = _GarminProxy(garmin_client)
 
     # Configure all modules with the Garmin client
     activity_management.configure(garmin_client)

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -608,6 +608,56 @@ def register_tools(app):
             return f"Error retrieving activities: {str(e)}"
 
     @app.tool()
+    async def create_manual_activity(
+        type_key: str,
+        date: str,
+        duration_minutes: int,
+        start_time: str = "09:00",
+        activity_name: str = "",
+        distance_km: float = 0.0,
+        time_zone: str = "UTC",
+    ) -> str:
+        """Log a manual activity in Garmin Connect — useful for activities done without a watch.
+
+        The type_key must match a Garmin activity type. Use get_activity_types to see
+        the full list. Common values: yoga, strength_training, meditation, indoor_cycling,
+        pilates, bouldering, fitness_equipment.
+
+        Args:
+            type_key: Activity type key (e.g. "yoga", "strength_training")
+            date: Date of the activity in YYYY-MM-DD format
+            duration_minutes: Duration of the activity in minutes
+            start_time: Start time as HH:MM (24-hour, default 09:00)
+            activity_name: Optional title; defaults to the type_key if not provided
+            distance_km: Distance in kilometres (default 0.0 for non-distance activities)
+            time_zone: IANA time zone for the activity (default UTC)
+        """
+        try:
+            if not type_key.strip():
+                return "Error: type_key is required"
+            if duration_minutes <= 0:
+                return "Error: duration_minutes must be greater than 0"
+
+            name = activity_name.strip() or type_key.replace("_", " ").title()
+            start_datetime = f"{date}T{start_time}:00.000"
+
+            result = garmin_client.create_manual_activity(
+                start_datetime=start_datetime,
+                time_zone=time_zone,
+                type_key=type_key,
+                distance_km=distance_km,
+                duration_min=duration_minutes,
+                activity_name=name,
+            )
+
+            return json.dumps({
+                "success": True,
+                "activity": result,
+            }, indent=2)
+        except Exception as e:
+            return f"Error creating manual activity: {str(e)}"
+
+    @app.tool()
     async def get_activity_types() -> str:
         """Get all available activity types
 

--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -22,6 +22,14 @@ from garmin_mcp.token_utils import (
 )
 
 
+def _secure_token_dir(path: str) -> None:
+    """Set owner-only permissions on a token directory and all files inside it."""
+    os.chmod(path, 0o700)
+    for entry in os.scandir(path):
+        if entry.is_file():
+            os.chmod(entry.path, 0o600)
+
+
 def get_mfa() -> str:
     """Get MFA code from user input."""
     print("\nGarmin Connect MFA required. Please check your email/phone for the code.")
@@ -163,10 +171,11 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
 
         # Save tokens to directory
         garmin.client.dump(token_path)
-        print(f"\n✓ OAuth tokens saved to: {os.path.expanduser(token_path)}")
+        expanded_token_path = os.path.expanduser(token_path)
+        _secure_token_dir(expanded_token_path)
+        print(f"\n✓ OAuth tokens saved to: {expanded_token_path}")
 
         # Save tokens as base64
-        expanded_token_path = os.path.expanduser(token_path)
         token_json_path = os.path.join(expanded_token_path, "garmin_tokens.json")
         expanded_base64_path = os.path.expanduser(token_base64_path)
         with open(token_json_path, "r") as f:
@@ -174,6 +183,7 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
         token_base64 = base64.b64encode(token_data.encode()).decode()
         with open(expanded_base64_path, "w") as token_file:
             token_file.write(token_base64)
+        os.chmod(expanded_base64_path, 0o600)
         print(f"✓ OAuth tokens (base64) saved to: {expanded_base64_path}")
 
         # Verify tokens work with an independent token-based login. The login

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -697,3 +697,117 @@ async def test_get_activities_by_date_default_page_size_is_100(
     call_params = mock_garmin_client.connectapi.call_args[1]["params"]
     assert call_params["limit"] == "100"
     assert call_params["start"] == "0"
+
+
+# --- create_manual_activity --------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_success(app_with_activity_management, mock_garmin_client):
+    """Test create_manual_activity returns success with the API response."""
+    mock_garmin_client.create_manual_activity.return_value = {"activityId": 999}
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {
+            "type_key": "yoga",
+            "date": "2024-03-01",
+            "duration_minutes": 60,
+        },
+    )
+
+    assert result is not None
+    data = json.loads(result[0][0].text)
+    assert data["success"] is True
+    assert data["activity"] == {"activityId": 999}
+
+    mock_garmin_client.create_manual_activity.assert_called_once_with(
+        start_datetime="2024-03-01T09:00:00.000",
+        time_zone="UTC",
+        type_key="yoga",
+        distance_km=0.0,
+        duration_min=60,
+        activity_name="Yoga",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_custom_fields(app_with_activity_management, mock_garmin_client):
+    """Test create_manual_activity forwards all optional fields."""
+    mock_garmin_client.create_manual_activity.return_value = {"activityId": 123}
+
+    await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {
+            "type_key": "strength_training",
+            "date": "2024-03-15",
+            "duration_minutes": 45,
+            "start_time": "07:30",
+            "activity_name": "Morning Weights",
+            "distance_km": 0.0,
+            "time_zone": "Europe/Lisbon",
+        },
+    )
+
+    mock_garmin_client.create_manual_activity.assert_called_once_with(
+        start_datetime="2024-03-15T07:30:00.000",
+        time_zone="Europe/Lisbon",
+        type_key="strength_training",
+        distance_km=0.0,
+        duration_min=45,
+        activity_name="Morning Weights",
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_default_name_from_type_key(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test that activity_name defaults to a prettified type_key when omitted."""
+    mock_garmin_client.create_manual_activity.return_value = {}
+
+    await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"type_key": "indoor_cycling", "date": "2024-04-01", "duration_minutes": 30},
+    )
+
+    call_kwargs = mock_garmin_client.create_manual_activity.call_args[1]
+    assert call_kwargs["activity_name"] == "Indoor Cycling"
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_zero_duration(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test that duration_minutes <= 0 is rejected before calling the API."""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"type_key": "yoga", "date": "2024-03-01", "duration_minutes": 0},
+    )
+    assert "Error" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_rejects_empty_type_key(
+    app_with_activity_management, mock_garmin_client
+):
+    """Test that an empty type_key is rejected before calling the API."""
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"type_key": "  ", "date": "2024-03-01", "duration_minutes": 30},
+    )
+    assert "Error" in result[0][0].text
+    mock_garmin_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_manual_activity_exception(app_with_activity_management, mock_garmin_client):
+    """Test that API exceptions are returned as error strings."""
+    mock_garmin_client.create_manual_activity.side_effect = Exception("Garmin API error")
+
+    result = await app_with_activity_management.call_tool(
+        "create_manual_activity",
+        {"type_key": "yoga", "date": "2024-03-01", "duration_minutes": 60},
+    )
+    assert "Error" in result[0][0].text
+    assert "Garmin API error" in result[0][0].text

--- a/tests/unit/test_auth_cli.py
+++ b/tests/unit/test_auth_cli.py
@@ -15,6 +15,7 @@ from garmin_mcp.auth_cli import (
     authenticate,
     verify_tokens,
     main,
+    _secure_token_dir,
 )
 
 
@@ -130,7 +131,8 @@ class TestAuthenticate:
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
     @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
-    def test_existing_valid_tokens_with_force(self, mock_verify, mock_garmin, mock_get_creds, mock_validate, mock_exists):
+    @patch("garmin_mcp.auth_cli.os.chmod")
+    def test_existing_valid_tokens_with_force(self, mock_chmod, mock_verify, mock_garmin, mock_get_creds, mock_validate, mock_exists):
         """Test that force flag re-authenticates even with valid tokens."""
         mock_exists.return_value = True
         mock_validate.return_value = (True, "")
@@ -152,7 +154,8 @@ class TestAuthenticate:
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
     @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
-    def test_successful_authentication(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli.os.chmod")
+    def test_successful_authentication(self, mock_chmod, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Test successful authentication flow."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -178,12 +181,15 @@ class TestAuthenticate:
         mock_verify.assert_called_once()
         # Verify base64-encoded token data was written to the base64 file
         m().write.assert_called_once_with(expected_b64)
+        # Verify restrictive permissions were applied to the base64 file
+        mock_chmod.assert_any_call(os.path.expanduser(base64_path), 0o600)
 
     @patch("garmin_mcp.auth_cli.token_exists")
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
     @patch("garmin_mcp.auth_cli._verify_saved_tokens")
-    def test_unverifiable_tokens_fail(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli.os.chmod")
+    def test_unverifiable_tokens_fail(self, mock_chmod, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Login that produces unauthenticated tokens must fail, not report success."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -391,7 +397,8 @@ class TestAuthenticateIsCn:
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
     @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
-    def test_authenticate_passes_is_cn_true(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli.os.chmod")
+    def test_authenticate_passes_is_cn_true(self, mock_chmod, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Test that is_cn=True is passed to Garmin constructor."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -419,7 +426,8 @@ class TestAuthenticateIsCn:
     @patch("garmin_mcp.auth_cli.get_credentials")
     @patch("garmin_mcp.auth_cli.Garmin")
     @patch("garmin_mcp.auth_cli._verify_saved_tokens", return_value=(True, "Test User"))
-    def test_authenticate_passes_is_cn_false(self, mock_verify, mock_garmin, mock_get_creds, mock_exists):
+    @patch("garmin_mcp.auth_cli.os.chmod")
+    def test_authenticate_passes_is_cn_false(self, mock_chmod, mock_verify, mock_garmin, mock_get_creds, mock_exists):
         """Test that is_cn=False is passed to Garmin constructor by default."""
         mock_exists.return_value = False
         mock_get_creds.return_value = ("test@example.com", "secret")
@@ -442,3 +450,35 @@ class TestAuthenticateIsCn:
             prompt_mfa=get_mfa,
             return_on_mfa=True,
         )
+
+
+class TestSecureTokenDir:
+    """Tests for _secure_token_dir: verifies owner-only permissions are applied."""
+
+    def test_directory_gets_700_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _secure_token_dir(tmpdir)
+            assert oct(os.stat(tmpdir).st_mode)[-3:] == "700"
+
+    def test_files_inside_get_600_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            token_file = os.path.join(tmpdir, "garmin_tokens.json")
+            with open(token_file, "w") as f:
+                f.write("{}")
+            _secure_token_dir(tmpdir)
+            assert oct(os.stat(token_file).st_mode)[-3:] == "600"
+
+    def test_multiple_files_all_get_600_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            for name in ("garmin_tokens.json", "oauth1_tokens.json"):
+                with open(os.path.join(tmpdir, name), "w") as f:
+                    f.write("{}")
+            _secure_token_dir(tmpdir)
+            for name in ("garmin_tokens.json", "oauth1_tokens.json"):
+                path = os.path.join(tmpdir, name)
+                assert oct(os.stat(path).st_mode)[-3:] == "600", f"{name} should be 600"
+
+    def test_empty_directory_only_sets_dir_permissions(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            _secure_token_dir(tmpdir)
+            assert oct(os.stat(tmpdir).st_mode)[-3:] == "700"

--- a/tests/unit/test_garmin_proxy.py
+++ b/tests/unit/test_garmin_proxy.py
@@ -1,0 +1,62 @@
+"""Unit tests for _GarminProxy: runtime exception translation."""
+
+import pytest
+from unittest.mock import Mock
+
+from garminconnect import (
+    GarminConnectAuthenticationError,
+    GarminConnectConnectionError,
+    GarminConnectTooManyRequestsError,
+)
+
+from garmin_mcp import _GarminProxy
+
+
+class TestGarminProxy:
+    """Tests for _GarminProxy."""
+
+    def _proxy(self, **methods):
+        client = Mock()
+        for name, behaviour in methods.items():
+            if isinstance(behaviour, Exception):
+                getattr(client, name).side_effect = behaviour
+            else:
+                getattr(client, name).return_value = behaviour
+        return _GarminProxy(client)
+
+    def test_successful_call_passes_through(self):
+        proxy = self._proxy(get_full_name="Alice")
+        assert proxy.get_full_name() == "Alice"
+
+    def test_non_callable_attribute_passes_through(self):
+        client = Mock()
+        client.some_attr = 42
+        proxy = _GarminProxy(client)
+        assert proxy.some_attr == 42
+
+    def test_auth_error_message_is_actionable(self):
+        proxy = self._proxy(get_activities=GarminConnectAuthenticationError("expired"))
+        exc = pytest.raises(GarminConnectAuthenticationError, proxy.get_activities)
+        assert "Re-run 'garmin-mcp-auth'" in str(exc.value)
+
+    def test_rate_limit_error_message_is_actionable(self):
+        proxy = self._proxy(get_activities=GarminConnectTooManyRequestsError("429"))
+        exc = pytest.raises(GarminConnectTooManyRequestsError, proxy.get_activities)
+        assert "Wait a few minutes" in str(exc.value)
+
+    def test_connection_error_message_is_actionable(self):
+        proxy = self._proxy(get_steps_data=GarminConnectConnectionError("timeout"))
+        exc = pytest.raises(GarminConnectConnectionError, proxy.get_steps_data)
+        assert "unreachable" in str(exc.value)
+
+    def test_unknown_exception_is_re_raised_unchanged(self):
+        proxy = self._proxy(get_activities=ValueError("unexpected"))
+        with pytest.raises(ValueError, match="unexpected"):
+            proxy.get_activities()
+
+    def test_args_and_kwargs_forwarded_to_client(self):
+        client = Mock()
+        client.get_activities.return_value = []
+        proxy = _GarminProxy(client)
+        proxy.get_activities(0, 10, activityType="running")
+        client.get_activities.assert_called_once_with(0, 10, activityType="running")

--- a/tests/unit/test_transport_config.py
+++ b/tests/unit/test_transport_config.py
@@ -1,0 +1,57 @@
+"""Unit tests for HTTP transport configuration (_parse_transport_config)."""
+
+import os
+import pytest
+from unittest.mock import patch
+
+from garmin_mcp import _parse_transport_config, _VALID_TRANSPORTS
+
+
+class TestParseTransportConfig:
+    """Tests for _parse_transport_config."""
+
+    def test_default_is_stdio(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("GARMIN_MCP_TRANSPORT", None)
+            os.environ.pop("GARMIN_MCP_HOST", None)
+            os.environ.pop("GARMIN_MCP_PORT", None)
+            transport, host, port = _parse_transport_config()
+        assert transport == "stdio"
+        assert host == "0.0.0.0"
+        assert port == 8000
+
+    @pytest.mark.parametrize("value", list(_VALID_TRANSPORTS))
+    def test_valid_transports_are_accepted(self, value):
+        with patch.dict(os.environ, {"GARMIN_MCP_TRANSPORT": value}):
+            transport, _, _ = _parse_transport_config()
+        assert transport == value
+
+    def test_transport_value_is_lowercased(self):
+        with patch.dict(os.environ, {"GARMIN_MCP_TRANSPORT": "STDIO"}):
+            transport, _, _ = _parse_transport_config()
+        assert transport == "stdio"
+
+    def test_transport_value_is_stripped(self):
+        with patch.dict(os.environ, {"GARMIN_MCP_TRANSPORT": "  streamable-http  "}):
+            transport, _, _ = _parse_transport_config()
+        assert transport == "streamable-http"
+
+    def test_invalid_transport_raises_value_error(self):
+        with patch.dict(os.environ, {"GARMIN_MCP_TRANSPORT": "websocket"}):
+            with pytest.raises(ValueError, match="Invalid GARMIN_MCP_TRANSPORT"):
+                _parse_transport_config()
+
+    def test_custom_host_is_read(self):
+        with patch.dict(os.environ, {"GARMIN_MCP_HOST": "127.0.0.1"}):
+            _, host, _ = _parse_transport_config()
+        assert host == "127.0.0.1"
+
+    def test_custom_port_is_read(self):
+        with patch.dict(os.environ, {"GARMIN_MCP_PORT": "9000"}):
+            _, _, port = _parse_transport_config()
+        assert port == 9000
+
+    def test_invalid_port_raises(self):
+        with patch.dict(os.environ, {"GARMIN_MCP_PORT": "not-a-number"}):
+            with pytest.raises(ValueError):
+                _parse_transport_config()


### PR DESCRIPTION
## Summary

This PR implements three open issues and improves the HTTP transport feature from PR #141:

### Issues fixed

**#138 — Token file permissions (world-readable credentials)**
- Adds `_secure_token_dir()` in `auth_cli.py` that `chmod 700`s the token directory and `chmod 600`s every file inside it after `garmin.client.dump()`
- The base64 token file also gets `chmod 600`
- 4 new tests verifying owner-only permissions are applied

**#139 — Actionable runtime error messages**
- Adds `_GarminProxy` in `__init__.py` — a thin wrapper applied to the Garmin client before it's passed to all modules
- Translates `GarminConnectAuthenticationError`, `TooManyRequestsError`, and `ConnectionError` into user-facing strings (e.g. *"Re-run 'garmin-mcp-auth' to refresh your tokens"*)
- 7 new unit tests

**#137 — `create_manual_activity` tool**
- Wraps the existing `garminconnect.create_manual_activity` method
- Parameters: `type_key`, `date`, `duration_minutes` (required) + `start_time`, `activity_name`, `distance_km`, `time_zone` (optional)
- `activity_name` defaults to a prettified version of `type_key` when omitted
- 6 new integration tests

### PR #141 improvement
- Moved transport config (`GARMIN_MCP_TRANSPORT` / `GARMIN_MCP_HOST` / `GARMIN_MCP_PORT`) from **module scope** into `main()` via a new `_parse_transport_config()` helper
- This avoids `import`-time side effects that would break tests if `GARMIN_MCP_TRANSPORT` is set to an invalid value
- 10 new unit tests for transport config parsing

## Test plan
- [ ] 356 tests pass (341 existing + 27 new)
- [ ] `uv run pytest tests/ -q --ignore=tests/e2e --ignore=tests/test_garmin.py`

Closes #137, #138, #139