### PR TITLE
fix: correct run_seconds display units and add create_run_workout integration tests

### DIFF
--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -54,10 +54,13 @@ def build_run_json(
 ) -> dict:
     """Build the Garmin Connect JSON for a continuous run workout."""
     zone = _zone_number(hr_zone)
+    run_display = (
+        f"{run_seconds // 60}m" if run_seconds % 60 == 0 else f"{run_seconds}s"
+    )
     return {
         "workoutName": name,
         "description": (
-            f"{warmup_min}m warmup + {run_seconds}s run Z{zone} + {cooldown_min}m cooldown"
+            f"{warmup_min}m warmup + {run_display} run Z{zone} + {cooldown_min}m cooldown"
         ),
         "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
         "workoutSegments": [{

--- a/tests/integration/test_workout_builders_tools.py
+++ b/tests/integration/test_workout_builders_tools.py
@@ -138,3 +138,49 @@ async def test_schedule_week_partial_idempotency(
     assert scheduled[1]["status"] == "scheduled"
     # Only the new one triggered the POST
     assert mock_garmin_client.client.post.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_create_run_workout_success(app_with_builders, mock_garmin_client):
+    """create_run_workout uploads the workout and returns the workout_id."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 9876543210,
+        "workoutName": "Step 8 - 30min continuous",
+    }
+
+    result = await app_with_builders.call_tool(
+        "create_run_workout",
+        {
+            "name": "Step 8 - 30min continuous",
+            "run_seconds": 1800,
+            "warmup_min": 5,
+            "cooldown_min": 5,
+            "hr_zone": "Z3",
+        },
+    )
+
+    assert result is not None
+    payload = json.loads(result[0][0].text)
+    assert payload["status"] == "success"
+    assert payload["workout_id"] == 9876543210
+    mock_garmin_client.upload_workout.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_create_run_workout_exception(app_with_builders, mock_garmin_client):
+    """create_run_workout returns an error string when the API raises an exception."""
+    mock_garmin_client.upload_workout.side_effect = Exception("Upload failed")
+
+    result = await app_with_builders.call_tool(
+        "create_run_workout",
+        {
+            "name": "Step 8 - 30min continuous",
+            "run_seconds": 1800,
+            "warmup_min": 5,
+            "cooldown_min": 5,
+        },
+    )
+
+    assert result is not None
+    assert "Error" in result[0][0].text
+    assert "Upload failed" in result[0][0].text


### PR DESCRIPTION
## Summary

Follow-up to #156 (`create_run_workout` tool):

- **Fix description units**: `build_run_json()` now displays the run duration in minutes when `run_seconds` is a round number of minutes (e.g. 1800s → `30m run`) and in seconds otherwise (e.g. 90s → `90s run`). Before this fix the description always showed seconds (`1800s run`).
- **Add integration tests**: adds `test_create_run_workout_success` and `test_create_run_workout_exception` to `tests/integration/test_workout_builders_tools.py`, following the same pattern as the existing workout builder tests.

## Test plan

- [ ] `uv run pytest tests/integration/test_workout_builders_tools.py -v` — all 5 tests pass
- [ ] `uv run pytest tests/ -q --ignore=tests/e2e --ignore=tests/test_garmin.py` — all 363 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)