### PR TITLE
feat: complete custom-food lifecycle (rebase of #152)

### DIFF
--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -396,7 +396,7 @@ def register_tools(app):
         """
         try:
             url = f"/nutrition-service/customFood/{food_id}"
-            resp = garmin_client.client.delete("connectapi", url, api=True)
+            garmin_client.client.delete("connectapi", url, api=True)
             return json.dumps(
                 {"status": "success", "food_id": food_id,
                  "message": f"Custom food {food_id} deleted successfully."},

--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -238,7 +238,11 @@ def register_tools(app):
     ) -> str:
         """Update an existing custom food in the user's Garmin nutrition library
 
-        Modifies a custom food's name and/or nutritional information.
+        Fetches the food's current nutrition before writing so that omitted
+        optional fields (carbs, protein, fat, etc.) preserve their existing
+        values rather than being cleared. Only the fields you explicitly pass
+        are changed; everything else is carried forward from the current record.
+
         Use get_custom_foods first to find the foodId and servingId.
 
         Args:
@@ -259,13 +263,25 @@ def register_tools(app):
             potassium: Potassium in mg per serving
         """
         try:
-            nutrition = {
-                "servingId": serving_id,
-                "servingUnit": serving_unit,
-                "numberOfUnits": _num_to_str(number_of_units),
-                "calories": _num_to_str(calories),
-            }
-            optional_fields = {
+            # Fetch current nutrition so omitted fields are preserved (not wiped).
+            existing_nutrition: dict = {}
+            try:
+                search_url = (
+                    f"/nutrition-service/customFood"
+                    f"?searchExpression={quote(food_name)}"
+                    f"&start=0&limit=20&includeContent=true"
+                )
+                search_data = garmin_client.connectapi(search_url)
+                foods = search_data.get("customFoods", []) if isinstance(search_data, dict) else []
+                for f in foods:
+                    if str(f.get("foodMetaData", {}).get("foodId", "")) == food_id:
+                        existing_nutrition = (f.get("nutritionContents") or [{}])[0]
+                        break
+            except Exception:
+                pass  # proceed without existing data; caller's values win
+
+            # API field name → optional param value (None means "not supplied by caller")
+            optional_updates = {
                 "carbs": carbs,
                 "protein": protein,
                 "fat": fat,
@@ -276,7 +292,18 @@ def register_tools(app):
                 "cholesterol": cholesterol,
                 "potassium": potassium,
             }
-            for key, value in optional_fields.items():
+            nutrition: dict = {
+                "servingId": serving_id,
+                "servingUnit": serving_unit,
+                "numberOfUnits": _num_to_str(number_of_units),
+                "calories": _num_to_str(calories),
+            }
+            # Carry forward existing optional fields, then overlay caller-supplied values.
+            preserved_keys = set(optional_updates.keys())
+            for key, existing_val in existing_nutrition.items():
+                if key in preserved_keys and existing_val is not None:
+                    nutrition[key] = _num_to_str(existing_val)
+            for key, value in optional_updates.items():
                 if value is not None:
                     nutrition[key] = _num_to_str(value)
 
@@ -568,7 +595,7 @@ def register_tools(app):
                 f"&start=0&limit=10&includeContent=true"
             )
             search_data = garmin_client.connectapi(search_url)
-            foods = search_data if isinstance(search_data, list) else []
+            foods = search_data.get("customFoods", []) if isinstance(search_data, dict) else []
 
             food_id = None
             serving_id = None
@@ -621,7 +648,7 @@ def register_tools(app):
                         f"&start=0&limit=10&includeContent=true"
                     )
                     lookup_data = garmin_client.connectapi(lookup_url)
-                    lookup_foods = lookup_data if isinstance(lookup_data, list) else []
+                    lookup_foods = lookup_data.get("customFoods", []) if isinstance(lookup_data, dict) else []
                     for f in lookup_foods:
                         meta = f.get("foodMetaData", f)
                         if meta.get("foodName", "").lower() == food_name.lower():

--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -307,6 +307,34 @@ def register_tools(app):
             return f"Error updating custom food: {str(e)}"
 
     @app.tool()
+    async def delete_custom_food(food_id: str) -> str:
+        """Delete a custom food from the user's Garmin nutrition library
+
+        Permanently removes a custom food entry. The food must not be
+        actively referenced in a logged meal to be deleted.
+        Use get_custom_foods to find the foodId.
+
+        Args:
+            food_id: ID of the custom food to delete — a 32-char hex string
+                (from get_custom_foods or create_custom_food)
+        """
+        try:
+            url = f"/nutrition-service/customFood/{food_id}"
+            resp = garmin_client.client.delete("connectapi", url, api=True)
+            return json.dumps(
+                {"status": "success", "food_id": food_id,
+                 "message": f"Custom food {food_id} deleted successfully."},
+                indent=2,
+            )
+        except GarminConnectConnectionError as e:
+            body = ""
+            if hasattr(e, "error") and hasattr(e.error, "response"):
+                body = getattr(e.error.response, "text", "")
+            return f"Error deleting custom food: {e} | Response: {body}"
+        except Exception as e:
+            return f"Error deleting custom food: {str(e)}"
+
+    @app.tool()
     async def log_custom_food(
         meal_date: str,
         meal_time: str,

--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -139,6 +139,7 @@ def register_tools(app):
         calories: float,
         serving_unit: str = "G",
         number_of_units: float = 100,
+        brand_name: Optional[str] = None,
         carbs: Optional[float] = None,
         protein: Optional[float] = None,
         fat: Optional[float] = None,
@@ -148,6 +149,10 @@ def register_tools(app):
         sodium: Optional[float] = None,
         cholesterol: Optional[float] = None,
         potassium: Optional[float] = None,
+        trans_fat: Optional[float] = None,
+        calcium: Optional[float] = None,
+        iron: Optional[float] = None,
+        vitamin_d: Optional[float] = None,
     ) -> str:
         """Create a custom food in the user's Garmin nutrition library
 
@@ -156,11 +161,16 @@ def register_tools(app):
         log_custom_food. If the API returns no data (204), use
         get_custom_foods(search=food_name) to retrieve those IDs.
 
+        All nutrient amounts are ABSOLUTE values per serving, not %DV.
+        Nutrition labels often print %DV for calcium/iron/vitamin D —
+        convert to absolute units before passing.
+
         Args:
             food_name: Name of the custom food (e.g. "Homemade Chocolate Cookies")
             calories: Calories per serving
             serving_unit: Unit for serving size (e.g. "G", "ML", "OZ"). Default "G"
             number_of_units: Serving size in the specified unit. Default 100
+            brand_name: Brand or vendor name (e.g. "Three Bridges")
             carbs: Carbohydrates in grams per serving
             protein: Protein in grams per serving
             fat: Total fat in grams per serving
@@ -170,6 +180,10 @@ def register_tools(app):
             sodium: Sodium in mg per serving
             cholesterol: Cholesterol in mg per serving
             potassium: Potassium in mg per serving
+            trans_fat: Trans fat in grams per serving
+            calcium: Calcium in mg per serving (NOT %DV)
+            iron: Iron in mg per serving (NOT %DV)
+            vitamin_d: Vitamin D in mcg per serving (NOT %DV)
         """
         try:
             nutrition = {
@@ -188,19 +202,27 @@ def register_tools(app):
                 "sodium": sodium,
                 "cholesterol": cholesterol,
                 "potassium": potassium,
+                "transFat": trans_fat,
+                "calcium": calcium,
+                "iron": iron,
+                "vitaminD": vitamin_d,
             }
             for key, value in optional_fields.items():
                 if value is not None:
                     nutrition[key] = _num_to_str(value)
 
+            food_meta: dict = {
+                "foodName": food_name,
+                "foodType": "GENERIC",
+                "source": "GARMIN",
+                "regionCode": "US",
+                "languageCode": "en",
+            }
+            if brand_name is not None:
+                food_meta["brandName"] = brand_name
+
             payload = {
-                "foodMetaData": {
-                    "foodName": food_name,
-                    "foodType": "GENERIC",
-                    "source": "GARMIN",
-                    "regionCode": "US",
-                    "languageCode": "en",
-                },
+                "foodMetaData": food_meta,
                 "nutritionContents": [nutrition],
             }
             url = "/nutrition-service/customFood"
@@ -226,6 +248,7 @@ def register_tools(app):
         calories: float,
         serving_unit: str = "G",
         number_of_units: float = 100,
+        brand_name: Optional[str] = None,
         carbs: Optional[float] = None,
         protein: Optional[float] = None,
         fat: Optional[float] = None,
@@ -235,13 +258,21 @@ def register_tools(app):
         sodium: Optional[float] = None,
         cholesterol: Optional[float] = None,
         potassium: Optional[float] = None,
+        trans_fat: Optional[float] = None,
+        calcium: Optional[float] = None,
+        iron: Optional[float] = None,
+        vitamin_d: Optional[float] = None,
     ) -> str:
         """Update an existing custom food in the user's Garmin nutrition library
 
-        Fetches the food's current nutrition before writing so that omitted
-        optional fields (carbs, protein, fat, etc.) preserve their existing
-        values rather than being cleared. Only the fields you explicitly pass
-        are changed; everything else is carried forward from the current record.
+        Fetches the food's current record before writing so that omitted optional
+        fields (brand, carbs, protein, fat, micros, etc.) preserve their existing
+        values rather than being cleared. Only the fields you explicitly pass are
+        changed; everything else is carried forward from the current record.
+
+        All nutrient amounts are ABSOLUTE values per serving, not %DV.
+        Nutrition labels often print %DV for calcium/iron/vitamin D —
+        convert to absolute units before passing.
 
         Use get_custom_foods first to find the foodId and servingId.
 
@@ -252,6 +283,7 @@ def register_tools(app):
             calories: Calories per serving
             serving_unit: Unit for serving size (e.g. "G", "ML", "OZ"). Default "G"
             number_of_units: Serving size in the specified unit. Default 100
+            brand_name: Brand or vendor name; omit to preserve the existing value
             carbs: Carbohydrates in grams per serving
             protein: Protein in grams per serving
             fat: Total fat in grams per serving
@@ -261,10 +293,15 @@ def register_tools(app):
             sodium: Sodium in mg per serving
             cholesterol: Cholesterol in mg per serving
             potassium: Potassium in mg per serving
+            trans_fat: Trans fat in grams per serving
+            calcium: Calcium in mg per serving (NOT %DV)
+            iron: Iron in mg per serving (NOT %DV)
+            vitamin_d: Vitamin D in mcg per serving (NOT %DV)
         """
         try:
-            # Fetch current nutrition so omitted fields are preserved (not wiped).
+            # Fetch current record so omitted fields are preserved (not wiped).
             existing_nutrition: dict = {}
+            existing_brand: Optional[str] = None
             try:
                 search_url = (
                     f"/nutrition-service/customFood"
@@ -276,6 +313,7 @@ def register_tools(app):
                 for f in foods:
                     if str(f.get("foodMetaData", {}).get("foodId", "")) == food_id:
                         existing_nutrition = (f.get("nutritionContents") or [{}])[0]
+                        existing_brand = f.get("foodMetaData", {}).get("brandName")
                         break
             except Exception:
                 pass  # proceed without existing data; caller's values win
@@ -291,6 +329,10 @@ def register_tools(app):
                 "sodium": sodium,
                 "cholesterol": cholesterol,
                 "potassium": potassium,
+                "transFat": trans_fat,
+                "calcium": calcium,
+                "iron": iron,
+                "vitaminD": vitamin_d,
             }
             nutrition: dict = {
                 "servingId": serving_id,
@@ -307,15 +349,22 @@ def register_tools(app):
                 if value is not None:
                     nutrition[key] = _num_to_str(value)
 
+            # Effective brand: caller-supplied wins, else preserve existing, else omit.
+            effective_brand = brand_name if brand_name is not None else existing_brand
+
+            food_meta: dict = {
+                "foodId": food_id,
+                "foodName": food_name,
+                "foodType": "GENERIC",
+                "source": "GARMIN",
+                "regionCode": "US",
+                "languageCode": "en",
+            }
+            if effective_brand is not None:
+                food_meta["brandName"] = effective_brand
+
             payload = {
-                "foodMetaData": {
-                    "foodId": food_id,
-                    "foodName": food_name,
-                    "foodType": "GENERIC",
-                    "source": "GARMIN",
-                    "regionCode": "US",
-                    "languageCode": "en",
-                },
+                "foodMetaData": food_meta,
                 "nutritionContents": [nutrition],
             }
             url = "/nutrition-service/customFood"

--- a/tests/e2e/test_brand_and_micros_live.py
+++ b/tests/e2e/test_brand_and_micros_live.py
@@ -1,0 +1,234 @@
+"""
+Live integration tests for brand_name and new micronutrients (transFat, calcium,
+iron, vitaminD) on create_custom_food and update_custom_food.
+
+Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
+Skipped automatically when tokens are absent.
+
+Run with: pytest tests/e2e/test_brand_and_micros_live.py -m live -s
+
+Validation scenarios:
+  1. Create with brand + all four micros → read back → assert all fields present
+  2. Merge check: update with ONLY calories (omitting brand/micros) → assert brand and
+     all four micros are UNCHANGED (proves the merge carries the new fields)
+  3. Update-set check: update with a NEW brand and a changed micro → assert those
+     changed and the untouched ones persisted
+  4. Cleanup via delete_custom_food
+"""
+import os
+import sys
+import time
+import pytest
+from urllib.parse import quote
+
+TOKEN_PATH = os.path.expanduser("~/.garminconnect")
+
+pytestmark = pytest.mark.live
+
+_FOOD_NAME = "ZZ Live Brand Micros Test"
+_BRAND_1 = "TestBrand Alpha"
+_BRAND_2 = "TestBrand Beta"
+
+# Distinctive values that are easy to spot in a read-back
+_MICROS_1 = {"transFat": 1.5, "calcium": 130, "iron": 4, "vitaminD": 2.5}
+# Changed value for step 3 — only vitaminD changes
+_MICROS_3 = {"vitaminD": 10.0}
+
+
+@pytest.fixture(scope="module")
+def garmin():
+    if not os.path.isdir(TOKEN_PATH):
+        pytest.skip("No Garmin token store found")
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+    from garminconnect import Garmin
+    g = Garmin()
+    g.login(TOKEN_PATH)
+    return g
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _search(garmin, name):
+    r = garmin.connectapi(
+        f"/nutrition-service/customFood"
+        f"?searchExpression={quote(name)}&start=0&limit=20&includeContent=true"
+    )
+    return r.get("customFoods", []) if isinstance(r, dict) else []
+
+
+def _find_by_id(garmin, name, food_id):
+    for f in _search(garmin, name):
+        if str(f.get("foodMetaData", {}).get("foodId", "")) == food_id:
+            return f
+    return None
+
+
+def _delete_food(garmin, food_id):
+    garmin.client.delete("connectapi", f"/nutrition-service/customFood/{food_id}", api=True)
+
+
+def _create(garmin, food_name, calories, brand_name=None, **micros):
+    food_meta = {
+        "foodName": food_name,
+        "foodType": "GENERIC",
+        "source": "GARMIN",
+        "regionCode": "US",
+        "languageCode": "en",
+    }
+    if brand_name is not None:
+        food_meta["brandName"] = brand_name
+
+    def _s(v):
+        f = float(v)
+        return str(int(f)) if f == int(f) else str(f)
+
+    nutrition = {"servingUnit": "G", "numberOfUnits": "100", "calories": _s(calories)}
+    key_map = {"transFat": "transFat", "calcium": "calcium", "iron": "iron", "vitaminD": "vitaminD"}
+    for k, v in micros.items():
+        if v is not None:
+            nutrition[key_map[k]] = _s(v)
+
+    resp = garmin.client.put(
+        "connectapi", "/nutrition-service/customFood",
+        json={"foodMetaData": food_meta, "nutritionContents": [nutrition]},
+        api=True,
+    )
+    return str(resp["foodMetaData"]["foodId"]), str(resp["nutritionContents"][0]["servingId"])
+
+
+def _update(garmin, food_id, serving_id, food_name, calories, brand_name=None, existing_brand=None, **micros):
+    """Replicate the fixed update_custom_food merge logic."""
+    # Fetch existing to preserve omitted fields
+    existing_nutrition: dict = {}
+    existing_brand_fetched = None
+    try:
+        r = garmin.connectapi(
+            f"/nutrition-service/customFood"
+            f"?searchExpression={quote(food_name)}&start=0&limit=20&includeContent=true"
+        )
+        foods = r.get("customFoods", []) if isinstance(r, dict) else []
+        for f in foods:
+            if str(f.get("foodMetaData", {}).get("foodId", "")) == food_id:
+                existing_nutrition = (f.get("nutritionContents") or [{}])[0]
+                existing_brand_fetched = f.get("foodMetaData", {}).get("brandName")
+                break
+    except Exception:
+        pass
+
+    preserved = {"carbs", "protein", "fat", "fiber", "sugar", "saturatedFat",
+                 "sodium", "cholesterol", "potassium", "transFat", "calcium", "iron", "vitaminD"}
+
+    def _s(v):
+        f = float(v)
+        return str(int(f)) if f == int(f) else str(f)
+
+    nutrition: dict = {"servingId": serving_id, "servingUnit": "G",
+                       "numberOfUnits": "100", "calories": _s(calories)}
+    for key, val in existing_nutrition.items():
+        if key in preserved and val is not None:
+            nutrition[key] = _s(val)
+    # overlay caller-supplied micros
+    key_map = {"transFat": "transFat", "calcium": "calcium", "iron": "iron", "vitaminD": "vitaminD"}
+    for k, v in micros.items():
+        if v is not None:
+            nutrition[key_map[k]] = _s(v)
+
+    effective_brand = brand_name if brand_name is not None else existing_brand_fetched
+    food_meta: dict = {
+        "foodId": food_id,
+        "foodName": food_name,
+        "foodType": "GENERIC",
+        "source": "GARMIN",
+        "regionCode": "US",
+        "languageCode": "en",
+    }
+    if effective_brand is not None:
+        food_meta["brandName"] = effective_brand
+
+    garmin.client.put(
+        "connectapi", "/nutrition-service/customFood",
+        json={"foodMetaData": food_meta, "nutritionContents": [nutrition]},
+        api=True,
+    )
+
+
+# ── pre-test cleanup ──────────────────────────────────────────────────────────
+
+@pytest.fixture(autouse=True, scope="module")
+def cleanup_before(garmin):
+    """Remove any leftover food from previous aborted runs."""
+    for f in _search(garmin, _FOOD_NAME):
+        if f.get("foodMetaData", {}).get("foodName") == _FOOD_NAME:
+            _delete_food(garmin, str(f["foodMetaData"]["foodId"]))
+            time.sleep(0.5)
+    yield
+
+
+# ── tests ─────────────────────────────────────────────────────────────────────
+
+def test_brand_and_micros_create_and_merge(garmin):
+    """
+    Single test exercises all four validation scenarios sequentially:
+    1. Create with brand + all four micros → read back → assert all present
+    2. Update with ONLY calories (omit brand/micros) → assert brand + micros unchanged
+    3. Update with new brand + changed vitaminD → assert change applied, others unchanged
+    4. Cleanup
+    """
+    # ── step 1: create ───────────────────────────────────────────────────────
+    food_id, serving_id = _create(
+        garmin, _FOOD_NAME, 200,
+        brand_name=_BRAND_1,
+        **_MICROS_1,
+    )
+    time.sleep(1)
+
+    rec = _find_by_id(garmin, _FOOD_NAME, food_id)
+    assert rec is not None, "Food not found after create"
+    meta = rec.get("foodMetaData", {})
+    nc = (rec.get("nutritionContents") or [{}])[0]
+
+    assert meta.get("brandName") == _BRAND_1, f"brandName after create: {meta.get('brandName')!r}"
+    assert nc.get("transFat") == 1.5, f"transFat after create: {nc.get('transFat')!r}"
+    assert nc.get("calcium") == 130, f"calcium after create: {nc.get('calcium')!r}"
+    assert nc.get("iron") == 4, f"iron after create: {nc.get('iron')!r}"
+    assert nc.get("vitaminD") == 2.5, f"vitaminD after create: {nc.get('vitaminD')!r}"
+
+    # ── step 2: merge check — update ONLY calories, omit brand + all micros ──
+    _update(garmin, food_id, serving_id, _FOOD_NAME, 250)  # no brand, no micros supplied
+    time.sleep(1)
+
+    rec2 = _find_by_id(garmin, _FOOD_NAME, food_id)
+    assert rec2 is not None, "Food not found after merge update"
+    meta2 = rec2.get("foodMetaData", {})
+    nc2 = (rec2.get("nutritionContents") or [{}])[0]
+
+    assert meta2.get("brandName") == _BRAND_1, \
+        f"brandName wiped by merge update: {meta2.get('brandName')!r}"
+    assert nc2.get("transFat") == 1.5, f"transFat wiped: {nc2.get('transFat')!r}"
+    assert nc2.get("calcium") == 130, f"calcium wiped: {nc2.get('calcium')!r}"
+    assert nc2.get("iron") == 4, f"iron wiped: {nc2.get('iron')!r}"
+    assert nc2.get("vitaminD") == 2.5, f"vitaminD wiped: {nc2.get('vitaminD')!r}"
+
+    # ── step 3: update-set check — change brand + one micro ──────────────────
+    _update(garmin, food_id, serving_id, _FOOD_NAME, 250,
+            brand_name=_BRAND_2, **_MICROS_3)
+    time.sleep(1)
+
+    rec3 = _find_by_id(garmin, _FOOD_NAME, food_id)
+    assert rec3 is not None, "Food not found after update-set"
+    meta3 = rec3.get("foodMetaData", {})
+    nc3 = (rec3.get("nutritionContents") or [{}])[0]
+
+    assert meta3.get("brandName") == _BRAND_2, \
+        f"brandName not updated: {meta3.get('brandName')!r}"
+    assert nc3.get("vitaminD") == 10.0, f"vitaminD not updated: {nc3.get('vitaminD')!r}"
+    # untouched micros from step 1 must survive
+    assert nc3.get("transFat") == 1.5, f"transFat lost in step 3: {nc3.get('transFat')!r}"
+    assert nc3.get("calcium") == 130, f"calcium lost in step 3: {nc3.get('calcium')!r}"
+    assert nc3.get("iron") == 4, f"iron lost in step 3: {nc3.get('iron')!r}"
+
+    # ── step 4: cleanup ───────────────────────────────────────────────────────
+    _delete_food(garmin, food_id)
+    time.sleep(1)
+    assert _find_by_id(garmin, _FOOD_NAME, food_id) is None, \
+        f"Food {food_id} still present after delete"

--- a/tests/e2e/test_brand_and_micros_live.py
+++ b/tests/e2e/test_brand_and_micros_live.py
@@ -5,7 +5,7 @@ iron, vitaminD) on create_custom_food and update_custom_food.
 Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
 Skipped automatically when tokens are absent.
 
-Run with: pytest tests/e2e/test_brand_and_micros_live.py -m live -s
+Run with: pytest tests/e2e/test_brand_and_micros_live.py -m e2e -s
 
 Validation scenarios:
   1. Create with brand + all four micros → read back → assert all fields present
@@ -23,7 +23,7 @@ from urllib.parse import quote
 
 TOKEN_PATH = os.path.expanduser("~/.garminconnect")
 
-pytestmark = pytest.mark.live
+pytestmark = pytest.mark.e2e
 
 _FOOD_NAME = "ZZ Live Brand Micros Test"
 _BRAND_1 = "TestBrand Alpha"

--- a/tests/e2e/test_delete_custom_food_live.py
+++ b/tests/e2e/test_delete_custom_food_live.py
@@ -1,0 +1,81 @@
+"""
+Live integration test for delete_custom_food.
+
+Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
+Skipped automatically when tokens are absent.
+
+Run with: pytest tests/e2e/test_delete_custom_food_live.py -m live -s
+"""
+import os
+import sys
+import time
+import pytest
+from urllib.parse import quote
+
+TOKEN_PATH = os.path.expanduser("~/.garminconnect")
+
+pytestmark = pytest.mark.live
+
+
+@pytest.fixture(scope="module")
+def garmin():
+    if not os.path.isdir(TOKEN_PATH):
+        pytest.skip("No Garmin token store found")
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+    from garminconnect import Garmin
+    g = Garmin()
+    g.login(TOKEN_PATH)
+    return g
+
+
+def _search(garmin, name):
+    r = garmin.connectapi(
+        f"/nutrition-service/customFood"
+        f"?searchExpression={quote(name)}&start=0&limit=10&includeContent=true"
+    )
+    return r.get("customFoods", [])
+
+
+FOOD_NAME = "ZZ Live Delete Custom Food Test"
+
+
+def test_delete_custom_food_round_trip(garmin):
+    """Create a custom food, confirm it exists, delete it, confirm it's gone."""
+    # Create
+    resp = garmin.client.put(
+        "connectapi",
+        "/nutrition-service/customFood",
+        json={
+            "foodMetaData": {
+                "foodName": FOOD_NAME,
+                "foodType": "GENERIC",
+                "source": "GARMIN",
+                "regionCode": "US",
+                "languageCode": "en",
+            },
+            "nutritionContents": [
+                {"servingUnit": "G", "numberOfUnits": "100", "calories": "1"}
+            ],
+        },
+        api=True,
+    )
+    food_id = str(resp["foodMetaData"]["foodId"])
+    time.sleep(1)
+
+    # Confirm exists
+    foods = _search(garmin, FOOD_NAME)
+    assert any(f["foodMetaData"]["foodId"] == food_id for f in foods), \
+        f"Custom food {food_id} not found after create"
+
+    # Delete — exact call used by delete_custom_food tool
+    del_resp = garmin.client.delete(
+        "connectapi", f"/nutrition-service/customFood/{food_id}", api=True
+    )
+    assert del_resp == {} or not del_resp, \
+        f"Expected empty response (204), got: {del_resp!r}"
+    time.sleep(1)
+
+    # Confirm gone
+    foods2 = _search(garmin, FOOD_NAME)
+    assert not any(f["foodMetaData"]["foodId"] == food_id for f in foods2), \
+        f"Custom food {food_id} still present after delete"

--- a/tests/e2e/test_delete_custom_food_live.py
+++ b/tests/e2e/test_delete_custom_food_live.py
@@ -4,7 +4,7 @@ Live integration test for delete_custom_food.
 Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
 Skipped automatically when tokens are absent.
 
-Run with: pytest tests/e2e/test_delete_custom_food_live.py -m live -s
+Run with: pytest tests/e2e/test_delete_custom_food_live.py -m e2e -s
 """
 import os
 import sys
@@ -14,7 +14,7 @@ from urllib.parse import quote
 
 TOKEN_PATH = os.path.expanduser("~/.garminconnect")
 
-pytestmark = pytest.mark.live
+pytestmark = pytest.mark.e2e
 
 
 @pytest.fixture(scope="module")

--- a/tests/e2e/test_upsert_dedup_and_update_merge_live.py
+++ b/tests/e2e/test_upsert_dedup_and_update_merge_live.py
@@ -4,7 +4,7 @@ Live integration tests for Bug A (upsert_and_log dedup) and Bug B (update_custom
 Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
 Skipped automatically when tokens are absent.
 
-Run with: pytest tests/e2e/test_upsert_dedup_and_update_merge_live.py -m live -s
+Run with: pytest tests/e2e/test_upsert_dedup_and_update_merge_live.py -m e2e -s
 """
 import os
 import sys
@@ -15,7 +15,7 @@ from urllib.parse import quote
 
 TOKEN_PATH = os.path.expanduser("~/.garminconnect")
 
-pytestmark = pytest.mark.live
+pytestmark = pytest.mark.e2e
 
 TEST_DATE = datetime.now().strftime("%Y-%m-%d")
 

--- a/tests/e2e/test_upsert_dedup_and_update_merge_live.py
+++ b/tests/e2e/test_upsert_dedup_and_update_merge_live.py
@@ -1,0 +1,279 @@
+"""
+Live integration tests for Bug A (upsert_and_log dedup) and Bug B (update_custom_food merge).
+
+Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
+Skipped automatically when tokens are absent.
+
+Run with: pytest tests/e2e/test_upsert_dedup_and_update_merge_live.py -m live -s
+"""
+import os
+import sys
+import time
+import pytest
+from datetime import datetime, timezone
+from urllib.parse import quote
+
+TOKEN_PATH = os.path.expanduser("~/.garminconnect")
+
+pytestmark = pytest.mark.live
+
+TEST_DATE = datetime.now().strftime("%Y-%m-%d")
+
+
+@pytest.fixture(scope="module")
+def garmin():
+    if not os.path.isdir(TOKEN_PATH):
+        pytest.skip("No Garmin token store found")
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+    from garminconnect import Garmin
+    g = Garmin()
+    g.login(TOKEN_PATH)
+    return g
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _search_foods(garmin, name):
+    r = garmin.connectapi(
+        f"/nutrition-service/customFood"
+        f"?searchExpression={quote(name)}&start=0&limit=20&includeContent=true"
+    )
+    return r.get("customFoods", []) if isinstance(r, dict) else []
+
+
+def _find_by_id(garmin, name, food_id):
+    for f in _search_foods(garmin, name):
+        if str(f.get("foodMetaData", {}).get("foodId", "")) == food_id:
+            return f
+    return None
+
+
+def _count_library(garmin, name):
+    return sum(
+        1 for f in _search_foods(garmin, name)
+        if f.get("foodMetaData", {}).get("foodName") == name
+    )
+
+
+def _count_log_entries(garmin, food_id, date):
+    log = garmin.connectapi(f"/nutrition-service/food/logs/{date}")
+    return sum(
+        1 for meal in log.get("mealDetails", [])
+        for food in meal.get("loggedFoods", [])
+        if food.get("foodMetaData", {}).get("foodId") == food_id
+    )
+
+
+def _get_log_entries(garmin, food_id, date):
+    log = garmin.connectapi(f"/nutrition-service/food/logs/{date}")
+    return [
+        food for meal in log.get("mealDetails", [])
+        for food in meal.get("loggedFoods", [])
+        if food.get("foodMetaData", {}).get("foodId") == food_id
+    ]
+
+
+def _delete_food(garmin, food_id):
+    garmin.client.delete("connectapi", f"/nutrition-service/customFood/{food_id}", api=True)
+
+
+def _delete_log_entry(garmin, log_id, date):
+    garmin.client.delete(
+        "connectapi", f"/nutrition-service/food/logs/{date}",
+        json={"logIds": [log_id]}, api=True,
+    )
+
+
+def _upsert_and_log(garmin, food_name, calories, meal_id):
+    """Replicate the fixed upsert_and_log find-or-create-then-log logic."""
+    r = garmin.connectapi(
+        f"/nutrition-service/customFood"
+        f"?searchExpression={quote(food_name)}&start=0&limit=10&includeContent=true"
+    )
+    foods = r.get("customFoods", []) if isinstance(r, dict) else []
+    food_id = serving_id = None
+    for f in foods:
+        meta = f.get("foodMetaData", {})
+        if meta.get("foodName", "").lower() == food_name.lower():
+            food_id = str(meta.get("foodId", ""))
+            contents = f.get("nutritionContents", [])
+            serving_id = str(contents[0].get("servingId", "")) if contents else ""
+            break
+
+    created = False
+    if not food_id:
+        resp = garmin.client.put(
+            "connectapi", "/nutrition-service/customFood",
+            json={
+                "foodMetaData": {
+                    "foodName": food_name, "foodType": "GENERIC",
+                    "source": "GARMIN", "regionCode": "US", "languageCode": "en",
+                },
+                "nutritionContents": [
+                    {"servingUnit": "G", "numberOfUnits": "100",
+                     "calories": str(int(calories))}
+                ],
+            },
+            api=True,
+        )
+        food_id = str(resp["foodMetaData"]["foodId"])
+        serving_id = str(resp["nutritionContents"][0]["servingId"])
+        created = True
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.000Z")
+    garmin.client.put(
+        "connectapi", "/nutrition-service/food/logs",
+        json={
+            "mealDate": TEST_DATE,
+            "foodLogItems": [
+                {
+                    "logTimestamp": ts, "logSource": "GCW", "logCategory": "REGULAR_LOG",
+                    "mealTime": "15:00:00", "action": "ADD", "mealId": meal_id,
+                    "foodId": food_id, "servingId": serving_id,
+                    "source": "GARMIN", "regionCode": "US", "languageCode": "en",
+                    "servingQty": 1.0,
+                }
+            ],
+        },
+        api=True,
+    )
+    return food_id, created
+
+
+# ── Bug A: upsert dedup ───────────────────────────────────────────────────────
+
+# Name sorts very late alphabetically to mimic the original failure mode
+# (foods beyond the first page were never matched).
+_UPSERT_NAME = "ZZ Live Upsert Dedup Test ZZZZZ"
+
+
+@pytest.fixture(autouse=False)
+def cleanup_upsert(garmin):
+    """Remove any pre-existing library/log entries for the test food."""
+    for f in _search_foods(garmin, _UPSERT_NAME):
+        if f["foodMetaData"]["foodName"] == _UPSERT_NAME:
+            fid = str(f["foodMetaData"]["foodId"])
+            for entry in _get_log_entries(garmin, fid, TEST_DATE):
+                _delete_log_entry(garmin, entry["logId"], TEST_DATE)
+                time.sleep(0.3)
+            time.sleep(0.3)
+            _delete_food(garmin, fid)
+    time.sleep(0.5)
+    yield
+
+
+def test_upsert_dedup_same_name_reuses_food(garmin, cleanup_upsert):
+    """
+    Calling upsert twice with the same food_name must reuse the same library
+    entry (one food, two log rows) — not create a duplicate.
+
+    Uses a name that sorts very late alphabetically to reproduce the original
+    failure where page-1 results never included the food, so it was always created.
+    """
+    meals = garmin.connectapi(f"/nutrition-service/meals/{TEST_DATE}")
+    meal_id = next(m["mealId"] for m in meals["meals"] if m["mealName"] == "SNACKS")
+
+    fid1, created1 = _upsert_and_log(garmin, _UPSERT_NAME, 100, meal_id)
+    assert created1, "First call should create the food"
+    time.sleep(1)
+
+    fid2, created2 = _upsert_and_log(garmin, _UPSERT_NAME, 100, meal_id)
+    assert not created2, "Second call must reuse, not create"
+    time.sleep(1)
+
+    assert fid1 == fid2, f"Got different food IDs: {fid1} vs {fid2}"
+    assert _count_library(garmin, _UPSERT_NAME) == 1, "Expected exactly 1 library entry"
+    assert _count_log_entries(garmin, fid1, TEST_DATE) == 2, "Expected 2 log entries"
+
+    # cleanup
+    for entry in _get_log_entries(garmin, fid1, TEST_DATE):
+        _delete_log_entry(garmin, entry["logId"], TEST_DATE)
+        time.sleep(0.3)
+    time.sleep(0.3)
+    _delete_food(garmin, fid1)
+
+
+# ── Bug B: update merge ───────────────────────────────────────────────────────
+
+_UPDATE_NAME = "ZZ Live Update Merge Test"
+
+
+def test_update_custom_food_preserves_unset_fields(garmin):
+    """
+    Calling update_custom_food with only sodium (omitting carbs/protein/fat)
+    must preserve the existing macro values, not wipe them.
+    """
+    resp = garmin.client.put(
+        "connectapi", "/nutrition-service/customFood",
+        json={
+            "foodMetaData": {
+                "foodName": _UPDATE_NAME, "foodType": "GENERIC",
+                "source": "GARMIN", "regionCode": "US", "languageCode": "en",
+            },
+            "nutritionContents": [
+                {"servingUnit": "G", "numberOfUnits": "100", "calories": "200",
+                 "carbs": "10", "protein": "20", "fat": "5"}
+            ],
+        },
+        api=True,
+    )
+    food_id = str(resp["foodMetaData"]["foodId"])
+    serving_id = str(resp["nutritionContents"][0]["servingId"])
+    time.sleep(1)
+
+    # Confirm initial values
+    before = _find_by_id(garmin, _UPDATE_NAME, food_id)
+    assert before is not None, "Food not found after create"
+    nc_before = (before.get("nutritionContents") or [{}])[0]
+    assert nc_before.get("carbs") == 10
+    assert nc_before.get("protein") == 20
+    assert nc_before.get("fat") == 5
+
+    # Update with only sodium — replicate the fixed update logic
+    existing = nc_before
+    optional_updates = {
+        "carbs": None, "protein": None, "fat": None, "fiber": None,
+        "sugar": None, "saturatedFat": None, "sodium": 500.0,
+        "cholesterol": None, "potassium": None,
+    }
+
+    def _s(v):
+        f = float(v)
+        return str(int(f)) if f == int(f) else str(f)
+
+    nutrition: dict = {
+        "servingId": serving_id, "servingUnit": "G",
+        "numberOfUnits": "100", "calories": "200",
+    }
+    preserved = set(optional_updates.keys())
+    for key, val in existing.items():
+        if key in preserved and val is not None:
+            nutrition[key] = _s(val)
+    for key, val in optional_updates.items():
+        if val is not None:
+            nutrition[key] = _s(val)
+
+    garmin.client.put(
+        "connectapi", "/nutrition-service/customFood",
+        json={
+            "foodMetaData": {
+                "foodId": food_id, "foodName": _UPDATE_NAME, "foodType": "GENERIC",
+                "source": "GARMIN", "regionCode": "US", "languageCode": "en",
+            },
+            "nutritionContents": [nutrition],
+        },
+        api=True,
+    )
+    time.sleep(1)
+
+    after = _find_by_id(garmin, _UPDATE_NAME, food_id)
+    assert after is not None, "Food not found after update"
+    nc_after = (after.get("nutritionContents") or [{}])[0]
+
+    assert nc_after.get("carbs") == 10, f"carbs wiped: {nc_after.get('carbs')}"
+    assert nc_after.get("protein") == 20, f"protein wiped: {nc_after.get('protein')}"
+    assert nc_after.get("fat") == 5, f"fat wiped: {nc_after.get('fat')}"
+    assert nc_after.get("sodium") == 500, f"sodium not set: {nc_after.get('sodium')}"
+
+    # cleanup
+    _delete_food(garmin, food_id)

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -357,6 +357,151 @@ async def test_update_custom_food_error(app_with_nutrition, mock_garmin_client):
     assert "Error updating custom food" in result[0][0].text
 
 
+@pytest.mark.asyncio
+async def test_create_custom_food_with_brand_and_micros(app_with_nutrition, mock_garmin_client):
+    """brand_name goes to foodMetaData.brandName; new micros go to nutritionContents"""
+    mock_garmin_client.client.put.return_value = {"foodMetaData": {"foodId": "x"}}
+    result = await app_with_nutrition.call_tool(
+        "create_custom_food",
+        {
+            "food_name": "Branded Bar",
+            "calories": 200,
+            "brand_name": "ACME",
+            "trans_fat": 0.5,
+            "calcium": 130,
+            "iron": 2,
+            "vitamin_d": 2.5,
+        },
+    )
+    assert result is not None
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    assert payload["foodMetaData"]["brandName"] == "ACME"
+    nc = payload["nutritionContents"][0]
+    assert nc["transFat"] == "0.5"
+    assert nc["calcium"] == "130"
+    assert nc["iron"] == "2"
+    assert nc["vitaminD"] == "2.5"
+
+
+@pytest.mark.asyncio
+async def test_create_custom_food_minimal_no_brand(app_with_nutrition, mock_garmin_client):
+    """brand_name absent → brandName key must not appear in foodMetaData"""
+    mock_garmin_client.client.put.return_value = {}
+    await app_with_nutrition.call_tool(
+        "create_custom_food",
+        {"food_name": "Plain Food", "calories": 50},
+    )
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    assert "brandName" not in payload["foodMetaData"]
+    nc = payload["nutritionContents"][0]
+    for key in ("transFat", "calcium", "iron", "vitaminD"):
+        assert key not in nc
+
+
+@pytest.mark.asyncio
+async def test_update_custom_food_with_brand_and_micros(app_with_nutrition, mock_garmin_client):
+    """Caller-supplied brand and micros appear in the PUT payload"""
+    mock_garmin_client.client.put.return_value = {"foodMetaData": {"foodId": "abc123"}}
+    result = await app_with_nutrition.call_tool(
+        "update_custom_food",
+        {
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "food_name": "Branded Food",
+            "calories": 300,
+            "brand_name": "BigCo",
+            "trans_fat": 1.0,
+            "calcium": 260,
+            "iron": 4,
+            "vitamin_d": 5,
+        },
+    )
+    assert result is not None
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    assert payload["foodMetaData"]["brandName"] == "BigCo"
+    nc = payload["nutritionContents"][0]
+    assert nc["transFat"] == "1"
+    assert nc["calcium"] == "260"
+    assert nc["iron"] == "4"
+    assert nc["vitaminD"] == "5"
+
+
+@pytest.mark.asyncio
+async def test_update_custom_food_preserves_brand_and_micros(app_with_nutrition, mock_garmin_client):
+    """When brand and micros are omitted, the merge carries them from the existing record."""
+    # Real API returns nutritionContents values as numbers (not strings).
+    existing_food = {
+        "customFoods": [
+            {
+                "foodMetaData": {
+                    "foodId": "abc123",
+                    "foodName": "Existing Food",
+                    "brandName": "OriginalBrand",
+                },
+                "nutritionContents": [
+                    {
+                        "servingId": "srv456",
+                        "calories": 200,
+                        "transFat": 0.5,
+                        "calcium": 100,
+                        "iron": 3,
+                        "vitaminD": 2,
+                    }
+                ],
+            }
+        ]
+    }
+    mock_garmin_client.connectapi.return_value = existing_food
+    mock_garmin_client.client.put.return_value = {}
+
+    await app_with_nutrition.call_tool(
+        "update_custom_food",
+        {
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "food_name": "Existing Food",
+            "calories": 200,
+            # brand_name, trans_fat, calcium, iron, vitamin_d intentionally omitted
+        },
+    )
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    # Brand preserved from existing record
+    assert payload["foodMetaData"]["brandName"] == "OriginalBrand"
+    nc = payload["nutritionContents"][0]
+    assert nc["transFat"] == "0.5"
+    assert nc["calcium"] == "100"
+    assert nc["iron"] == "3"
+    assert nc["vitaminD"] == "2"
+
+
+@pytest.mark.asyncio
+async def test_update_custom_food_brand_overrides_existing(app_with_nutrition, mock_garmin_client):
+    """Caller-supplied brand_name replaces the existing one"""
+    existing_food = {
+        "customFoods": [
+            {
+                "foodMetaData": {"foodId": "abc123", "foodName": "Food", "brandName": "OldBrand"},
+                "nutritionContents": [{"servingId": "srv456", "calories": 100}],
+            }
+        ]
+    }
+    mock_garmin_client.connectapi.return_value = existing_food
+    mock_garmin_client.client.put.return_value = {}
+
+    await app_with_nutrition.call_tool(
+        "update_custom_food",
+        {
+            "food_id": "abc123",
+            "serving_id": "srv456",
+            "food_name": "Food",
+            "calories": 100,
+            "brand_name": "NewBrand",
+        },
+    )
+    payload = mock_garmin_client.client.put.call_args[1]["json"]
+    assert payload["foodMetaData"]["brandName"] == "NewBrand"
+
+
 MOCK_MEALS = {
     "meals": [
         {"mealId": 20249, "mealName": "BREAKFAST", "startTime": "06:00:00", "endTime": "09:00:00"},

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -585,12 +585,14 @@ async def test_delete_food_log_error(app_with_nutrition, mock_garmin_client):
 
 # upsert_and_log tests
 
-MOCK_CUSTOM_FOODS = [
-    {
-        "foodMetaData": {"foodId": "food001", "foodName": "Greek Yogurt"},
-        "nutritionContents": [{"servingId": "srv001", "calories": "100"}],
-    }
-]
+MOCK_CUSTOM_FOODS = {
+    "customFoods": [
+        {
+            "foodMetaData": {"foodId": "food001", "foodName": "Greek Yogurt"},
+            "nutritionContents": [{"servingId": "srv001", "calories": "100"}],
+        }
+    ]
+}
 
 
 @pytest.mark.asyncio
@@ -628,8 +630,8 @@ async def test_upsert_and_log_creates_new_food(app_with_nutrition, mock_garmin_c
         "nutritionContents": [{"servingId": "srv999"}],
     }
     mock_garmin_client.connectapi.side_effect = [
-        [],           # search returns empty
-        MOCK_MEALS,   # meal resolution
+        {"customFoods": []},  # search returns empty
+        MOCK_MEALS,           # meal resolution
     ]
     mock_garmin_client.client.put.side_effect = [created_food, {}]
     result = await app_with_nutrition.call_tool(

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -525,6 +525,35 @@ async def test_log_custom_food_error(app_with_nutrition, mock_garmin_client):
     assert "Error logging food" in result[0][0].text
 
 
+# delete_custom_food tests
+
+@pytest.mark.asyncio
+async def test_delete_custom_food(app_with_nutrition, mock_garmin_client):
+    """Test delete_custom_food calls DELETE /customFood/{foodId} and returns success"""
+    mock_garmin_client.client.delete.return_value = {}
+    food_id = "08b27145e29d41479e36d8d3788fcccf"
+    result = await app_with_nutrition.call_tool(
+        "delete_custom_food",
+        {"food_id": food_id},
+    )
+    assert "success" in result[0][0].text
+    assert food_id in result[0][0].text
+    mock_garmin_client.client.delete.assert_called_once_with(
+        "connectapi", f"/nutrition-service/customFood/{food_id}", api=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_delete_custom_food_error(app_with_nutrition, mock_garmin_client):
+    """Test delete_custom_food handles API errors"""
+    mock_garmin_client.client.delete.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "delete_custom_food",
+        {"food_id": "08b27145e29d41479e36d8d3788fcccf"},
+    )
+    assert "Error deleting custom food" in result[0][0].text
+
+
 # delete_food_log tests
 
 @pytest.mark.asyncio


### PR DESCRIPTION
This is a rebase of PR #152 onto current main (post-#151 merge) with one minor cleanup:

- Removed unused `resp` assignment in `delete_custom_food` (DELETE returns 204; result unused)

All original changes from #152 are included:
- New `delete_custom_food` tool
- Bug fix: `upsert_and_log` dedup (was always creating new entries due to wrong isinstance check)
- Bug fix: `update_custom_food` does a read-merge-write to preserve existing fields
- New optional params: `brand_name`, `trans_fat`, `calcium`, `iron`, `vitamin_d`

370 tests pass.

Closes #152