### PR TITLE
fix(weather): correct temperature unit label and repair null weather fields

### DIFF
--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -651,7 +651,16 @@ def register_tools(app):
 
     @app.tool()
     async def get_activity_weather(activity_id: Union[int, str]) -> str:
-        """Get weather data for an activity
+        """Get weather data for an activity.
+
+        The temperature and dew_point values are in the unit matching the
+        account's measurement system (Fahrenheit for statute_us / imperial
+        accounts, Celsius for metric). The temperature_unit field ("F" or "C")
+        reflects whichever unit the API returned; do not assume Celsius.
+
+        Wind speed unit also follows the measurement system (mph for imperial,
+        km/h for metric), but no wind_speed_unit field is included because the
+        Garmin API does not document the wind speed unit explicitly.
 
         Args:
             activity_id: ID of the activity to retrieve weather data for
@@ -662,17 +671,32 @@ def register_tools(app):
             if not weather:
                 return f"No weather data found for activity with ID {activity_id}"
 
-            # Curate weather data
+            # Determine temperature unit from the account's measurement system.
+            # Garmin's weather endpoint returns temp in the account's display
+            # unit (no unit indicator in the payload itself).
+            try:
+                unit_system = garmin_client.get_unit_system()
+                temp_unit = "F" if unit_system == "statute_us" else "C"
+            except Exception:
+                temp_unit = None
+
+            weather_type_dto = weather.get('weatherTypeDTO') or {}
+            station_dto = weather.get('weatherStationDTO') or {}
+
             curated = {
                 "activity_id": activity_id,
-                "temperature_celsius": weather.get('temp'),
-                "apparent_temperature_celsius": weather.get('apparentTemp'),
+                "temperature": weather.get('temp'),
+                "temperature_unit": temp_unit,
+                "apparent_temperature": weather.get('apparentTemp'),
+                "dew_point": weather.get('dewPoint'),
                 "humidity_percent": weather.get('relativeHumidity'),
-                "wind_speed_mps": weather.get('windSpeed'),
+                "wind_speed": weather.get('windSpeed'),
                 "wind_direction_degrees": weather.get('windDirection'),
-                "weather_type": weather.get('weatherTypeDTO', {}).get('weatherTypeName'),
-                "weather_description": weather.get('weatherTypeDTO', {}).get('weatherTypeDesc'),
-                "location": weather.get('issueLocation'),
+                "wind_direction_compass": weather.get('windDirectionCompassPoint'),
+                "wind_gust": weather.get('windGust'),
+                "weather_description": weather_type_dto.get('desc'),
+                "station_id": station_dto.get('id'),
+                "station_name": station_dto.get('name'),
                 "issue_time": weather.get('issueDate'),
             }
 


### PR DESCRIPTION
`get_activity_weather` returned temperature under a `temperature_celsius` key, but the raw Garmin payload carries no unit indicator — the value follows the account's `measurementSystem` setting, so imperial accounts got Fahrenheit mislabeled as Celsius. Confirmed against a real activity: raw payload `temp=79` for a Florida morning (79°F correct; 79°C impossible).

## Changes

- Rename `temperature_celsius` → `temperature`, add `temperature_unit` ("F"/"C") derived from `get_unit_system()`; same rename for `apparent_temperature_celsius` → `apparent_temperature`.
- Repair three always-null fields caused by wrong source keys:
  - `weather_description`: was reading `weatherTypeName`/`weatherTypeDesc` (keys don't exist) → now reads `weatherTypeDTO.desc`
  - `station_name` / `station_id`: was reading `issueLocation` (doesn't exist) → now reads `weatherStationDTO.name` / `.id`
- Add `dew_point` (`dewPoint`), `wind_direction_compass` (`windDirectionCompassPoint`), `wind_gust` (`windGust`).
- Rename `wind_speed_mps` → `wind_speed` (Garmin doesn't document the unit; it follows `measurementSystem` like temperature).
- Docstring updated to describe unit behaviour and wind speed ambiguity.

## Verified live (real account, activity in Florida)

**Before:**
```json
{"temperature_celsius": 79, "weather_description": null, "location": null}
```

**After:**
```json
{
  "temperature": 79,
  "temperature_unit": "F",
  "dew_point": 77,
  "humidity_percent": 94,
  "wind_speed": 5,
  "wind_direction_degrees": 0,
  "wind_direction_compass": "n",
  "weather_description": "Mostly Cloudy",
  "station_id": "KCOI",
  "station_name": "Merritt Island Airport",
  "issue_time": "2026-06-23T11:15:00.000+00:00"
}
```