### PR TITLE
fix(workouts): validate calendar_date up front in schedule_workout/schedule_workouts

### DIFF
--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -961,6 +961,16 @@ def register_tools(app):
             calendar_date: Date to schedule the workout in YYYY-MM-DD format
         """
         try:
+            _validate_date(calendar_date, "calendar_date")
+        except ValueError as e:
+            return json.dumps({
+                "status": "failed",
+                "workout_id": workout_id,
+                "scheduled_date": calendar_date,
+                "message": str(e),
+            }, indent=2)
+
+        try:
             if _is_already_scheduled(workout_id, calendar_date):
                 return json.dumps({
                     "status": "success",
@@ -1030,6 +1040,17 @@ def register_tools(app):
                     "workout_id": workout_id,
                     "scheduled_date": calendar_date,
                     "message": "Missing required field: calendar_date"
+                })
+                continue
+
+            try:
+                _validate_date(calendar_date, "calendar_date")
+            except ValueError as e:
+                results.append({
+                    "status": "failed",
+                    "workout_id": workout_id,
+                    "scheduled_date": calendar_date,
+                    "message": str(e),
                 })
                 continue
 

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -1488,6 +1488,69 @@ async def test_schedule_workouts_missing_fields(app_with_workouts, mock_garmin_c
 
 
 @pytest.mark.asyncio
+async def test_schedule_workouts_rejects_invalid_date(app_with_workouts, mock_garmin_client):
+    """A malformed calendar_date is rejected up front, without calling the API."""
+    import json as json_module
+
+    result = await app_with_workouts.call_tool(
+        "schedule_workouts",
+        {"schedules": [{"workout_id": 123456, "calendar_date": "not-a-date"}]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["total"] == 1
+    assert result_data["succeeded"] == 0
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "failed"
+    assert "YYYY-MM-DD" in result_data["results"][0]["message"]
+    mock_garmin_client.client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_workouts_invalid_date_skips_inline_upload(
+    app_with_workouts, mock_garmin_client
+):
+    """A bad date on an inline item is rejected before any upload is attempted."""
+    import json as json_module
+
+    inline_data = _running_workout_with_steps([_timed_interval_step(
+        {"workoutTargetTypeId": 4, "workoutTargetTypeKey": "heart.rate.zone"}
+    )])
+    result = await app_with_workouts.call_tool(
+        "schedule_workouts",
+        {"schedules": [{"workout_data": inline_data, "calendar_date": "2024/02/01"}]}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["failed"] == 1
+    assert result_data["results"][0]["status"] == "failed"
+    assert "YYYY-MM-DD" in result_data["results"][0]["message"]
+    mock_garmin_client.upload_workout.assert_not_called()
+    mock_garmin_client.client.post.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_schedule_workout_rejects_invalid_date(app_with_workouts, mock_garmin_client):
+    """The single-workout scheduler rejects a malformed date without an API call."""
+    import json as json_module
+
+    result = await app_with_workouts.call_tool(
+        "schedule_workout",
+        {"workout_id": 123456, "calendar_date": "01-15-2024"}
+    )
+
+    assert result is not None
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "failed"
+    assert result_data["workout_id"] == 123456
+    assert "YYYY-MM-DD" in result_data["message"]
+    mock_garmin_client.client.post.assert_not_called()
+    mock_garmin_client.query_garmin_graphql.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_schedule_workouts_exception(app_with_workouts, mock_garmin_client):
     """Test schedule_workouts when an exception is raised"""
     import json as json_module


### PR DESCRIPTION
## What

`_validate_date` is already used across the workouts **read** tools (`get_scheduled_workouts`, `get_training_plan_workouts`) and inside the `_is_already_scheduled` idempotency pre-check — but the two **write** tools, `schedule_workout` and `schedule_workouts`, never validated their `calendar_date`.

Because `_is_already_scheduled` deliberately swallows its own errors (`except Exception: return False`, so the idempotency check can't block a legitimate schedule), a malformed date falls straight through to the real `POST workout-service/schedule/{id}` with a garbage body. The call is doomed, and the caller gets back an opaque `HTTP 4xx` / Garmin error string instead of a clear "wrong format" message.

## Change

Validate `calendar_date` up front in both tools, before any network call, matching each tool's existing failure style:

- **`schedule_workout`** — returns a structured `{"status": "failed", …, "message": "Invalid calendar_date '…': expected YYYY-MM-DD"}` and never POSTs.
- **`schedule_workouts`** — per item, rejects a bad date right next to the existing `calendar_date is None` guard (same `status: "failed"` shape, then `continue`). This also short-circuits **before** the inline `workout_data` upload, so a malformed date no longer triggers a wasted upload.

No happy-path change: valid `YYYY-MM-DD` dates flow exactly as before.

## Tests (+3)

- `test_schedule_workouts_rejects_invalid_date` — bad date → `failed`, `post` not called.
- `test_schedule_workouts_invalid_date_skips_inline_upload` — bad date on an inline item → no `upload_workout`, no `post`.
- `test_schedule_workout_rejects_invalid_date` — covers the single-workout tool (which previously had no tests) → `failed`, and neither `post` nor the GraphQL pre-check is called.

## Validation

```
uv sync
uv run pytest tests/integration tests/unit   # 388 passed (was 385)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)