### PR TITLE
ci: publish multi-arch Docker images to GHCR on release (closes #136)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,57 @@
+name: Publish Docker image
+
+# Publish a versioned, multi-arch image to the GitHub Container Registry
+# (ghcr.io) on each published release. Uses the built-in GITHUB_TOKEN, so no
+# extra secrets are required. The package inherits the repo's visibility; make
+# it public once under Packages settings if anonymous `docker pull` is desired.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Extract image metadata (tags, labels)
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        # metadata-action lowercases the image name, so Taxuspt/garmin_mcp
+        # becomes ghcr.io/taxuspt/garmin_mcp.
+        images: ghcr.io/${{ github.repository }}
+        tags: |
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
+          type=raw,value=latest
+
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max

--- a/README.md
+++ b/README.md
@@ -648,6 +648,21 @@ docker run -it \
   garmin-mcp
 ```
 
+#### Using a Prebuilt Image (GHCR)
+
+Versioned, multi-arch images are published to the GitHub Container Registry on
+each release, so you can skip the local build:
+
+```bash
+docker run -it \
+  -e GARMIN_EMAIL="your_email@example.com" \
+  -e GARMIN_PASSWORD="your_password" \
+  -v garmin-tokens:/root/.garminconnect \
+  ghcr.io/taxuspt/garmin_mcp:latest
+```
+
+Pin a specific version (e.g. `ghcr.io/taxuspt/garmin_mcp:0.1.0`) for reproducible deployments.
+
 #### Using File-Based Secrets (More Secure)
 
 For enhanced security, especially in production environments, use file-based secrets instead of environment variables:


### PR DESCRIPTION
## What

Closes #136. There's a `Dockerfile` but no published image, so everyone has to `docker build` locally. This adds a workflow that builds and pushes a versioned, multi-arch image to the GitHub Container Registry on each release.

Per the issue, this uses **GHCR** — zero extra secrets (the built-in `GITHUB_TOKEN`), lives next to the repo, and multi-arch is easy.

## How it works

- **Trigger:** `release: [published]` (plus `workflow_dispatch` for manual runs).
- **Image:** `ghcr.io/taxuspt/garmin_mcp` (`docker/metadata-action` lowercases the repo owner).
- **Tags:** semver `{{version}}` and `{{major}}.{{minor}}`, plus `latest`.
- **Platforms:** `linux/amd64` and `linux/arm64` (via QEMU + Buildx), with GitHub Actions layer caching.
- **Auth:** `GITHUB_TOKEN` with `permissions: packages: write`.

Also documents pulling the prebuilt image in the README's Docker section.

## One-time maintainer step

GHCR packages created by Actions inherit the repo's visibility. After the first release publishes the image, flip the package to **public** once under *Packages → Package settings* if you want anonymous `docker pull`.

## Validation

- Workflow YAML parsed and structurally checked (release trigger, `packages: write`, QEMU/Buildx/login/metadata/build-push steps present).
- **Note:** the actual multi-arch build/push only runs in the upstream repo on a real release (a Docker daemon wasn't available locally to dry-run the build). The `Dockerfile` is the existing, unmodified one already used by `docker-compose`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)