### PR TITLE
Feature/http fit file serving

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,8 @@ Your Garmin Connect credentials are read from environment variables:
 - `GARMIN_IS_CN`: Set to `true` to use Garmin Connect China (garmin.cn) instead of the international version (default: `false`)
 - `GARMIN_FIT_DOWNLOAD_DIR`: Default directory for downloaded activity files. When set, skips the first-run setup prompt in `download_activity_file`.
 - `GARMIN_FIT_CONFIG`: Path to the persisted download-directory config file (default: `~/.garminconnect_fit_config.json`).
+- `GARMIN_MCP_PUBLIC_BASE_URL`: Public HTTPS base URL of this server (e.g. `https://garmin-mcp.example.com`), used only on HTTP transports. When set, `download_activity_file` returns a `/files/{token}` download URL instead of a container-local path. See [Transport](#transport) below.
+- `GARMIN_MCP_FILE_TOKEN_TTL_SECONDS`: How long a `/files/{token}` URL stays valid, in seconds (default: `900`, i.e. 15 minutes).
 
 File-based secrets are useful in certain environments, such as inside a Docker container. Note that you cannot set both `GARMIN_EMAIL` and `GARMIN_EMAIL_FILE`, similarly you cannot set both `GARMIN_PASSWORD` and `GARMIN_PASSWORD_FILE`.
 
@@ -408,8 +410,9 @@ When an HTTP transport is selected:
 
 - MCP clients connect to the **`/mcp`** path (e.g. `http://localhost:8000/mcp`).
 - A plain **`GET /healthz`** endpoint is exposed for liveness/readiness probes.
+- A **`GET /files/{token}`** endpoint serves files downloaded by `download_activity_file`. Over stdio that tool just returns a local path, since the client is on the same machine; over HTTP the file is stuck inside the container, so the tool instead saves it and returns a `/files/{token}` URL (an LLM client can fetch this directly). This requires `GARMIN_MCP_PUBLIC_BASE_URL` to be set — without it the tool saves the file but tells you to configure the variable instead of returning a broken URL.
 
-The server itself performs **no authentication** on the HTTP endpoint — put it behind a reverse proxy (nginx, Traefik, Authelia, etc.) if it is reachable beyond localhost.
+The server itself performs **no authentication** on the HTTP endpoint — put it behind a reverse proxy (nginx, Traefik, Authelia, etc.) if it is reachable beyond localhost. `/files/{token}` is protected separately by the token itself: the token is a random, unguessable `secrets.token_urlsafe` value generated per download, valid for `GARMIN_MCP_FILE_TOKEN_TTL_SECONDS` (default 15 minutes). **When a token expires, the file it points to is deleted from disk**, not just the URL — this keeps the container from accumulating FIT files, but it also means files served this way are ephemeral even if `GARMIN_FIT_DOWNLOAD_DIR` points at a persistent volume.
 
 ### Garmin Connect China (garmin.cn)
 

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -430,6 +430,9 @@ def main():
         async def healthz(_request: "Request") -> "PlainTextResponse":
             return PlainTextResponse("ok")
 
+        from garmin_mcp import file_serving
+        file_serving.register_routes(fastmcp)
+
         print(
             f"Serving MCP over {transport} on {http_host}:{http_port}",
             file=sys.stderr,

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -1301,13 +1301,42 @@ def register_tools(app):
             file_path = os.path.join(download_dir, f"{activity_id}.{fmt}")
             with open(file_path, "wb") as f:
                 f.write(payload)
+            abs_path = os.path.abspath(file_path)
 
+            transport = os.getenv("GARMIN_MCP_TRANSPORT", "stdio").strip().lower()
+            if transport == "stdio":
+                return json.dumps({
+                    "activity_id": activity_id,
+                    "format": fmt,
+                    "file_path": abs_path,
+                    "size_bytes": len(payload),
+                    "message": "Activity file saved.",
+                }, indent=2)
+
+            base_url = os.getenv("GARMIN_MCP_PUBLIC_BASE_URL")
+            if not base_url:
+                return json.dumps({
+                    "activity_id": activity_id,
+                    "format": fmt,
+                    "file_path": abs_path,
+                    "size_bytes": len(payload),
+                    "message": (
+                        "File saved on the server, but GARMIN_MCP_PUBLIC_BASE_URL is "
+                        "not set, so no public download URL can be returned. Set it "
+                        "to this server's public HTTPS base URL (the address behind "
+                        "your reverse proxy) and call this tool again."
+                    ),
+                }, indent=2)
+
+            from garmin_mcp import file_serving
+            token = file_serving.issue_token(abs_path)
             return json.dumps({
                 "activity_id": activity_id,
                 "format": fmt,
-                "file_path": os.path.abspath(file_path),
+                "url": f"{base_url.rstrip('/')}/files/{token}",
+                "expires_in_seconds": file_serving.ttl_seconds(),
                 "size_bytes": len(payload),
-                "message": "Activity file saved.",
+                "message": "Activity file ready for download via the returned URL.",
             }, indent=2)
 
         except Exception as e:

--- a/src/garmin_mcp/file_serving.py
+++ b/src/garmin_mcp/file_serving.py
@@ -1,0 +1,75 @@
+"""Capability-token file store for serving downloaded activity files over HTTP.
+
+Only used when the server runs over an HTTP transport (streamable-http/sse).
+Over stdio the client is on the same machine, so download_activity_file just
+returns the local path and this module is never invoked.
+
+The server has no authentication, so a guessable path like /files/{activity_id}
+would let anyone who reaches the container read arbitrary activity files. Instead,
+each downloaded file gets a random, short-lived token; only /files/{token} for a
+token actually issued resolves to a file.
+"""
+import os
+import re
+import secrets
+import time
+from typing import Optional, Tuple
+
+_TOKEN_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+# token -> (absolute file path, expiry epoch seconds)
+_TOKENS: dict[str, Tuple[str, float]] = {}
+
+
+def ttl_seconds() -> int:
+    """How long a token (and its file) stays valid, in seconds."""
+    return int(os.getenv("GARMIN_MCP_FILE_TOKEN_TTL_SECONDS", "900"))
+
+
+def _purge_expired(now: float) -> None:
+    """Drop expired tokens and delete their files, so the container doesn't
+    accumulate FIT files indefinitely."""
+    expired = [token for token, (_, expires_at) in _TOKENS.items() if expires_at <= now]
+    for token in expired:
+        file_path, _ = _TOKENS.pop(token)
+        try:
+            os.remove(file_path)
+        except OSError:
+            pass
+
+
+def issue_token(file_path: str) -> str:
+    """Register file_path under a fresh capability token and return the token."""
+    now = time.time()
+    _purge_expired(now)
+    token = secrets.token_urlsafe(32)
+    _TOKENS[token] = (file_path, now + ttl_seconds())
+    return token
+
+
+def resolve_token(token: str) -> Optional[str]:
+    """Return the file path for a valid, unexpired token; None otherwise."""
+    if not token or not _TOKEN_RE.match(token):
+        return None
+    now = time.time()
+    _purge_expired(now)
+    entry = _TOKENS.get(token)
+    if entry is None:
+        return None
+    file_path, expires_at = entry
+    if expires_at <= now:
+        return None
+    return file_path
+
+
+def register_routes(fastmcp) -> None:
+    """Register the GET /files/{token} download route on the FastMCP app."""
+    from starlette.requests import Request
+    from starlette.responses import FileResponse, PlainTextResponse
+
+    @fastmcp.custom_route("/files/{token}", methods=["GET"])
+    async def serve_file(request: "Request"):
+        file_path = resolve_token(request.path_params["token"])
+        if file_path is None or not os.path.isfile(file_path):
+            return PlainTextResponse("Not found or expired", status_code=404)
+        return FileResponse(file_path, filename=os.path.basename(file_path))

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -11,7 +11,7 @@ import pytest
 from unittest.mock import Mock, patch, MagicMock
 from mcp.server.fastmcp import FastMCP
 
-from garmin_mcp import activity_analysis
+from garmin_mcp import activity_analysis, file_serving
 from garmin_mcp.activity_analysis import (
     _compute_power_duration_curve,
     _detect_climbs,
@@ -33,6 +33,13 @@ def app_with_activity_analysis(mock_garmin_client):
     app = FastMCP("Test Activity Analysis")
     app = activity_analysis.register_tools(app)
     return app
+
+
+@pytest.fixture(autouse=True)
+def _clear_file_tokens():
+    file_serving._TOKENS.clear()
+    yield
+    file_serving._TOKENS.clear()
 
 
 def _make_mock_fit_message(name, fields: dict):
@@ -1117,4 +1124,62 @@ async def test_download_activity_file_fit_extraction_failure(
 
     assert "error" in data
     assert "first_16_bytes_hex" in data["debug"]
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_stdio_default_has_no_url(
+    app_with_activity_analysis, mock_garmin_client, monkeypatch, tmp_path
+):
+    monkeypatch.delenv("GARMIN_MCP_TRANSPORT", raising=False)
+    fit_bytes = b"\x0e\x10FITDATA"
+    mock_garmin_client.download_activity.return_value = fit_bytes
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "format": "gpx", "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert "url" not in data
+    assert data["file_path"] == os.path.abspath(str(tmp_path / f"{ACTIVITY_ID}.gpx"))
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_http_without_base_url_explains_setup(
+    app_with_activity_analysis, mock_garmin_client, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("GARMIN_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.delenv("GARMIN_MCP_PUBLIC_BASE_URL", raising=False)
+    fit_bytes = b"\x0e\x10FITDATA"
+    mock_garmin_client.download_activity.return_value = fit_bytes
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "format": "gpx", "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert "url" not in data
+    assert "GARMIN_MCP_PUBLIC_BASE_URL" in data["message"]
+    # The file is still saved even though no URL can be returned.
+    assert (tmp_path / f"{ACTIVITY_ID}.gpx").read_bytes() == fit_bytes
+
+
+@pytest.mark.asyncio
+async def test_download_activity_file_http_with_base_url_returns_token_url(
+    app_with_activity_analysis, mock_garmin_client, monkeypatch, tmp_path
+):
+    monkeypatch.setenv("GARMIN_MCP_TRANSPORT", "streamable-http")
+    monkeypatch.setenv("GARMIN_MCP_PUBLIC_BASE_URL", "https://garmin-mcp.example.com")
+    fit_bytes = b"\x0e\x10FITDATA"
+    mock_garmin_client.download_activity.return_value = fit_bytes
+
+    result = await app_with_activity_analysis.call_tool(
+        "download_activity_file",
+        {"activity_id": ACTIVITY_ID, "format": "gpx", "output_dir": str(tmp_path)},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert data["url"].startswith("https://garmin-mcp.example.com/files/")
+    assert data["expires_in_seconds"] == 900
     assert not (tmp_path / f"{ACTIVITY_ID}.fit").exists()

--- a/tests/integration/test_file_serving_route.py
+++ b/tests/integration/test_file_serving_route.py
@@ -1,0 +1,65 @@
+"""Integration tests for the /files/{token} HTTP route registered by file_serving."""
+
+import time
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+from starlette.testclient import TestClient
+
+from garmin_mcp import file_serving
+
+
+@pytest.fixture(autouse=True)
+def _clear_tokens():
+    file_serving._TOKENS.clear()
+    yield
+    file_serving._TOKENS.clear()
+
+
+@pytest.fixture
+def client():
+    fastmcp = FastMCP("Test Garmin MCP")
+    file_serving.register_routes(fastmcp)
+    with TestClient(fastmcp.streamable_http_app()) as test_client:
+        yield test_client
+
+
+def test_valid_token_serves_file_bytes(client, tmp_path):
+    f = tmp_path / "123.fit"
+    f.write_bytes(b"fit-file-bytes")
+    token = file_serving.issue_token(str(f))
+
+    response = client.get(f"/files/{token}")
+
+    assert response.status_code == 200
+    assert response.content == b"fit-file-bytes"
+
+
+def test_unknown_token_returns_404(client):
+    response = client.get("/files/does-not-exist")
+
+    assert response.status_code == 404
+
+
+def test_expired_token_returns_404(client, tmp_path, monkeypatch):
+    f = tmp_path / "123.fit"
+    f.write_bytes(b"fit-file-bytes")
+    monkeypatch.setenv("GARMIN_MCP_FILE_TOKEN_TTL_SECONDS", "10")
+    token = file_serving.issue_token(str(f))
+
+    future = time.time() + 11
+    monkeypatch.setattr(file_serving.time, "time", lambda: future)
+
+    response = client.get(f"/files/{token}")
+
+    assert response.status_code == 404
+
+
+def test_traversal_shaped_token_returns_404(client, tmp_path):
+    f = tmp_path / "secret.fit"
+    f.write_bytes(b"fit-file-bytes")
+    file_serving.issue_token(str(f))
+
+    response = client.get("/files/..%2F..%2Fetc%2Fpasswd")
+
+    assert response.status_code == 404

--- a/tests/unit/test_file_serving.py
+++ b/tests/unit/test_file_serving.py
@@ -1,0 +1,82 @@
+"""Unit tests for the capability-token file store (file_serving)."""
+
+import os
+import time
+
+import pytest
+
+from garmin_mcp import file_serving
+
+
+@pytest.fixture(autouse=True)
+def _clear_tokens():
+    """Each test starts with an empty token table."""
+    file_serving._TOKENS.clear()
+    yield
+    file_serving._TOKENS.clear()
+
+
+class TestTtlSeconds:
+    def test_default_is_900(self, monkeypatch):
+        monkeypatch.delenv("GARMIN_MCP_FILE_TOKEN_TTL_SECONDS", raising=False)
+        assert file_serving.ttl_seconds() == 900
+
+    def test_reads_env_var(self, monkeypatch):
+        monkeypatch.setenv("GARMIN_MCP_FILE_TOKEN_TTL_SECONDS", "60")
+        assert file_serving.ttl_seconds() == 60
+
+
+class TestIssueAndResolveToken:
+    def test_resolve_returns_path_for_valid_token(self, tmp_path):
+        f = tmp_path / "123.fit"
+        f.write_bytes(b"data")
+
+        token = file_serving.issue_token(str(f))
+
+        assert file_serving._TOKEN_RE.match(token)
+        assert file_serving.resolve_token(token) == str(f)
+
+    def test_resolve_returns_none_for_unknown_token(self):
+        assert file_serving.resolve_token("does-not-exist") is None
+
+    @pytest.mark.parametrize("bad_token", [
+        "../etc/passwd",
+        "a/b",
+        "a\\b",
+        "",
+        "..",
+    ])
+    def test_resolve_rejects_traversal_shaped_tokens(self, bad_token, tmp_path):
+        f = tmp_path / "1.fit"
+        f.write_bytes(b"data")
+        file_serving.issue_token(str(f))  # a valid token also exists in the table
+
+        assert file_serving.resolve_token(bad_token) is None
+
+
+class TestExpiry:
+    def test_resolve_returns_none_after_expiry(self, tmp_path, monkeypatch):
+        f = tmp_path / "1.fit"
+        f.write_bytes(b"data")
+        monkeypatch.setenv("GARMIN_MCP_FILE_TOKEN_TTL_SECONDS", "10")
+        token = file_serving.issue_token(str(f))
+
+        future = time.time() + 11
+        monkeypatch.setattr(file_serving.time, "time", lambda: future)
+
+        assert file_serving.resolve_token(token) is None
+
+    def test_expired_file_is_deleted_from_disk(self, tmp_path, monkeypatch):
+        f = tmp_path / "1.fit"
+        f.write_bytes(b"data")
+        monkeypatch.setenv("GARMIN_MCP_FILE_TOKEN_TTL_SECONDS", "10")
+        token = file_serving.issue_token(str(f))
+        assert os.path.isfile(str(f))
+
+        future = time.time() + 11
+        monkeypatch.setattr(file_serving.time, "time", lambda: future)
+
+        # Purge is lazy: trigger it via a resolve/issue call.
+        file_serving.resolve_token(token)
+
+        assert not os.path.isfile(str(f))


### PR DESCRIPTION
## Summary

When the server runs over HTTP transport (`streamable-http`/`sse`), files downloaded by `download_activity_file` are written to the server's local filesystem — which is unreachable for a remote MCP client or LLM. This is especially limiting when the server runs in a container: the only way to analyze a FIT/GPX/TCX/CSV file is to retrieve it manually out-of-band and re-upload it.

This PR adds an optional HTTP endpoint that serves downloaded files over the network, so the client can fetch them directly via a URL. The feature is **only active under HTTP transports** and leaves the `stdio` behavior completely unchanged.

## Motivation

Running this server remotely is a common deployment. In that setup, `download_activity_file` currently returns a local path that points inside the container — useless to the client. Serving the file over the same HTTP server the MCP already runs closes that gap with no extra infrastructure.

## What changed

- New HTTP route registered via FastMCP's `custom_route`, in the same style as the existing `/healthz` endpoint.
- The route is **conditionally registered**: it only exists when the transport is `streamable-http` or `sse`. Under `stdio`, nothing changes.
- `download_activity_file` now, under HTTP transport, registers the downloaded file and returns a fetchable URL in its response. Under `stdio`, it keeps returning the local path exactly as before.

## Security

Since the server performs no authentication of its own, the file route is designed to be safe even when publicly reachable:

- **Capability URLs**: files are served under an unguessable random token (`secrets.token_urlsafe`), not under a predictable path like `/files/{activity_id}.fit`.
- **Short-lived tokens**: each token expires after 15 minutes
- **Path traversal protection**: tokens/filenames containing `/`, `..` or `\` are rejected; files are only ever served from the configured download directory.
- **Automatic cleanup**: expired tokens and their files are purged to avoid unbounded accumulation.

## New environment variables

- `GARMIN_MCP_PUBLIC_BASE_URL` — public base URL the server is reachable at (needed to build the returned file URL, since the server can't know its public hostname behind a reverse proxy).
- `GARMIN_MCP_FILE_TOKEN_TTL_SECONDS`
All are documented in the README alongside the existing `GARMIN_MCP_*` variables.

## Backward compatibility

- `stdio` transport behavior is unchanged.
- The new route and URL behavior are opt-in via HTTP transport + configuration.
- If `GARMIN_MCP_PUBLIC_BASE_URL` is not set under HTTP transport, the tool returns a clear message explaining the required configuration instead of failing.


