### PR TITLE
fix(training): handle explicit null in nested training_status fields

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -492,9 +492,14 @@ def register_tools(app):
             if not status:
                 return f"No training status data found for {date}."
 
-            # Extract from nested structure
-            recent_status = status.get("mostRecentTrainingStatus", {})
-            latest_data = recent_status.get("latestTrainingStatusData", {})
+            # Extract from nested structure.
+            # NOTE: Garmin returns explicit `null` for sections the user has no data in
+            # (e.g. `mostRecentVO2Max.cycling` is null for users who never cycle).
+            # dict.get(key, default) only returns the default when key is MISSING — when
+            # the value is explicitly None, it returns None, breaking the next .get() in
+            # the chain. Use `or {}` to coalesce both cases.
+            recent_status = status.get("mostRecentTrainingStatus") or {}
+            latest_data = recent_status.get("latestTrainingStatusData") or {}
 
             # Get first device data (usually the primary device)
             device_data = {}
@@ -502,15 +507,16 @@ def register_tools(app):
                 device_data = data
                 break
 
-            acwr_data = device_data.get("acuteTrainingLoadDTO", {})
+            acwr_data = device_data.get("acuteTrainingLoadDTO") or {}
 
             # VO2 Max data
-            vo2_data = status.get("mostRecentVO2Max", {}).get("generic", {})
-            cycling_vo2_data = status.get("mostRecentVO2Max", {}).get("cycling", {})
+            most_recent_vo2 = status.get("mostRecentVO2Max") or {}
+            vo2_data = most_recent_vo2.get("generic") or {}
+            cycling_vo2_data = most_recent_vo2.get("cycling") or {}
 
             # Training load balance
-            load_balance = status.get("mostRecentTrainingLoadBalance", {})
-            load_map = load_balance.get("metricsTrainingLoadBalanceDTOMap", {})
+            load_balance = status.get("mostRecentTrainingLoadBalance") or {}
+            load_map = load_balance.get("metricsTrainingLoadBalanceDTOMap") or {}
             load_data = {}
             for device_id, data in load_map.items():
                 load_data = data


### PR DESCRIPTION
## Summary

`get_training_status` crashes with `'NoneType' object has no attribute 'get'` whenever any nested sub-section of the API response is explicitly `null`. Replaces `dict.get(key, {})` with `dict.get(key) or {}` on every vulnerable chain.

Closes #172.

## Root cause

The Garmin API returns explicit `null` (not missing keys) for sub-sections the user has no data in:

| User profile | Field that's null |
|---|---|
| Pure runner (no cycling activities) | `mostRecentVO2Max.cycling` |
| Pure cyclist (#172) | `mostRecentVO2Max.generic` |
| New user / sparse history | `mostRecentTrainingStatus`, `mostRecentTrainingLoadBalance` |
| Inactive day | `acuteTrainingLoadDTO` |

`dict.get(key, default)` only returns `default` when the key is **missing** — when the value is explicitly `None`, it returns `None`, and the next `.get()` in the chain raises `AttributeError`.

## Reproducer (runner case)

Confirmed against my own Forerunner 970 data dump:

```python
status = garmin_client.get_training_status("2026-06-23")
# status["mostRecentVO2Max"]["cycling"] is None (I never cycle)

cycling_vo2_data = status.get("mostRecentVO2Max", {}).get("cycling", {})
# cycling_vo2_data is None, not {}
cycling_vo2_data.get("vo2MaxValue")
# 💥 AttributeError: 'NoneType' object has no attribute 'get'
```

This is the same root cause as #172, just a different `null` field — `or {}` coalesces both missing-key and explicit-null cases, so the patch covers every sub-section in one go.

## Fix

Two-character change applied consistently: `.get(key, {})` → `.get(key) or {}` on every chain that touches an API field with a possible explicit null. Also added an inline comment explaining the `or {}` idiom for future contributors who would otherwise default to `.get(key, {})`.

## Verification

Before patch (date with a real run, `cycling=null`):
```
Error retrieving training status data: 'NoneType' object has no attribute 'get'
```

After patch (same date, same data):
```json
{
  "training_status": 7,
  "training_status_feedback": "PRODUCTIVE_2",
  "acute_load": 318,
  "chronic_load": 219,
  "load_ratio": 1.4,
  "acwr_status": "OPTIMAL",
  "vo2_max": 52.0,
  "vo2_max_precise": 52.2,
  "monthly_load_aerobic_low": 494.2,
  "monthly_load_aerobic_high": 212.4,
  "monthly_load_anaerobic": 0.0,
  "training_balance_feedback": "AEROBIC_HIGH_SHORTAGE"
}
```

End-to-end tested by loading the patched module via `register_tools` and calling the actual tool function — not just the inner extraction logic.

## Out of scope (separate issues to follow)

While auditing I noticed two other functions reading the same nested structure that have related but distinct bugs (both wrapped in `try/except: pass` so they silently lose data rather than crash):

- `get_training_load_trend` (line 738): assigns `status_data` to the device-id map without iterating, so `status_data.get("acuteTrainingLoadDTO")` always misses. Needs device iteration + `or {}` coalescing.
- `get_vo2max_trend` (line 893): same `mostRecentVO2Max.generic` chain — works for users with running VO2max but would silently drop days for cycling-only users (#172's profile).

Happy to send follow-up PRs for those if the maintainers prefer focused PRs, or fold them in here.

## Test plan

- [x] Reproduce crash on real data (runner, `cycling=null`)
- [x] Patch produces complete curated payload
- [x] End-to-end via `register_tools` (not just unit-level)
- [ ] Reproduce #172's profile (cyclist with `generic=null`) — don't have access to that account, but the fix targets both null fields symmetrically