### PR TITLE
fix(training): repair get_training_load_trend for device-keyed status data

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -734,12 +734,25 @@ def register_tools(app):
             try:
                 data = garmin_client.get_training_status(date_str)
                 if data:
-                    status_data = (
-                        data.get("mostRecentTrainingStatus", {})
-                        .get("latestTrainingStatusData", {})
-                    )
-                    atl_dto = status_data.get("acuteTrainingLoadDTO", {})
-                    vo2_data = data.get("mostRecentVO2Max", {}).get("generic", {})
+                    # latestTrainingStatusData is a dict keyed by device ID, not
+                    # the DTO directly. Pick the primary training device when
+                    # available, fall back to the first device. Use `or {}` to
+                    # coalesce explicit nulls (Garmin returns None for sections
+                    # the user has no data in, which breaks chained `.get`).
+                    recent_status = data.get("mostRecentTrainingStatus") or {}
+                    latest_data = recent_status.get("latestTrainingStatusData") or {}
+                    status_data: Dict[str, Any] = {}
+                    for dev_data in latest_data.values():
+                        if not isinstance(dev_data, dict):
+                            continue
+                        if dev_data.get("primaryTrainingDevice"):
+                            status_data = dev_data
+                            break
+                        if not status_data:
+                            status_data = dev_data
+                    atl_dto = status_data.get("acuteTrainingLoadDTO") or {}
+                    most_recent_vo2 = data.get("mostRecentVO2Max") or {}
+                    vo2_data = most_recent_vo2.get("generic") or {}
                     entry: Dict[str, Any] = {"date": date_str}
                     atl = atl_dto.get("dailyTrainingLoadAcute")
                     ctl = atl_dto.get("dailyTrainingLoadChronic")
@@ -755,10 +768,26 @@ def register_tools(app):
                     acwr_status = atl_dto.get("acwrStatus")
                     if acwr_status:
                         entry["acwr_status"] = acwr_status
-                    ts = status_data.get("trainingStatusDTO", {})
-                    ts_label = ts.get("trainingStatusCyclingFeedbackPhrase") or ts.get("trainingStatusFeedbackPhrase")
-                    if ts_label:
-                        entry["training_status"] = ts_label
+                    acwr_pct = atl_dto.get("acwrPercent")
+                    if acwr_pct is not None:
+                        entry["acwr_percent"] = acwr_pct
+                    chronic_min = atl_dto.get("minTrainingLoadChronic")
+                    if chronic_min is not None:
+                        entry["optimal_chronic_load_min"] = round(chronic_min, 1)
+                    chronic_max = atl_dto.get("maxTrainingLoadChronic")
+                    if chronic_max is not None:
+                        entry["optimal_chronic_load_max"] = round(chronic_max, 1)
+                    # Device data now has training status fields flattened — no
+                    # longer wrapped in a trainingStatusDTO sub-object.
+                    ts_phrase = status_data.get("trainingStatusFeedbackPhrase")
+                    if ts_phrase:
+                        entry["training_status"] = ts_phrase
+                    ts_code = status_data.get("trainingStatus")
+                    if ts_code is not None:
+                        entry["training_status_code"] = ts_code
+                    fitness_trend = status_data.get("fitnessTrend")
+                    if fitness_trend is not None:
+                        entry["fitness_trend"] = fitness_trend
                     vo2 = vo2_data.get("vo2MaxValue")
                     if vo2 is not None:
                         entry["vo2_max"] = round(vo2, 1)


### PR DESCRIPTION
### Problem

`get_training_load_trend` returns `vo2_max` only — CTL, ATL, ACWR, training_status are all missing.

Root cause: `mostRecentTrainingStatus.latestTrainingStatusData` is a **dict keyed by device ID**, not the DTO directly:

```python
# actual structure
data["mostRecentTrainingStatus"]["latestTrainingStatusData"]
# == {"3620729386": {...device-specific status data...}}
```

The existing code does `.get("latestTrainingStatusData", {}).get("acuteTrainingLoadDTO", {})` which yields an empty dict every time, so every load field returns `None`.

Additionally, the device data no longer wraps training status fields in a `trainingStatusDTO` sub-object — `trainingStatus`, `trainingStatusFeedbackPhrase`, and `fitnessTrend` are now flat on the device record.

### Fix

- Iterate the device map and prefer the primary training device (fall back to the first entry), mirroring the pattern already used by `get_training_status`.
- Read the flattened status keys directly (no more `trainingStatusDTO` lookup).
- Use `or {}` throughout to coalesce explicit `None` (Garmin returns `null` for sections the user has no data in, which breaks chained `.get(key, {})`).

Also exposes `acwr_percent` and the chronic-load tunnel (`optimal_chronic_load_min`/`max`), which are useful for plotting the PMC and were already extracted by `get_training_status`.

### Related

The same device-keyed-dict pattern was flagged out-of-scope in #173 — this PR addresses it independently. The two PRs touch different functions and can be merged in any order.

### Verification

Local e2e on 2026-06-23 → 2026-06-25 now returns full `atl / ctl / tsb / acwr / acwr_status / acwr_percent / optimal_chronic_load_min / optimal_chronic_load_max / training_status / training_status_code / fitness_trend / vo2_max` per day. Unit + integration tests 385/385 pass.