### PR TITLE
fix: handle null API values in get_training_status

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -493,8 +493,11 @@ def register_tools(app):
                 return f"No training status data found for {date}."
 
             # Extract from nested structure
-            recent_status = status.get("mostRecentTrainingStatus", {})
-            latest_data = recent_status.get("latestTrainingStatusData", {})
+            # Use `(x.get(key) or {})` instead of `x.get(key, {})` so that
+            # explicit null values in the API response are treated as missing
+            # rather than causing `NoneType has no attribute 'get'` errors.
+            recent_status = (status.get("mostRecentTrainingStatus") or {})
+            latest_data = (recent_status.get("latestTrainingStatusData") or {})
 
             # Get first device data (usually the primary device)
             device_data = {}
@@ -502,15 +505,15 @@ def register_tools(app):
                 device_data = data
                 break
 
-            acwr_data = device_data.get("acuteTrainingLoadDTO", {})
+            acwr_data = (device_data.get("acuteTrainingLoadDTO") or {})
 
             # VO2 Max data
-            vo2_data = status.get("mostRecentVO2Max", {}).get("generic", {})
-            cycling_vo2_data = status.get("mostRecentVO2Max", {}).get("cycling", {})
+            vo2_data = (status.get("mostRecentVO2Max") or {}).get("generic") or {}
+            cycling_vo2_data = (status.get("mostRecentVO2Max") or {}).get("cycling") or {}
 
             # Training load balance
-            load_balance = status.get("mostRecentTrainingLoadBalance", {})
-            load_map = load_balance.get("metricsTrainingLoadBalanceDTOMap", {})
+            load_balance = (status.get("mostRecentTrainingLoadBalance") or {})
+            load_map = (load_balance.get("metricsTrainingLoadBalanceDTOMap") or {})
             load_data = {}
             for device_id, data in load_map.items():
                 load_data = data
@@ -735,11 +738,11 @@ def register_tools(app):
                 data = garmin_client.get_training_status(date_str)
                 if data:
                     status_data = (
-                        data.get("mostRecentTrainingStatus", {})
-                        .get("latestTrainingStatusData", {})
+                        (data.get("mostRecentTrainingStatus") or {})
+                        .get("latestTrainingStatusData") or {}
                     )
-                    atl_dto = status_data.get("acuteTrainingLoadDTO", {})
-                    vo2_data = data.get("mostRecentVO2Max", {}).get("generic", {})
+                    atl_dto = (status_data.get("acuteTrainingLoadDTO") or {})
+                    vo2_data = (data.get("mostRecentVO2Max") or {}).get("generic") or {}
                     entry: Dict[str, Any] = {"date": date_str}
                     atl = atl_dto.get("dailyTrainingLoadAcute")
                     ctl = atl_dto.get("dailyTrainingLoadChronic")
@@ -890,7 +893,7 @@ def register_tools(app):
             try:
                 data = garmin_client.get_training_status(date_str)
                 if data:
-                    vo2_data = data.get("mostRecentVO2Max", {}).get("generic", {})
+                    vo2_data = (data.get("mostRecentVO2Max") or {}).get("generic") or {}
                     vo2 = vo2_data.get("vo2MaxValue")
                     if vo2 is not None:
                         vo2_rounded = round(vo2, 1)


### PR DESCRIPTION
## Problem
Several fields returned by Garmin's training status API can be
explicitly `null` — for example:
- `mostRecentVO2Max` for users without VO2max tracking data
- `mostRecentTrainingLoadBalance` for users without heat/altitude
  training history
Using `x.get(key, {})` does **not** guard against this. The default
`{}` only triggers when the key is **absent**. When the key is present
with a `null` value, `.get(key, {})` returns `None`, and the
subsequent `.get(...)` call raises: 

`'NoneType' object has no attribute 'get'`


This makes `get_training_status` (and tools that call it internally:
`get_training_load_trend`, `get_vo2max_trend`) completely unusable for
affected users.

Closes #172

## Fix

Replace all affected chained dict lookups with `(x.get(key) or {})`.
The `or {}` handles both cases — key absent and key present with
`null` — so the subsequent `.get(...)` always receives a dict.

## Affected locations

8 occurrences across 3 functions in `training.py`:
- `get_training_status` — 6 occurrences
- `get_training_load_trend` — 2 occurrences
- `get_vo2max_trend` (internal loop) — 1 occurrence

## Testing

Verified on a Garmin account where `mostRecentVO2Max` was previously
returned as `null` — all three tools now return data correctly.