### PR TITLE
Fix Garmin Connect China authentication

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -11,6 +11,10 @@ from mcp.server.fastmcp import FastMCP
 
 from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError, GarminConnectTooManyRequestsError
 
+from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+
+apply_garmin_cn_auth_patch()
+
 # Import all modules
 from garmin_mcp import activity_management
 from garmin_mcp import health_wellness

--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -13,6 +13,7 @@ import base64
 import requests
 from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError, GarminConnectTooManyRequestsError
 
+from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
 from garmin_mcp.token_utils import (
     get_token_path,
     get_token_base64_path,
@@ -20,6 +21,8 @@ from garmin_mcp.token_utils import (
     validate_tokens,
     get_token_info,
 )
+
+apply_garmin_cn_auth_patch()
 
 
 def _secure_token_dir(path: str) -> None:

--- a/src/garmin_mcp/garmin_cn_auth_patch.py
+++ b/src/garmin_mcp/garmin_cn_auth_patch.py
@@ -1,0 +1,100 @@
+"""Compatibility fixes for Garmin Connect China authentication.
+
+The garminconnect 0.3.2 client is domain-aware for most China endpoints, but
+the DI OAuth token exchange still uses a global module constant. It also tries
+the mobile login flow first, whose service URL is not domain-aware. Until the
+upstream client handles this natively, patch the client class at runtime.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+
+
+_SUPPORTED_GARMINCONNECT_VERSION = "0.3.2"
+
+
+def apply_garmin_cn_auth_patch() -> None:
+    """Patch garminconnect's client for Garmin Connect China auth flows."""
+
+    from garminconnect import client as client_mod
+
+    try:
+        installed_version = importlib.metadata.version("garminconnect")
+    except importlib.metadata.PackageNotFoundError:
+        return
+    if installed_version != _SUPPORTED_GARMINCONNECT_VERSION:
+        return
+
+    client_cls = client_mod.Client
+    if getattr(client_cls, "_garmin_mcp_cn_auth_patch_applied", False):
+        return
+
+    original_http_post = client_cls._http_post
+    original_login = client_cls.login
+
+    def patched_http_post(self, url, **kwargs):
+        if (
+            getattr(self, "domain", None) == "garmin.cn"
+            and url == client_mod.DI_TOKEN_URL
+        ):
+            url = "https://diauth.garmin.cn/di-oauth2-service/oauth/token"
+        return original_http_post(self, url, **kwargs)
+
+    def patched_login(self, email, password, prompt_mfa=None, return_on_mfa=False):
+        if getattr(self, "domain", None) != "garmin.cn":
+            return original_login(self, email, password, prompt_mfa, return_on_mfa)
+
+        strategies = [
+            ("portal+cffi", lambda: self._portal_web_login_cffi(email, password)),
+            (
+                "portal+requests",
+                lambda: self._portal_web_login_requests(email, password),
+            ),
+            ("widget+cffi", lambda: self._widget_web_login(email, password)),
+            ("mobile+cffi", lambda: self._mobile_login_cffi(email, password)),
+            ("mobile+requests", lambda: self._mobile_login_requests(email, password)),
+        ]
+
+        last_err = None
+        rate_limited_count = 0
+
+        for name, run in strategies:
+            try:
+                client_mod._LOGGER.debug("Trying login strategy: %s", name)
+                run()
+                return None, None
+            except client_mod.GarminConnectAuthenticationError:
+                raise
+            except client_mod._MFARequired:
+                if return_on_mfa:
+                    return "needs_mfa", None
+                if prompt_mfa:
+                    mfa_code = prompt_mfa()
+                    self._complete_mfa(mfa_code)
+                    return None, None
+                raise client_mod.GarminConnectAuthenticationError(
+                    "MFA Required but no prompt_mfa mechanism supplied"
+                )
+            except client_mod.GarminConnectTooManyRequestsError as exc:
+                client_mod._LOGGER.warning("%s returned 429: %s", name, exc)
+                rate_limited_count += 1
+                last_err = exc
+                continue
+            except Exception as exc:
+                client_mod._LOGGER.warning("%s failed: %s", name, exc)
+                last_err = exc
+                continue
+
+        if rate_limited_count == len(strategies):
+            raise client_mod.GarminConnectTooManyRequestsError(
+                "All login strategies rate limited (429). "
+                "Try again later or check your IP/network."
+            )
+        raise client_mod.GarminConnectConnectionError(
+            f"All login strategies exhausted: {last_err}"
+        )
+
+    client_cls._http_post = patched_http_post
+    client_cls.login = patched_login
+    client_cls._garmin_mcp_cn_auth_patch_applied = True

--- a/src/garmin_mcp/token_utils.py
+++ b/src/garmin_mcp/token_utils.py
@@ -6,6 +6,10 @@ from typing import Tuple
 
 from garminconnect import Garmin, GarminConnectConnectionError
 
+from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+
+apply_garmin_cn_auth_patch()
+
 
 def get_token_path() -> str:
     """Get token path from environment or default.

--- a/tests/unit/test_garmin_cn_auth_patch.py
+++ b/tests/unit/test_garmin_cn_auth_patch.py
@@ -1,0 +1,156 @@
+"""Tests for Garmin Connect China authentication compatibility."""
+
+import importlib
+import importlib.metadata
+
+import pytest
+
+
+def _reload_client_module():
+    from garminconnect import client as client_mod
+
+    return importlib.reload(client_mod)
+
+
+def test_cn_login_prefers_portal_flow_before_mobile_flow(monkeypatch):
+    _reload_client_module()
+    from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+    from garminconnect.client import Client
+
+    apply_garmin_cn_auth_patch()
+
+    calls = []
+    client = Client(domain="garmin.cn")
+
+    def portal_success(email, password):
+        calls.append("portal")
+
+    def mobile_success(email, password):
+        calls.append("mobile")
+
+    monkeypatch.setattr(client, "_portal_web_login_cffi", portal_success)
+    monkeypatch.setattr(client, "_mobile_login_cffi", mobile_success)
+
+    client.login("user@example.com", "secret")
+
+    assert calls == ["portal"]
+
+
+def test_cn_login_tries_widget_before_mobile_when_portal_fails(monkeypatch):
+    _reload_client_module()
+    from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+    from garminconnect.client import Client
+
+    apply_garmin_cn_auth_patch()
+
+    calls = []
+    client = Client(domain="garmin.cn")
+
+    def fail(name):
+        def inner(email, password):
+            calls.append(name)
+            raise RuntimeError(f"{name} failed")
+
+        return inner
+
+    def widget_success(email, password):
+        calls.append("widget")
+
+    monkeypatch.setattr(client, "_portal_web_login_cffi", fail("portal+cffi"))
+    monkeypatch.setattr(client, "_portal_web_login_requests", fail("portal+requests"))
+    monkeypatch.setattr(client, "_widget_web_login", widget_success)
+    monkeypatch.setattr(client, "_mobile_login_cffi", fail("mobile+cffi"))
+    monkeypatch.setattr(client, "_mobile_login_requests", fail("mobile+requests"))
+
+    client.login("user@example.com", "secret")
+
+    assert calls == ["portal+cffi", "portal+requests", "widget"]
+
+
+def test_cn_token_exchange_uses_cn_diauth_endpoint(monkeypatch):
+    _reload_client_module()
+    from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+    from garminconnect import GarminConnectAuthenticationError
+    from garminconnect import client as client_mod
+    from garminconnect.client import Client
+
+    apply_garmin_cn_auth_patch()
+
+    urls = []
+    client = Client(domain="garmin.cn")
+    monkeypatch.setattr(client_mod, "HAS_CFFI", False)
+
+    class Response:
+        status_code = 400
+        ok = False
+        text = "bad request"
+
+    def fake_post(url, **kwargs):
+        assert (
+            client_mod.DI_TOKEN_URL
+            == "https://diauth.garmin.com/di-oauth2-service/oauth/token"
+        )
+        urls.append(url)
+        return Response()
+
+    monkeypatch.setattr(client_mod.requests, "post", fake_post)
+
+    with pytest.raises(GarminConnectAuthenticationError):
+        client._exchange_service_ticket(
+            "ticket", service_url=client._portal_service_url
+        )
+
+    assert urls
+    assert set(urls) == {"https://diauth.garmin.cn/di-oauth2-service/oauth/token"}
+
+
+def test_non_cn_token_exchange_keeps_default_diauth_endpoint(monkeypatch):
+    _reload_client_module()
+    from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+    from garminconnect import GarminConnectAuthenticationError
+    from garminconnect import client as client_mod
+    from garminconnect.client import Client
+
+    apply_garmin_cn_auth_patch()
+
+    urls = []
+    client = Client(domain="garmin.com")
+    monkeypatch.setattr(client_mod, "HAS_CFFI", False)
+
+    class Response:
+        status_code = 400
+        ok = False
+        text = "bad request"
+
+    def fake_post(url, **kwargs):
+        urls.append(url)
+        return Response()
+
+    monkeypatch.setattr(client_mod.requests, "post", fake_post)
+
+    with pytest.raises(GarminConnectAuthenticationError):
+        client._exchange_service_ticket("ticket")
+
+    assert urls
+    assert set(urls) == {"https://diauth.garmin.com/di-oauth2-service/oauth/token"}
+
+
+def test_patch_noops_for_unsupported_garminconnect_version(monkeypatch):
+    client_mod = _reload_client_module()
+    from garmin_mcp.garmin_cn_auth_patch import apply_garmin_cn_auth_patch
+
+    original_login = client_mod.Client.login
+    original_http_post = client_mod.Client._http_post
+    original_version = importlib.metadata.version
+
+    def fake_version(name):
+        if name == "garminconnect":
+            return "9.9.9"
+        return original_version(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", fake_version)
+
+    apply_garmin_cn_auth_patch()
+
+    assert client_mod.Client.login is original_login
+    assert client_mod.Client._http_post is original_http_post


### PR DESCRIPTION
# Fix Garmin Connect China authentication

## Summary

Fix Garmin Connect China pre-authentication by applying a small compatibility
patch around `garminconnect==0.3.2`.

The upstream client is already domain-aware for many Garmin China URLs, but the
auth flow still has two China-specific issues:

- login tries the mobile flow first, whose service URL is not domain-aware
- DI OAuth token exchange uses the global `diauth.garmin.com` endpoint instead
  of `diauth.garmin.cn`

This patch applies the compatibility fix before the MCP server, auth CLI, or
token validation instantiate `Garmin`.

## Changes

- Add `garmin_cn_auth_patch.apply_garmin_cn_auth_patch()`
- Guard the compatibility patch so it only applies to `garminconnect==0.3.2`
- For `garmin.cn`, prefer portal login, then widget login, before mobile login
- For `garmin.cn`, rewrite DI OAuth POSTs to
  `https://diauth.garmin.cn/di-oauth2-service/oauth/token` without mutating the
  upstream module's global `DI_TOKEN_URL`
- Apply the patch in the server entrypoint, auth CLI, and token utilities
- Add unit tests covering the China login strategy order and DI endpoint

## Validation

- `python -m pytest tests/unit/test_garmin_cn_auth_patch.py`
- `python -m pytest tests/unit/test_auth_cli.py tests/unit/test_token_utils.py`
- `python -m pytest tests/unit` (`86 passed`)
- Live read-only verification against Garmin Connect China using saved OAuth
  tokens:
  - token login succeeded
  - `get_full_name()` returned the expected profile
  - `get_stats("2026-06-30")` returned daily metrics
