### PR TITLE
Harden HTTP transport bind and token file permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -397,7 +397,7 @@ File-based secrets are useful in certain environments, such as inside a Docker c
 By default the server communicates over **stdio**, which is what Claude Desktop, the MCP Inspector, and most local clients expect. To serve over **HTTP** instead (e.g. when running in a container or Kubernetes), set the transport via environment variables:
 
 - `GARMIN_MCP_TRANSPORT`: `stdio` (default), `streamable-http`, or `sse`
-- `GARMIN_MCP_HOST`: bind address for HTTP transports (default `0.0.0.0`)
+- `GARMIN_MCP_HOST`: bind address for HTTP transports (default `127.0.0.1`; set to `0.0.0.0` only when the endpoint is fronted by an authenticating reverse proxy)
 - `GARMIN_MCP_PORT`: bind port for HTTP transports (default `8000`)
 
 ```bash

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -12,6 +12,7 @@ from mcp.server.fastmcp import FastMCP
 from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnectConnectionError, GarminConnectTooManyRequestsError
 
 # Import all modules
+from garmin_mcp import token_utils
 from garmin_mcp import activity_management
 from garmin_mcp import health_wellness
 from garmin_mcp import user_profile
@@ -156,7 +157,10 @@ def _parse_transport_config() -> tuple[str, str, int]:
             f"Invalid GARMIN_MCP_TRANSPORT {transport!r}; "
             f"expected one of {', '.join(_VALID_TRANSPORTS)}"
         )
-    http_host = os.getenv("GARMIN_MCP_HOST", "0.0.0.0")
+    # Bind to loopback by default: the HTTP transport performs no authentication,
+    # so a 0.0.0.0 default would expose full read/write access to the user's
+    # Garmin account to the whole network. Opt in explicitly with GARMIN_MCP_HOST.
+    http_host = os.getenv("GARMIN_MCP_HOST", "127.0.0.1")
     http_port = int(os.getenv("GARMIN_MCP_PORT", "8000"))
     return transport, http_host, http_port
 
@@ -268,6 +272,10 @@ def init_api(email, password):
                 garmin.resume_login(result2, mfa_code)
             # Save Oauth1 and Oauth2 token files to directory for next login
             garmin.client.dump(tokenstore)
+            # Restrict the freshly written tokens to owner-only. These are
+            # ~6-month bearer credentials; the default umask would otherwise
+            # leave them world-readable on multi-user hosts.
+            token_utils.secure_token_dir(tokenstore)
             print(
                 f"Oauth tokens stored in '{tokenstore}' directory for future use. (first method)\n",
                 file=sys.stderr,
@@ -281,6 +289,7 @@ def init_api(email, password):
             dir_path = os.path.expanduser(tokenstore_base64)
             with open(dir_path, "w") as token_file:
                 token_file.write(token_base64)
+            os.chmod(dir_path, 0o600)
             print(
                 f"Oauth tokens encoded as base64 string and saved to '{dir_path}' file for future use. (second method)\n",
                 file=sys.stderr,
@@ -347,7 +356,7 @@ def main():
     # By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
     # Set GARMIN_MCP_TRANSPORT=streamable-http (or sse) to serve over HTTP.
     #   GARMIN_MCP_TRANSPORT - stdio (default) | streamable-http | sse
-    #   GARMIN_MCP_HOST      - bind address for HTTP transports (default 0.0.0.0)
+    #   GARMIN_MCP_HOST      - bind address for HTTP transports (default 127.0.0.1)
     #   GARMIN_MCP_PORT      - bind port for HTTP transports (default 8000)
     try:
         transport, http_host, http_port = _parse_transport_config()

--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -19,15 +19,8 @@ from garmin_mcp.token_utils import (
     token_exists,
     validate_tokens,
     get_token_info,
+    secure_token_dir as _secure_token_dir,
 )
-
-
-def _secure_token_dir(path: str) -> None:
-    """Set owner-only permissions on a token directory and all files inside it."""
-    os.chmod(path, 0o700)
-    for entry in os.scandir(path):
-        if entry.is_file():
-            os.chmod(entry.path, 0o600)
 
 
 def get_mfa() -> str:

--- a/src/garmin_mcp/token_utils.py
+++ b/src/garmin_mcp/token_utils.py
@@ -7,6 +7,25 @@ from typing import Tuple
 from garminconnect import Garmin, GarminConnectConnectionError
 
 
+def secure_token_dir(path: str) -> None:
+    """Set owner-only permissions on a token directory and the files inside it.
+
+    OAuth tokens are ~6-month bearer credentials to the full Garmin account, so
+    they must not be left world-readable on multi-user hosts. Safe to call on a
+    path that is a single file rather than a directory.
+    """
+    expanded = os.path.expanduser(path)
+    if not os.path.exists(expanded):
+        return
+    if os.path.isdir(expanded):
+        os.chmod(expanded, 0o700)
+        for entry in os.scandir(expanded):
+            if entry.is_file():
+                os.chmod(entry.path, 0o600)
+    else:
+        os.chmod(expanded, 0o600)
+
+
 def get_token_path() -> str:
     """Get token path from environment or default.
 

--- a/tests/unit/test_transport_config.py
+++ b/tests/unit/test_transport_config.py
@@ -17,7 +17,7 @@ class TestParseTransportConfig:
             os.environ.pop("GARMIN_MCP_PORT", None)
             transport, host, port = _parse_transport_config()
         assert transport == "stdio"
-        assert host == "0.0.0.0"
+        assert host == "127.0.0.1"
         assert port == 8000
 
     @pytest.mark.parametrize("value", list(_VALID_TRANSPORTS))


### PR DESCRIPTION
## Summary

Two local-exposure hardening fixes for the HTTP transport and OAuth token storage. No behavior change for existing stdio users; all 81 unit tests pass.

## 1. HTTP transport no longer binds to all interfaces by default

`GARMIN_MCP_HOST` defaulted to `0.0.0.0`, and the HTTP transport performs no authentication of its own. Enabling an HTTP transport (e.g. the quickstart `GARMIN_MCP_TRANSPORT=streamable-http garmin-mcp`) therefore exposed **full read *and write* access to the user's Garmin account** — health data, GPS history, plus mutating tools (upload/delete workouts and courses, delete food logs) — to anything that could route to the host.

This changes the default to `127.0.0.1`. External binding is now an explicit opt-in: set `GARMIN_MCP_HOST=0.0.0.0` when the endpoint is fronted by an authenticating reverse proxy (as the README already recommends). Containers/k8s deployments that need external reachability set the env var explicitly, so the secure posture is the default and the exposed posture is deliberate.

## 2. OAuth token files hardened in the server auto-auth path

`auth_cli.py` already set `0700`/`0600` on written tokens, but the server's own fallback path in `init_api()` (`__init__.py`) dumped the token directory and wrote the base64 token file with **no `chmod`**. Under a typical `022` umask these land world-readable — and they are ~6-month bearer credentials to the whole account, so any other local user on a multi-user host could read and reuse them.

This adds a shared `secure_token_dir()` helper in `token_utils.py`, applies it right after `garmin.client.dump()` in the server path, and adds `chmod 0600` on the base64 file. `auth_cli.py`'s private helper now aliases the shared one so both auth paths harden identically.

## Changes
- `src/garmin_mcp/__init__.py` — default host `127.0.0.1`; secure tokens in `init_api()`
- `src/garmin_mcp/token_utils.py` — new shared `secure_token_dir()` helper
- `src/garmin_mcp/auth_cli.py` — reuse the shared helper (DRY)
- `README.md` + inline docs — document the new default
- `tests/unit/test_transport_config.py` — updated default-host assertion

## Testing
`uv run pytest tests/unit -q` → **81 passed**.

## Also noticed (not in this PR — happy to follow up)
- The base64 token file is a second full copy of the credentials on disk, but the code that reads it back is commented out (`__init__.py`), so it's an unused secondary secret store worth removing.
- `upload_course(gpx_path)` reads any local `.gpx`-suffixed file and POSTs it to Garmin; since MCP tool args are model-controlled this is a minor exfil surface worth a note.
- `.github/workflows/security.yml` is named "Security Checks" but runs no actual vulnerability scan (there's a `# Add pip-audit or safety scan here` placeholder). Wiring in `pip-audit` would make it do what its name implies.
