### PR TITLE
feat: compute avg/max power per lap for running activities

### DIFF
--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -933,6 +933,52 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
 
     # HRV (time-domain) — always include summary if R-R data exists.
     # Raw R-R array only included when include_records=True (can be large).
+    # Per-lap average power for activities whose lap message has no native
+    # avg_power field (e.g. running with a wrist / Connect IQ power source).
+    # Reuse the same time-window bucketing as HRV, averaging record power_w.
+    if records and any("avg_power_w" not in lap for lap in laps):
+        import datetime as _dt2
+
+        def _parse_iso_pw(s):
+            if not s:
+                return None
+            try:
+                return _dt2.datetime.fromisoformat(str(s).replace("Z", "+00:00"))
+            except (ValueError, TypeError):
+                return None
+
+        rec_pw = []
+        for r in records:
+            pw = r.get("power_w")
+            if pw is None:
+                continue
+            ts_dt = _parse_iso_pw(r.get("timestamp"))
+            if ts_dt is not None:
+                rec_pw.append((ts_dt, float(pw)))
+
+        if rec_pw:
+            for lap in laps:
+                if "avg_power_w" in lap:
+                    continue
+                lap_start = _parse_iso_pw(lap.get("start_time"))
+                elapsed = lap.get("total_elapsed_time_s")
+                if lap_start is None or not elapsed:
+                    continue
+                lap_end = lap_start + _dt2.timedelta(seconds=float(elapsed))
+                vals = []
+                for ts_dt, pw in rec_pw:
+                    a, b, t = lap_start, lap_end, ts_dt
+                    if a.tzinfo and not t.tzinfo:
+                        t = t.replace(tzinfo=a.tzinfo)
+                    elif t.tzinfo and not a.tzinfo:
+                        a = a.replace(tzinfo=t.tzinfo)
+                        b = b.replace(tzinfo=t.tzinfo)
+                    if a <= t < b:
+                        vals.append(pw)
+                if vals:
+                    lap["avg_power_w"] = round(sum(vals) / len(vals))
+                    lap["max_power_w"] = round(max(vals))
+
     # Also compute per-lap HRV by bucketing R-R intervals by timestamp.
     if rr_pairs:
         all_rr = [rr for (_, rr) in rr_pairs]


### PR DESCRIPTION
## Problem

`get_activity_fit_data` computes `avg_power_w` **per lap** only when the FIT `lap` message carries a native `avg_power` field. For running activities where power comes from a wrist-based estimate or a Connect IQ datafield (e.g. Fenix 6 Pro), the `lap` message has **no native `avg_power`**, so `_get_field(message, "avg_power")` returns `None` and the key is dropped.

Result: per-lap power is missing for running, even though the per-second `record` messages **do** contain valid power values (the session-level power_duration_curve and temperature_stats are computed correctly from them).

## Fix

Reuse the existing per-lap time-window bucketing (the one already used for per-lap HRV) to average `record.power_w` into `avg_power_w` / `max_power_w` — **only for laps that don't already have a native `avg_power_w`**, so cycling behaviour with a dedicated power meter is left untouched.

The logic mirrors the existing HRV bucketing: for each lap, take records whose timestamp falls in `[lap_start, lap_start + total_elapsed_time_s)` and average their power.

## Testing

Verified on real running sessions (Fenix 6 Pro, Connect IQ power source): per-lap `avg_power_w` now matches values independently extracted from the same FIT with `fitparse`, bit-for-bit. Cycling activities with native lap power are unaffected (guarded by `"avg_power_w" not in lap`).

## Notes

Patch drafted with AI assistance and validated by me against my own activity data.