### PR TITLE
Fix get_training_load_trend reading acuteTrainingLoadDTO from wrong dict level

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -734,11 +734,15 @@ def register_tools(app):
             try:
                 data = garmin_client.get_training_status(date_str)
                 if data:
-                    status_data = (
+                    latest_data = (
                         data.get("mostRecentTrainingStatus", {})
                         .get("latestTrainingStatusData", {})
                     )
-                    atl_dto = status_data.get("acuteTrainingLoadDTO", {})
+                    device_data = {}
+                    for device_id, dev in latest_data.items():
+                        device_data = dev
+                        break
+                    atl_dto = device_data.get("acuteTrainingLoadDTO", {})
                     vo2_data = data.get("mostRecentVO2Max", {}).get("generic", {})
                     entry: Dict[str, Any] = {"date": date_str}
                     atl = atl_dto.get("dailyTrainingLoadAcute")
@@ -755,8 +759,7 @@ def register_tools(app):
                     acwr_status = atl_dto.get("acwrStatus")
                     if acwr_status:
                         entry["acwr_status"] = acwr_status
-                    ts = status_data.get("trainingStatusDTO", {})
-                    ts_label = ts.get("trainingStatusCyclingFeedbackPhrase") or ts.get("trainingStatusFeedbackPhrase")
+                    ts_label = device_data.get("trainingStatusCyclingFeedbackPhrase") or device_data.get("trainingStatusFeedbackPhrase")
                     if ts_label:
                         entry["training_status"] = ts_label
                     vo2 = vo2_data.get("vo2MaxValue")


### PR DESCRIPTION
## Problem
`get_training_load_trend` always returned entries with only `date` and
`vo2_max` — `atl`, `ctl`, `tsb`, and `acwr` were silently missing for
every date, regardless of the requested range.

## Root cause
`latestTrainingStatusData` in the Garmin API response is keyed by
device ID (a dict of `{device_id: {...actual fields...}}`), not a flat
dict containing `acuteTrainingLoadDTO` directly. The working
`get_training_status` function already handles this correctly by
iterating to the first device's data before reading
`acuteTrainingLoadDTO`. `get_training_load_trend` skipped that step
and read `acuteTrainingLoadDTO` directly off the outer, device-keyed
dict, which always returned `{}` — so `atl`/`ctl`/`acwr` were always
`None` and never added to the entry. The same issue applied to reading
the training status feedback phrase (`trainingStatusDTO`, which
doesn't exist at that level either).

## Fix
Mirror the device-data extraction already used in
`get_training_status`: iterate `latestTrainingStatusData.items()` to
get the first device's data, then read `acuteTrainingLoadDTO` and the
status feedback phrases from that.

## Testing
- All 304 existing integration tests still pass (none of them covered
  this function previously — no test regression, but also no existing
  coverage of the bug).
- Manually verified against a live Garmin Connect account: before the
  fix, every entry in the trend only contained `date` + `vo2_max`;
  after the fix, entries correctly include `atl`, `ctl`, `tsb`, `acwr`,
  `acwr_status`, and `training_status`, matching the values independently
  confirmed via `get_training_status` for several spot-checked dates.

Happy to add a regression test for this function if useful — let me
know your preferred structure (looks like `tests/e2e/` needs real
credentials; a mocked integration test in `tests/integration/` might
be the better fit).