### PR TITLE
Expose strokeType/equipmentType/drillType in curated swim workout steps

### DIFF
--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -318,7 +318,19 @@ def _curate_workout_step(step: dict) -> dict:
         zone_field='secondaryZoneNumber',
         prefix='secondary_',
     )
-
+# Swim stroke / equipment / drill info (Garmin returns these as nested dicts;
+    # previously dropped entirely -- patched after confirming via a raw
+    # connectapi pull that strokeType/equipmentType/drillType are real, reliable
+    # fields Garmin provides for swim steps, unrelated to secondaryTargetValueOne).
+    stroke_type = step.get('strokeType')
+    if isinstance(stroke_type, dict) and stroke_type.get('strokeTypeKey'):
+        curated['stroke_type'] = stroke_type.get('strokeTypeKey')
+    equipment_type = step.get('equipmentType')
+    if isinstance(equipment_type, dict) and equipment_type.get('equipmentTypeKey'):
+        curated['equipment_type'] = equipment_type.get('equipmentTypeKey')
+    drill_type = step.get('drillType')
+    if isinstance(drill_type, dict) and drill_type.get('drillTypeKey'):
+        curated['drill_type'] = drill_type.get('drillTypeKey')
     # Strength training exercise info
     if step.get('category'):
         curated['category'] = step.get('category')


### PR DESCRIPTION
_curate_workout_step in workouts.py extracts targetType/secondaryTargetType generically for all sports, but never reads strokeType, equipmentType, or drillType -- so get_workout_by_id silently drops stroke and equipment data for every swim workout. Confirmed via a raw connectapi pull against workout-service/fbt-adaptive/{uuid} that Garmin's backend returns these as clean, reliable nested dicts (e.g. {"strokeTypeKey": "free"}, {"equipmentTypeKey": "pull_buoy"}), fully independent of the ambiguous secondaryTargetValueOne field. This patch surfaces them the same way category/exerciseName are already surfaced for strength workouts. No behavior change for non-swim sports (fields are simply absent/null there).