### PR TITLE
Add remote Git Docker builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -634,6 +634,29 @@ docker compose up -d
 docker compose logs -f garmin-mcp
 ```
 
+By default, Compose builds from the current local checkout, so local changes are
+included. To deploy directly from the public GitHub repository instead, add the
+remote build context to `.env`:
+
+```dotenv
+GARMIN_MCP_BUILD_CONTEXT=https://github.com/Taxuspt/garmin_mcp.git#main
+```
+
+Then build and start the container:
+
+```bash
+docker compose up -d --build
+```
+
+Running the same command later fetches the current `main` branch and rebuilds
+the image locally. The public repository does not require GitHub credentials.
+To pin a specific version, replace `#main` with a release tag or commit SHA,
+for example `#v1.2.3` or `#0123456789abcdef`.
+
+Only the source used for the image is fetched remotely. If a future release
+changes `docker-compose.yml`, update your local copy of that file separately.
+Leave `GARMIN_MCP_BUILD_CONTEXT` unset to keep using the local checkout.
+
 #### Using Docker Directly
 
 ```bash

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   garmin-mcp:
     build:
-      context: .
+      context: ${GARMIN_MCP_BUILD_CONTEXT:-.}
       dockerfile: Dockerfile
     container_name: garmin-mcp-server
 


### PR DESCRIPTION
## Summary

- make the Docker Compose build context configurable with `GARMIN_MCP_BUILD_CONTEXT`
- keep local checkout builds as the default
- document public GitHub builds, explicit updates, version pinning, and the limitation around future Compose-file changes

## Why

Deployments can now rebuild directly from the public upstream repository without maintaining a synchronized source checkout, owning a container registry, or supplying GitHub credentials.

## Validation

- `docker compose config` resolves the default context to the local checkout
- `docker compose config` preserves `https://github.com/Taxuspt/garmin_mcp.git#main` when overridden
- remote Compose build fetched public upstream `main` anonymously and completed successfully
- resulting image imports the `garmin_mcp:main` entry point
- default local Compose build completed successfully
- `git diff --check`
