### PR TITLE
fix: encode cycling watt ranges as 3-second power targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,29 @@ Use either `zoneNumber` or `targetValueOne` / `targetValueTwo` on a target, not
 both. Garmin treats the named zone as authoritative and silently discards a
 coexisting custom range, so the upload tools reject that ambiguous shape.
 
+For cycling power, Garmin uses target type ID `2` with key `power.zone` for
+both named FTP zones and custom watt ranges. The presence of `zoneNumber`
+selects a named zone; concrete watts use `targetValueOne` / `targetValueTwo`
+and omit `zoneNumber`:
+
+```json
+{
+  "targetType": {
+    "workoutTargetTypeId": 2,
+    "workoutTargetTypeKey": "power.zone"
+  },
+  "targetValueOne": 150,
+  "targetValueTwo": 160
+}
+```
+
+Do not use target type ID `6` or key `power.between` for cycling power. Garmin
+treats ID `6` as `pace.zone`; the downloaded FIT workout becomes a speed/pace
+target and the device displays distance-per-time units instead of watts.
+With ID `2` and custom watt bounds, the downloaded FIT workout uses the
+`power_3s` target. `power.lap` is a distinct lap-average target, not an
+equivalent encoding for the same workout guidance.
+
 ## One-click Install (Claude Desktop)
 
 The easiest way to add this server to Claude Desktop is via the `.dxt` Desktop Extension file — no JSON editing required.

--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -260,17 +260,17 @@ WORKOUT_STRUCTURE_REFERENCE = {
     },
     "targetType_values": {
         "1": {"workoutTargetTypeKey": "no.target", "description": "No specific target"},
-        "2": {"workoutTargetTypeKey": "power.zone", "description": "Cycling power zone 1-7 (use zoneNumber; based on FTP %). Do NOT use for absolute watt targets."},
+        "2": {"workoutTargetTypeKey": "power.zone", "description": "Cycling power target: use zoneNumber 1-7 for an FTP zone, or targetValueOne/targetValueTwo for an absolute watt range (omit zoneNumber)."},
         "4": {"workoutTargetTypeKey": "heart.rate.zone", "description": "Heart rate zone (use zoneNumber 1-5 for named zones, or targetValueOne/targetValueTwo for custom bpm range)"},
-        "6 (running/swim)": {
+        "6": {
             "workoutTargetTypeKey": "pace.zone",
             "description": (
-                "Pace zone for running or swimming (use zoneNumber, or "
+                "Pace/speed target (use zoneNumber, or "
                 "step-level targetValueOne/targetValueTwo in m/s for a "
-                "custom range)"
+                "custom range). Not cycling power; using ID 6 for watts "
+                "makes Garmin devices display a speed target."
             ),
-        },
-        "6 (cycling)": {"workoutTargetTypeKey": "power.between", "description": "Cycling absolute watt range (use targetValueOne=low_watts, targetValueTwo=high_watts). Use this instead of power.zone when targeting specific watts, NOT zone numbers."}
+        }
     },
     "sportType_values": {
         "1": {"sportTypeKey": "running"},

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -2,6 +2,7 @@
 Workout-related functions for Garmin Connect MCP Server
 """
 import json
+import math
 import re
 import datetime
 from typing import Any, Dict, List, Optional, Union
@@ -34,17 +35,34 @@ END_CONDITION_TYPE_KEYS = {
     for condition_key, condition_id in END_CONDITION_TYPE_IDS.items()
 }
 
-# Verified from Garmin-created workouts and live upload/fetch probes. Unknown
+# Verified from Garmin-created workouts and live upload/fetch/FIT probes. Unknown
 # target type IDs are allowed so we do not block valid Garmin targets that are
 # not in this partial mapping yet.
+#
+# Cycling power uses the same target type for both named FTP zones and absolute
+# watt ranges.  The payload shape selects the mode:
+#   - zoneNumber -> named power zone
+#   - targetValueOne/targetValueTwo -> custom watt range
+#
+# ID 6 is pace.zone. Garmin treats the numeric ID as authoritative and rewrites
+# an attempted {id: 6, key: "power.between"} target to pace.zone; the resulting
+# FIT workout is a speed/pace target instead of a power target.
+#
+# ID 2 with custom watt bounds exports as current/3-second power guidance.
+# ID 9 / power.lap is a distinct lap-average target and is intentionally not
+# substituted for that behavior here.
 KNOWN_TARGET_TYPE_IDS = {
     1: frozenset(["no.target"]),
     2: frozenset(["power.zone"]),
     4: frozenset(["heart.rate.zone"]),
-    # ID 6 is sport-context-dependent:
-    #   - running / swimming: "pace.zone"
-    #   - cycling: "power.between" (absolute watt range, uses targetValueOne/targetValueTwo)
-    6: frozenset(["pace.zone", "power.between"]),
+    6: frozenset(["pace.zone"]),
+}
+
+REJECTED_TARGET_TYPE_KEYS = {
+    "power.between": (
+        "use workoutTargetTypeId 2 / 'power.zone' with step-level "
+        "targetValueOne/targetValueTwo and no zoneNumber for absolute watts"
+    ),
 }
 
 # Reverse map: workoutTargetTypeKey -> workoutTargetTypeId (each key maps to exactly one ID).
@@ -287,6 +305,13 @@ def _validate_target_type_block(step: dict, path: str, target_field: str) -> Non
         target_key = target_type.get('workoutTargetTypeKey')
         target_id = target_type.get('workoutTargetTypeId')
 
+        rejection = REJECTED_TARGET_TYPE_KEYS.get(target_key)
+        if rejection is not None:
+            raise ValueError(
+                f"{path}.{target_field} workoutTargetTypeKey "
+                f"{target_key!r} is unsupported; {rejection}"
+            )
+
         if target_id is not None:
             try:
                 target_id = int(target_id)
@@ -316,10 +341,117 @@ def _validate_target_type_block(step: dict, path: str, target_field: str) -> Non
             )
 
 
+def _effective_target_type_key(target_type: dict) -> Optional[str]:
+    """Resolve a missing target key from a known authoritative numeric ID."""
+    target_key = target_type.get('workoutTargetTypeKey')
+    if target_key:
+        return target_key
+
+    target_id = target_type.get('workoutTargetTypeId')
+    try:
+        target_id = int(target_id)
+    except (TypeError, ValueError):
+        return None
+
+    valid_keys = KNOWN_TARGET_TYPE_IDS.get(target_id)
+    if valid_keys is not None and len(valid_keys) == 1:
+        return next(iter(valid_keys))
+    return None
+
+
+def _validate_power_target_values(
+    step: dict,
+    path: str,
+    target_field: str,
+    value_one_field: str,
+    value_two_field: str,
+    zone_field: str,
+) -> None:
+    """Validate named-zone and custom-watt payload shapes for power targets."""
+    target_type = step.get(target_field)
+    if not isinstance(target_type, dict):
+        return
+    if _effective_target_type_key(target_type) != 'power.zone':
+        return
+
+    zone = step.get(zone_field)
+    low = step.get(value_one_field)
+    high = step.get(value_two_field)
+    has_range = low is not None or high is not None
+
+    # _normalize_workout_steps rejects zone-plus-range ambiguity for every
+    # target type before upload validation reaches this function.
+    if zone is None and not has_range:
+        raise ValueError(
+            f"{path}.{target_field} power target requires {zone_field} or a "
+            f"{value_one_field}/{value_two_field} watt range"
+        )
+    if has_range and (low is None or high is None):
+        raise ValueError(
+            f"{path}.{target_field} custom power target requires both "
+            f"{value_one_field} and {value_two_field}"
+        )
+
+    if zone is not None:
+        if isinstance(zone, bool):
+            raise ValueError(f"{path}.{zone_field} must be an integer between 1 and 7")
+        try:
+            zone_number = float(zone)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"{path}.{zone_field} must be an integer between 1 and 7"
+            ) from exc
+        if (
+            not math.isfinite(zone_number)
+            or not zone_number.is_integer()
+            or not 1 <= zone_number <= 7
+            or (
+                isinstance(zone, str)
+                and str(int(zone_number)) != zone.strip()
+            )
+        ):
+            raise ValueError(f"{path}.{zone_field} must be an integer between 1 and 7")
+        return
+
+    if (
+        isinstance(low, bool)
+        or isinstance(high, bool)
+        or not isinstance(low, (int, float))
+        or not isinstance(high, (int, float))
+    ):
+        raise ValueError(f"{path}.{target_field} watt range must be numeric")
+    low_watts = float(low)
+    high_watts = float(high)
+    if not math.isfinite(low_watts) or not math.isfinite(high_watts):
+        raise ValueError(f"{path}.{target_field} watt range must be finite")
+    if low_watts < 0 or high_watts < 0:
+        raise ValueError(f"{path}.{target_field} watt range must be non-negative")
+    if low_watts > high_watts:
+        raise ValueError(
+            f"{path}.{target_field} power target low value cannot exceed high value"
+        )
+
+
 def _validate_target_type_step(step: dict, path: str) -> None:
     """Reject targetType id/key pairs Garmin would silently reinterpret."""
     _validate_target_type_block(step, path, 'targetType')
     _validate_target_type_block(step, path, 'secondaryTargetType')
+    _validate_power_target_values(
+        step,
+        path,
+        target_field='targetType',
+        value_one_field='targetValueOne',
+        value_two_field='targetValueTwo',
+        zone_field='zoneNumber',
+    )
+    _validate_power_target_values(
+        step,
+        path,
+        target_field='secondaryTargetType',
+        value_one_field='secondaryTargetValueOne',
+        value_two_field='secondaryTargetValueTwo',
+        zone_field='secondaryZoneNumber',
+    )
 
     for index, nested in enumerate(step.get('workoutSteps', [])):
         _validate_target_type_step(nested, f"{path}.workoutSteps[{index}]")
@@ -740,17 +872,18 @@ def register_tools(app):
         Garmin treats workoutTargetTypeId as authoritative, so mismatches are rejected
         before upload.  Known mappings:
         - workoutTargetTypeId 1  -> "no.target"
-        - workoutTargetTypeId 2  -> "power.zone"  (cycling power zone 1-7, use zoneNumber)
+        - workoutTargetTypeId 2  -> "power.zone"  (cycling power target)
         - workoutTargetTypeId 4  -> "heart.rate.zone"
-        - workoutTargetTypeId 6  -> "pace.zone" (running/swim) OR "power.between" (cycling)
+        - workoutTargetTypeId 6  -> "pace.zone" (pace/speed target, not cycling power)
 
         IMPORTANT: For cycling power targets use the correct target type:
         - Power zone (zone 1-7 based on FTP %): use workoutTargetTypeId 2, key "power.zone",
           and "zoneNumber" (1-7).
-        - Absolute watt range (e.g. 200-250 W): use workoutTargetTypeId 6, key "power.between",
-          and "targetValueOne" (low watts) / "targetValueTwo" (high watts).
-        Using workoutTargetTypeId 2 with key "power.between" is a silent Garmin bug: the
-        workout uploads but Garmin stores it as "power.zone" and the intent is lost.
+        - Absolute watt range (e.g. 200-250 W): use the same workoutTargetTypeId 2 and
+          key "power.zone", set "targetValueOne" (low watts) / "targetValueTwo"
+          (high watts), and omit "zoneNumber".
+        Do not use workoutTargetTypeId 6 or key "power.between" for cycling power.
+        Garmin stores ID 6 as "pace.zone", causing the device to show a speed target.
 
         Use {"workoutTargetTypeId": 4, "workoutTargetTypeKey": "heart.rate.zone"} with
         targetValueOne/targetValueTwo for custom heart-rate ranges.
@@ -864,9 +997,10 @@ def register_tools(app):
         For custom heart-rate ranges, use targetType {"workoutTargetTypeId": 4,
         "workoutTargetTypeKey": "heart.rate.zone"} with targetValueOne/targetValueTwo.
         Target values belong on the workout step, alongside targetType, not inside it.
-        For cycling power zone targets (zone-based), use workoutTargetTypeId 2, key "power.zone".
-        For cycling absolute watt range targets, use workoutTargetTypeId 6, key "power.between",
-        with targetValueOne (low watts) and targetValueTwo (high watts).
+        For cycling power targets use workoutTargetTypeId 2 and key "power.zone".
+        Use zoneNumber for a named FTP zone, or targetValueOne/targetValueTwo for an
+        absolute watt range (with no zoneNumber). Never use ID 6 or "power.between"
+        for cycling power; Garmin stores ID 6 as a pace/speed target.
         Target type IDs and keys must match Garmin's canonical mapping.
 
         IMPORTANT: End condition IDs and keys must match Garmin's canonical mapping.

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -694,8 +694,8 @@ async def test_upload_workout_rejects_target_type_mismatch(app_with_workouts, mo
     )
 
     assert "targetType mismatch" in result[0][0].text
-    # ID 6 is valid for 'pace.zone' (running) and 'power.between' (cycling), not 'heart.rate'
-    assert "workoutTargetTypeId 6 is one of" in result[0][0].text
+    # ID 6 is pace.zone, not heart.rate.
+    assert "workoutTargetTypeId 6 is 'pace.zone', not 'heart.rate'" in result[0][0].text
     assert "not 'heart.rate'" in result[0][0].text
     mock_garmin_client.upload_workout.assert_not_called()
 
@@ -854,8 +854,8 @@ async def test_upload_workout_rejects_secondary_target_type_mismatch(app_with_wo
     )
 
     assert "secondaryTargetType mismatch" in result[0][0].text
-    # ID 6 is valid for 'pace.zone' (running) and 'power.between' (cycling), not 'heart.rate'
-    assert "workoutTargetTypeId 6 is one of" in result[0][0].text
+    # ID 6 is pace.zone, not heart.rate.
+    assert "workoutTargetTypeId 6 is 'pace.zone', not 'heart.rate'" in result[0][0].text
     assert "not 'heart.rate'" in result[0][0].text
     mock_garmin_client.upload_workout.assert_not_called()
 
@@ -921,7 +921,7 @@ async def test_upload_workout_rejects_nested_secondary_target_type_mismatch(
 
 
 # ---------------------------------------------------------------------------
-# Cycling power target tests (Issue #155)
+# Cycling power target tests (Issue #155 regression)
 # ---------------------------------------------------------------------------
 
 def _cycling_workout_with_steps(steps, name="Cycling Validation Workout"):
@@ -937,11 +937,12 @@ def _cycling_workout_with_steps(steps, name="Cycling Validation Workout"):
 
 
 @pytest.mark.asyncio
-async def test_upload_cycling_workout_power_between_accepted(app_with_workouts, mock_garmin_client):
-    """Cycling absolute watt range (power.between) uses workoutTargetTypeId 6.
+async def test_upload_cycling_workout_absolute_watts_accepted(app_with_workouts, mock_garmin_client):
+    """Cycling absolute watts use ID 2/power.zone without zoneNumber.
 
-    Fix for Issue #155: power.between must use ID 6, not ID 2.
-    ID 6 is valid for both 'pace.zone' (running) and 'power.between' (cycling).
+    Garmin uses the payload shape to distinguish a named power zone from a
+    custom watt range. A live upload/download probe encodes this shape as a
+    power target in the FIT workout.
     """
     import json as json_module
 
@@ -956,7 +957,7 @@ async def test_upload_cycling_workout_power_between_accepted(app_with_workouts, 
             "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
             "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
             "endConditionValue": 600.0,
-            "targetType": {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "power.between"},
+            "targetType": {"workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.zone"},
             "targetValueOne": 200,
             "targetValueTwo": 250,
         }],
@@ -974,15 +975,19 @@ async def test_upload_cycling_workout_power_between_accepted(app_with_workouts, 
 
     called_data = mock_garmin_client.upload_workout.call_args[0][0]
     step = called_data["workoutSegments"][0]["workoutSteps"][0]
-    assert step["targetType"]["workoutTargetTypeId"] == 6
-    assert step["targetType"]["workoutTargetTypeKey"] == "power.between"
+    assert step["targetType"]["workoutTargetTypeId"] == 2
+    assert step["targetType"]["workoutTargetTypeKey"] == "power.zone"
     assert step["targetValueOne"] == 200
     assert step["targetValueTwo"] == 250
+    assert "zoneNumber" not in step
 
 
 @pytest.mark.asyncio
-async def test_upload_cycling_workout_power_zone_accepted(app_with_workouts, mock_garmin_client):
-    """Cycling zone-based power (power.zone) uses workoutTargetTypeId 2 with zoneNumber."""
+@pytest.mark.parametrize("zone_number", [3, 4.0])
+async def test_upload_cycling_workout_power_zone_accepted(
+    app_with_workouts, mock_garmin_client, zone_number
+):
+    """Named power zones accept integer JSON values and integral floats."""
     import json as json_module
 
     mock_garmin_client.upload_workout.return_value = {
@@ -997,7 +1002,7 @@ async def test_upload_cycling_workout_power_zone_accepted(app_with_workouts, moc
             "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
             "endConditionValue": 1200.0,
             "targetType": {"workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.zone"},
-            "zoneNumber": 3,
+            "zoneNumber": zone_number,
         }],
         name="Cycling Power Zone Test",
     )
@@ -1014,19 +1019,28 @@ async def test_upload_cycling_workout_power_zone_accepted(app_with_workouts, moc
     step = called_data["workoutSegments"][0]["workoutSteps"][0]
     assert step["targetType"]["workoutTargetTypeId"] == 2
     assert step["targetType"]["workoutTargetTypeKey"] == "power.zone"
-    assert step["zoneNumber"] == 3
+    assert step["zoneNumber"] == zone_number
 
 
 @pytest.mark.asyncio
-async def test_upload_cycling_workout_wrong_id_for_power_between_rejected(
-    app_with_workouts, mock_garmin_client
+@pytest.mark.parametrize(
+    "target_type",
+    [
+        {"workoutTargetTypeKey": "power.between"},
+        {
+            "workoutTargetTypeId": 6,
+            "workoutTargetTypeKey": "power.between",
+        },
+        {
+            "workoutTargetTypeId": 9,
+            "workoutTargetTypeKey": "power.between",
+        },
+    ],
+)
+async def test_upload_cycling_workout_rejects_legacy_power_between_target(
+    app_with_workouts, mock_garmin_client, target_type
 ):
-    """Using workoutTargetTypeId 2 with key 'power.between' is the root cause of Issue #155.
-
-    Garmin silently treats ID 2 as 'power.zone' regardless of the key string, so
-    the stored workout comes back as target_type='power.zone' instead of 'power.between'.
-    The validator catches this mismatch before upload.
-    """
+    """Reject the legacy key independently of a missing or misleading ID."""
     workout_data = _cycling_workout_with_steps(
         [{
             "type": "ExecutableStepDTO",
@@ -1034,7 +1048,7 @@ async def test_upload_cycling_workout_wrong_id_for_power_between_rejected(
             "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
             "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
             "endConditionValue": 600.0,
-            "targetType": {"workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.between"},
+            "targetType": target_type,
             "targetValueOne": 200,
             "targetValueTwo": 250,
         }],
@@ -1046,9 +1060,9 @@ async def test_upload_cycling_workout_wrong_id_for_power_between_rejected(
         {"workout_data": workout_data}
     )
 
-    assert "targetType mismatch" in result[0][0].text
-    # ID 2 maps to 'power.zone' only (single key) so the error names it directly
-    assert "workoutTargetTypeId 2 is 'power.zone', not 'power.between'" in result[0][0].text
+    assert "workoutTargetTypeKey 'power.between' is unsupported" in result[0][0].text
+    assert "use workoutTargetTypeId 2 / 'power.zone'" in result[0][0].text
+    assert "targetValueOne/targetValueTwo and no zoneNumber" in result[0][0].text
     mock_garmin_client.upload_workout.assert_not_called()
 
 
@@ -1058,7 +1072,7 @@ async def test_upload_cycling_workout_wrong_id_for_power_zone_rejected(
 ):
     """Using workoutTargetTypeId 6 with key 'power.zone' is a mismatch.
 
-    ID 6 is valid for 'pace.zone' and 'power.between' only, not 'power.zone'.
+    ID 6 is pace.zone, not power.zone.
     """
     workout_data = _cycling_workout_with_steps(
         [{
@@ -1079,17 +1093,220 @@ async def test_upload_cycling_workout_wrong_id_for_power_zone_rejected(
     )
 
     assert "targetType mismatch" in result[0][0].text
-    # ID 6 has two valid keys (pace.zone, power.between) so the error lists both
-    assert "workoutTargetTypeId 6 is one of" in result[0][0].text
-    assert "not 'power.zone'" in result[0][0].text
+    assert "workoutTargetTypeId 6 is 'pace.zone', not 'power.zone'" in result[0][0].text
     mock_garmin_client.upload_workout.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_upload_cycling_workout_power_between_in_repeat_group(
+async def test_upload_cycling_workout_pace_target_remains_valid(
     app_with_workouts, mock_garmin_client
 ):
-    """power.between targets inside RepeatGroupDTO steps are accepted."""
+    """The power fix must not block an intentional cycling speed target."""
+    import json as json_module
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 200004,
+        "workoutName": "Cycling Speed Target",
+    }
+    workout_data = _cycling_workout_with_steps(
+        [{
+            "type": "ExecutableStepDTO",
+            "stepOrder": 1,
+            "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+            "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+            "endConditionValue": 600.0,
+            "targetType": {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"},
+            "targetValueOne": 150,
+            "targetValueTwo": 160,
+        }],
+        name="Cycling Speed Target",
+    )
+
+    result = await app_with_workouts.call_tool("upload_workout", {"workout_data": workout_data})
+
+    assert json_module.loads(result[0][0].text)["status"] == "success"
+    mock_garmin_client.upload_workout.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_cycling_workout_rejects_zone_and_range_during_normalization(
+    app_with_workouts, mock_garmin_client
+):
+    """Shared target normalization rejects a named zone plus custom bounds."""
+    workout_data = _cycling_workout_with_steps(
+        [{
+            "type": "ExecutableStepDTO",
+            "stepOrder": 1,
+            "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+            "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+            "endConditionValue": 600.0,
+            "targetType": {"workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.zone"},
+            "zoneNumber": 4,
+            "targetValueOne": 150,
+            "targetValueTwo": 160,
+        }],
+        name="Ambiguous Cycling Power Target",
+    )
+
+    result = await app_with_workouts.call_tool("upload_workout", {"workout_data": workout_data})
+
+    assert "mixes zoneNumber=4 with custom range fields" in result[0][0].text
+    assert "use either a named zone or a custom range" in result[0][0].text
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_values", "expected_error"),
+    [
+        ({}, "requires zoneNumber or a targetValueOne/targetValueTwo watt range"),
+        ({"targetValueOne": 250}, "requires both targetValueOne and targetValueTwo"),
+        (
+            {"targetValueOne": 300, "targetValueTwo": 250},
+            "power target low value cannot exceed high value",
+        ),
+        ({"targetValueOne": -1, "targetValueTwo": 250}, "must be non-negative"),
+        ({"targetValueOne": float("inf"), "targetValueTwo": 250}, "must be finite"),
+        ({"targetValueOne": "200", "targetValueTwo": 250}, "must be numeric"),
+        ({"targetValueOne": True, "targetValueTwo": 250}, "must be numeric"),
+        ({"zoneNumber": True}, "must be an integer between 1 and 7"),
+        ({"zoneNumber": 4.5}, "must be an integer between 1 and 7"),
+        ({"zoneNumber": "04"}, "must be an integer between 1 and 7"),
+        ({"zoneNumber": 8}, "must be an integer between 1 and 7"),
+    ],
+)
+async def test_upload_cycling_workout_rejects_invalid_power_target_values(
+    app_with_workouts, mock_garmin_client, target_values, expected_error
+):
+    """Reject malformed power targets before Garmin can reinterpret them."""
+    step = {
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+        "endConditionValue": 600.0,
+        "targetType": {"workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.zone"},
+        **target_values,
+    }
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": _cycling_workout_with_steps([step])},
+    )
+
+    assert expected_error in result[0][0].text
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("target_values", "expected_error"),
+    [
+        ({"targetValueOne": 250}, "requires both targetValueOne and targetValueTwo"),
+        (
+            {"targetValueOne": 300, "targetValueTwo": 250},
+            "power target low value cannot exceed high value",
+        ),
+        ({"targetValueOne": -1, "targetValueTwo": 250}, "must be non-negative"),
+    ],
+)
+async def test_upload_cycling_workout_validates_power_values_from_id_without_key(
+    app_with_workouts, mock_garmin_client, target_values, expected_error
+):
+    """Known numeric IDs remain authoritative when the key is omitted."""
+    step = {
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+        "endConditionValue": 600.0,
+        "targetType": {"workoutTargetTypeId": 2},
+        **target_values,
+    }
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": _cycling_workout_with_steps([step])},
+    )
+
+    assert expected_error in result[0][0].text
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_cycling_workout_secondary_absolute_watts_accepted(
+    app_with_workouts, mock_garmin_client
+):
+    """Secondary custom watt targets use their secondary value fields."""
+    import json as json_module
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 200005,
+        "workoutName": "Cycling Secondary Power Target",
+    }
+    step = {
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+        "endConditionValue": 600.0,
+        "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+        "secondaryTargetType": {
+            "workoutTargetTypeId": 2,
+            "workoutTargetTypeKey": "power.zone",
+        },
+        "secondaryTargetValueOne": 200,
+        "secondaryTargetValueTwo": 250,
+    }
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": _cycling_workout_with_steps([step])},
+    )
+
+    assert json_module.loads(result[0][0].text)["status"] == "success"
+    mock_garmin_client.upload_workout.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_upload_cycling_workout_rejects_ambiguous_secondary_power_target(
+    app_with_workouts, mock_garmin_client
+):
+    """Shared normalization also protects secondary power targets."""
+    step = {
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+        "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+        "endConditionValue": 600.0,
+        "targetType": {
+            "workoutTargetTypeId": 1,
+            "workoutTargetTypeKey": "no.target",
+        },
+        "secondaryTargetType": {
+            "workoutTargetTypeId": 2,
+            "workoutTargetTypeKey": "power.zone",
+        },
+        "secondaryZoneNumber": 4,
+        "secondaryTargetValueOne": 200,
+        "secondaryTargetValueTwo": 250,
+    }
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": _cycling_workout_with_steps([step])},
+    )
+
+    assert "mixes secondaryZoneNumber=4 with custom range fields" in result[0][0].text
+    assert "use either a named zone or a custom range" in result[0][0].text
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_cycling_workout_absolute_watts_in_repeat_group(
+    app_with_workouts, mock_garmin_client
+):
+    """Absolute power.zone watt ranges inside RepeatGroupDTO are accepted."""
     import json as json_module
 
     mock_garmin_client.upload_workout.return_value = {
@@ -1119,7 +1336,7 @@ async def test_upload_cycling_workout_power_between_in_repeat_group(
                         "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
                         "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
                         "endConditionValue": 300.0,
-                        "targetType": {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "power.between"},
+                        "targetType": {"workoutTargetTypeId": 2, "workoutTargetTypeKey": "power.zone"},
                         "targetValueOne": 250,
                         "targetValueTwo": 300,
                     },
@@ -1155,8 +1372,8 @@ async def test_upload_cycling_workout_power_between_in_repeat_group(
 
     called_data = mock_garmin_client.upload_workout.call_args[0][0]
     interval_step = called_data["workoutSegments"][0]["workoutSteps"][1]["workoutSteps"][0]
-    assert interval_step["targetType"]["workoutTargetTypeId"] == 6
-    assert interval_step["targetType"]["workoutTargetTypeKey"] == "power.between"
+    assert interval_step["targetType"]["workoutTargetTypeId"] == 2
+    assert interval_step["targetType"]["workoutTargetTypeKey"] == "power.zone"
     assert interval_step["targetValueOne"] == 250
     assert interval_step["targetValueTwo"] == 300
 


### PR DESCRIPTION
## Summary

- encode explicit cycling watt ranges with target type ID `2` / `power.zone`
- use the payload shape to distinguish named FTP zones from custom watt ranges
- reject the legacy `power.between` key regardless of a missing or misleading
  numeric ID, before Garmin silently turns it into a speed target
- validate primary, secondary, and nested power targets without blocking intentional cycling speed targets
- document the verified Garmin Connect and FIT behavior

## Root cause and live validation

Garmin treats `workoutTargetTypeId` as authoritative. Target type ID `6` is
stored as `pace.zone`, even when the submitted key is `power.between`. The
resulting FIT workout contains a speed/pace target, so devices display speed
units instead of watts.

A live upload, fetch, and FIT download round trip confirmed the correct payload
for current-power guidance:

| Garmin Connect payload | Garmin Connect result | Downloaded FIT result |
| --- | --- | --- |
| ID `2`, `power.zone`, `targetValueOne: 150`, `targetValueTwo: 160`, no `zoneNumber` | `power.zone`, 150-160 | `power_3s`, custom bounds 1150-1160 (150-160 W in FIT custom-target encoding) |

The resulting scheduled workout also displays watts rather than speed units on
the device.

Garmin's Connect IQ documentation defines `POWER_3S` and `POWER_LAP` as separate
workout target types:
https://developer.garmin.com/connect-iq/api-docs/Toybox/Activity.html#WorkoutStepTargetType-module

This PR intentionally preserves the observed `power_3s` semantics. It does not
substitute ID `9` / `power.lap`, which represents lap-average power guidance.

## Changes

- make the canonical target mapping unambiguous: ID `2` is `power.zone`, ID `6`
  is `pace.zone`
- allow either `zoneNumber` 1-7 or a complete custom watt range for
  `power.zone`, but never both
- validate finite, non-negative, ordered watt bounds and reject incomplete
  ranges
- resolve a missing key from authoritative known IDs, so ID `2` cannot bypass
  custom-watt validation
- apply the same validation to primary and secondary targets, including steps
  nested inside repeat groups
- keep valid pace/speed targets available for cycling workouts
- update the MCP tool guidance, structure reference, README, and regression
  tests

## Compatibility note

This intentionally reverses the cycling-power guidance merged in #159.
Existing callers or stored prompts that still emit `power.between` will now
receive an actionable validation error instead of uploading a silently
misinterpreted speed target. They must migrate to ID `2` / `power.zone` with
step-level `targetValueOne` and `targetValueTwo`, and no `zoneNumber`, for
absolute watts.

## Testing

- rebased onto upstream `main` at `a16f057`
- focused workout integration tests: `103 passed`
- Python 3.10.20: `476 passed`
- Python 3.12.13: `476 passed`
- Python 3.13.13: `476 passed`
- `uv lock --check`
- `git diff --check`
- live Garmin Connect upload/fetch/FIT round trip using a seven-step cycling
  workout with warmup, three work intervals, recoveries, and cooldown

## Related work

This is a follow-up correction to #155 and #159. PR #186 was closed in favor of
this implementation after live FIT and device validation established that
ID `2` custom bounds provide the intended `power_3s` guidance, while
`power.lap` is a distinct lap-average target.

Closes #245
