### PR TITLE
fix: use reps for strength workout end condition instead of hardcoded time

### DIFF
--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -252,9 +252,10 @@ def build_strength_json(
             "stepOrder": step_order,
             "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
             "description": f"{ex_name}: {sets} sets x {reps} reps",
-            "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
-            "endConditionValue": float(sets * 45),  # rough estimate: 45s per set
+            "endCondition": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
+            "endConditionValue": float(reps),
             "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+            "category": "UNASSIGNED",
             "exerciseName": ex_name,
         })
         step_order += 1


### PR DESCRIPTION
This PR addresses Issue #196 where `create_strength_workout` ignored the user-provided `reps` count and defaulted to a hardcoded time-based end condition.

### Changes:
- Changed `conditionTypeId` from `2` (time) to `10` (reps).
- Assigned the actual `reps` value to `endConditionValue`.
- Added a default `category: "UNASSIGNED"` to the payload to satisfy Garmin Connect strict validation for strength exercises.

Closes #196.