### PR TITLE
fix: convert raw minutes to hours in get_morning_training_readiness

### DIFF
--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -883,7 +883,7 @@ def register_tools(app):
                 "date": date,
                 "readiness_score": readiness.get('readinessScore'),
                 "readiness_level": readiness.get('readinessLevel'),
-                "recovery_time_hours": readiness.get('recoveryTime'),
+                "recovery_time_hours": round(readiness.get('recoveryTime', 0) / 60, 1) if readiness.get('recoveryTime') is not None else None,
                 "hrv_status": readiness.get('hrvStatus'),
                 "sleep_quality": readiness.get('sleepQuality'),
                 "sleep_score": readiness.get('sleepScore'),


### PR DESCRIPTION
This PR addresses Issue #187 where `recovery_time_hours` in `get_morning_training_readiness` incorrectly returned raw minutes.

### Changes:
- Converted the raw minute value from `recoveryTime` to hours by dividing by 60 and rounding to 1 decimal place.
- Handled cases where `recoveryTime` is missing or `None` to prevent TypeErrors.
- Ensures consistency with how `recovery_time_hours` is handled in other endpoints.

Closes #187.