### PR TITLE
fix: preserve original API error messages in _GarminProxy

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -142,7 +142,9 @@ class _GarminProxy:
             except tuple(self._MESSAGES) as exc:
                 for exc_type, msg in self._MESSAGES.items():
                     if isinstance(exc, exc_type):
-                        raise type(exc)(msg) from None
+                        error_details = str(exc)
+                        full_msg = f"{msg} (Details: {error_details})" if error_details else msg
+                        raise type(exc)(full_msg) from None
                 raise
 
         return _call


### PR DESCRIPTION
This PR addresses Issue #183 where `_GarminProxy` discarded the actual error messages provided by the Garmin API or `garminconnect` library.

### Changes:
- Modified the `__getattr__` exception wrapper in `_GarminProxy`.
- Instead of completely replacing the original exception message with the hardcoded proxy string, it now appends the original `str(exc)` as `(Details: ...)`.
- If the original exception has no string representation, it cleanly falls back to just the proxy message.

This preserves the user-friendly intent of the proxy while ensuring developers and users can still see the actual root cause (e.g., HTTP 403, specific API rejections).

Closes #183.