### PR TITLE
fix: change DXT server.type from 'uv' to 'python' (closes #188)

### DIFF
--- a/dxt/manifest.json
+++ b/dxt/manifest.json
@@ -25,7 +25,7 @@
     "garmin-connect"
   ],
   "server": {
-    "type": "uv",
+    "type": "python",
     "entry_point": "garmin_mcp",
     "mcp_config": {
       "command": "uvx",


### PR DESCRIPTION
## Summary

Fixes the prebuilt `garmin-mcp.dxt` failing to install with:

> Failed to preview extension: Invalid manifest: server: Invalid enum value. Expected 'python' | 'node' | 'binary', received 'uv'

Claude Desktop's extension manifest schema only accepts `"python"`, `"node"`, or `"binary"` for `server.type`. Changed from `"uv"` (invalid) to `"python"`. The `mcp_config.command` / `args` that invoke `uvx` are unchanged — only the schema-level type declaration is corrected.

## Test plan
- [ ] Install the `.dxt` in Claude Desktop — should no longer show the invalid manifest error

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)