### PR TITLE
fix: suppress stdout during garminconnect login to prevent MCP stdio corruption (closes #166)

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -233,15 +233,20 @@ def init_api(email, password):
         # with open(dir_path, "r") as token_file:
         #     tokenstore = token_file.read()
 
-        # Suppress stderr for token validation to avoid confusing library errors
+        # Suppress stderr AND stdout during token validation.
+        # garminconnect may print progress dots (e.g. ".") to stdout; any write
+        # to stdout before the MCP server starts corrupts the JSON-RPC framing.
         old_stderr = sys.stderr
+        old_stdout = sys.stdout
         sys.stderr = io.StringIO()
+        sys.stdout = io.StringIO()
 
         try:
             garmin = Garmin(is_cn=is_cn)
             garmin.login(tokenstore)
         finally:
             sys.stderr = old_stderr
+            sys.stdout = old_stdout
 
     except (FileNotFoundError, GarminConnectConnectionError, GarminConnectTooManyRequestsError, GarminConnectAuthenticationError):
         # Session is expired. You'll need to log in again
@@ -268,7 +273,13 @@ def init_api(email, password):
             garmin = Garmin(
                 email=email, password=password, is_cn=is_cn, prompt_mfa=get_mfa, return_on_mfa=True
             )
-            result1, result2 = garmin.login()
+            # Suppress stdout so library progress dots don't corrupt MCP framing.
+            _saved_stdout = sys.stdout
+            sys.stdout = io.StringIO()
+            try:
+                result1, result2 = garmin.login()
+            finally:
+                sys.stdout = _saved_stdout
             if result1 == "needs_mfa":
                 mfa_code = get_mfa()
                 garmin.resume_login(result2, mfa_code)


### PR DESCRIPTION
## Problem

The `garminconnect` library's `login()` method prints progress characters (including `.`) to **stdout** during authentication. In MCP stdio mode, stdout is the JSON-RPC transport channel — any unexpected byte on stdout before the server's first message corrupts the framing and causes Claude Desktop to report "Server disconnected".

The existing `TextIOWrapper` fix (#162) addressed CRLF encoding, but the library output itself was never suppressed, so a `.` written by the library still reached the MCP client before any MCP frame, breaking the handshake.

Issue reporter observed: `input_value='.\n'` arriving before the MCP session — this is the garminconnect progress dot.

## Fix

Redirect `sys.stdout` to a `StringIO` buffer for the duration of each `garmin.login()` call (both the token-file path and the email/password path), then restore it. Stderr is already suppressed during the token-file path; this PR extends that suppression to stdout.

```python
old_stdout = sys.stdout
sys.stdout = io.StringIO()
try:
    garmin.login(...)
finally:
    sys.stdout = old_stdout
```

Any library output during login is discarded. Error messages from the server itself still go to `sys.stderr` (unaffected).

## Test plan
- [x] 400 tests pass

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)