### PR TITLE
feat: add set_nutrition_daily_settings tool (closes #181)

### DIFF
--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -87,6 +87,60 @@ def register_tools(app):
             return f"Error retrieving nutrition settings: {str(e)}"
 
     @app.tool()
+    async def set_nutrition_daily_settings(
+        date: str,
+        calorie_goal: Optional[int] = None,
+        carbs_grams: Optional[int] = None,
+        fat_grams: Optional[int] = None,
+        protein_grams: Optional[int] = None,
+    ) -> str:
+        """Update daily nutrition goals (calorie target and macronutrient targets).
+
+        Reads the current settings for the date, applies the supplied overrides,
+        and writes the merged result back.  Only the fields you provide are
+        changed; omitted fields keep their existing values.
+
+        Garmin stores macros as grams.  The calorie goal should match
+        4*carbs + 4*protein + 9*fat to within a small rounding margin — Garmin
+        accepts minor mismatches but will silently correct large discrepancies.
+
+        Args:
+            date: Date in YYYY-MM-DD format (settings are typically set once and
+                  inherited across days, but Garmin accepts per-day overrides)
+            calorie_goal: Daily calorie target in kcal
+            carbs_grams: Daily carbohydrate target in grams
+            fat_grams: Daily fat target in grams
+            protein_grams: Daily protein target in grams
+        """
+        if all(v is None for v in (calorie_goal, carbs_grams, fat_grams, protein_grams)):
+            return "No fields to update — supply at least one of calorie_goal, carbs_grams, fat_grams, protein_grams."
+        try:
+            url = f"/nutrition-service/settings/{date}"
+            current = garmin_client.connectapi(url)
+            if not current:
+                return f"Could not read current nutrition settings for {date} — cannot apply update."
+            if calorie_goal is not None:
+                current["activeDailyCalories"] = calorie_goal
+            if carbs_grams is not None:
+                current["activeDailyCarbohydrateGrams"] = carbs_grams
+            if fat_grams is not None:
+                current["activeDailyFatGrams"] = fat_grams
+            if protein_grams is not None:
+                current["activeDailyProteinGrams"] = protein_grams
+            resp = garmin_client.client.put("connectapi", url, json=current, api=True)
+            result = resp if resp else current
+            return json.dumps({
+                "status": "updated",
+                "date": date,
+                "calorie_goal": result.get("activeDailyCalories"),
+                "carbs_grams": result.get("activeDailyCarbohydrateGrams"),
+                "fat_grams": result.get("activeDailyFatGrams"),
+                "protein_grams": result.get("activeDailyProteinGrams"),
+            }, indent=2)
+        except Exception as e:
+            return f"Error updating nutrition settings: {str(e)}"
+
+    @app.tool()
     async def get_custom_foods(
         search: str = "",
         start: int = 0,

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -853,3 +853,100 @@ async def test_delete_food_log_accepts_hex_uuid(app_with_nutrition, mock_garmin_
         "connectapi", "/nutrition-service/food/logs/2024-01-15",
         json={"logIds": [hex_log_id]}, api=True
     )
+
+
+# set_nutrition_daily_settings tests
+
+_CURRENT_SETTINGS = {
+    "activeDailyCalories": 2000,
+    "activeDailyCarbohydrateGrams": 250,
+    "activeDailyFatGrams": 65,
+    "activeDailyProteinGrams": 120,
+    "planDate": "2024-01-15",
+}
+
+
+@pytest.mark.asyncio
+async def test_set_nutrition_daily_settings_updates_all_fields(app_with_nutrition, mock_garmin_client):
+    """All four fields are updated and the merged payload is PUT back."""
+    mock_garmin_client.connectapi.return_value = dict(_CURRENT_SETTINGS)
+    mock_garmin_client.client.put.return_value = {
+        "activeDailyCalories": 1800,
+        "activeDailyCarbohydrateGrams": 200,
+        "activeDailyFatGrams": 60,
+        "activeDailyProteinGrams": 140,
+    }
+
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings",
+        {"date": "2024-01-15", "calorie_goal": 1800, "carbs_grams": 200, "fat_grams": 60, "protein_grams": 140},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["status"] == "updated"
+    assert data["calorie_goal"] == 1800
+    assert data["carbs_grams"] == 200
+    assert data["fat_grams"] == 60
+    assert data["protein_grams"] == 140
+    # Verify the PUT was called with the merged payload
+    put_call = mock_garmin_client.client.put.call_args
+    assert put_call.args[1] == "/nutrition-service/settings/2024-01-15"
+    assert put_call.kwargs["json"]["activeDailyCalories"] == 1800
+
+
+@pytest.mark.asyncio
+async def test_set_nutrition_daily_settings_partial_update(app_with_nutrition, mock_garmin_client):
+    """Only the supplied fields are changed; others keep their existing values."""
+    mock_garmin_client.connectapi.return_value = dict(_CURRENT_SETTINGS)
+    mock_garmin_client.client.put.return_value = None  # some endpoints return nothing
+
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings",
+        {"date": "2024-01-15", "calorie_goal": 1900},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["status"] == "updated"
+    assert data["calorie_goal"] == 1900
+    # Unchanged fields come back from the merged current settings (since resp=None)
+    assert data["carbs_grams"] == _CURRENT_SETTINGS["activeDailyCarbohydrateGrams"]
+    put_call = mock_garmin_client.client.put.call_args
+    assert put_call.kwargs["json"]["activeDailyCarbohydrateGrams"] == 250
+
+
+@pytest.mark.asyncio
+async def test_set_nutrition_daily_settings_no_fields_provided(app_with_nutrition, mock_garmin_client):
+    """Returns a clear message when no fields are supplied."""
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings",
+        {"date": "2024-01-15"},
+    )
+    assert "No fields to update" in result[0][0].text
+    mock_garmin_client.connectapi.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_nutrition_daily_settings_no_current_data(app_with_nutrition, mock_garmin_client):
+    """Returns a clear message when GET returns nothing (no baseline to merge into)."""
+    mock_garmin_client.connectapi.return_value = None
+
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings",
+        {"date": "2024-01-15", "calorie_goal": 1800},
+    )
+    assert "Could not read current" in result[0][0].text
+    mock_garmin_client.client.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_set_nutrition_daily_settings_api_error(app_with_nutrition, mock_garmin_client):
+    """API errors are surfaced as a clean message."""
+    mock_garmin_client.connectapi.return_value = dict(_CURRENT_SETTINGS)
+    mock_garmin_client.client.put.side_effect = Exception("403 Forbidden")
+
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings",
+        {"date": "2024-01-15", "calorie_goal": 1800},
+    )
+    assert "Error updating nutrition settings" in result[0][0].text
+    assert "403" in result[0][0].text


### PR DESCRIPTION
## Summary

Adds a `set_nutrition_daily_settings` tool that lets an agent update daily calorie and macronutrient targets.

## How it works

The tool does a read-modify-write: it GETs the current settings for the date, applies only the fields you supply, then PUTs the merged result back. Fields you don't provide stay unchanged.

```json
{
  "status": "updated",
  "date": "2024-01-15",
  "calorie_goal": 1900,
  "carbs_grams": 250,
  "fat_grams": 65,
  "protein_grams": 140
}
```

**Parameters:**
- `date` — YYYY-MM-DD
- `calorie_goal` — kcal (optional)
- `carbs_grams` — grams (optional)
- `fat_grams` — grams (optional)
- `protein_grams` — grams (optional)

At least one macro/calorie field is required; calling with none returns an early error without hitting the API.

## Use case (from Issue #181)

When an agent recalculates macro targets from bodyweight and activity level, it can now apply those numbers directly instead of the user having to copy them into Garmin Connect manually.

## Test plan
- [x] 5 new integration tests (all fields, partial update, no fields, no current data, API error)
- [x] 405 tests pass

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)