### PR TITLE
fix(weather): correct temperature unit + label wind for activity weather

### DIFF
--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -655,14 +655,15 @@ def register_tools(app):
     async def get_activity_weather(activity_id: Union[int, str]) -> str:
         """Get weather data for an activity.
 
-        The temperature and dew_point values are in the unit matching the
-        account's measurement system (Fahrenheit for statute_us / imperial
-        accounts, Celsius for metric). The temperature_unit field ("F" or "C")
-        reflects whichever unit the API returned; do not assume Celsius.
+        Garmin's weather endpoint returns temperatures in Fahrenheit (from the
+        weather-station source) with no unit indicator, regardless of account
+        settings. This tool converts them to the account's display unit: metric
+        accounts get Celsius, statute_us accounts keep Fahrenheit. The
+        temperature_unit field ("F" or "C") states which unit was returned.
 
-        Wind speed unit also follows the measurement system (mph for imperial,
-        km/h for metric), but no wind_speed_unit field is included because the
-        Garmin API does not document the wind speed unit explicitly.
+        Wind speed, unlike temperature, is already returned in the account's
+        display unit (km/h for metric, mph for statute_us), so it is passed
+        through unconverted and labeled via the wind_speed_unit field.
 
         Args:
             activity_id: ID of the activity to retrieve weather data for
@@ -673,26 +674,53 @@ def register_tools(app):
             if not weather:
                 return f"No weather data found for activity with ID {activity_id}"
 
-            # Determine temperature unit from the account's measurement system.
-            # Garmin's weather endpoint returns temp in the account's display
-            # unit (no unit indicator in the payload itself).
+            # Garmin's activity-weather endpoint returns temperatures in
+            # FAHRENHEIT (from the METAR/station source), regardless of the
+            # account's measurement system — the payload carries no unit field.
+            # (Confirmed: a metric account still gets °F here, e.g. temp 57.)
+            # So convert the raw Fahrenheit values to the account's display unit.
+            def _f_to_c(value):
+                return round((value - 32) * 5 / 9, 1) if value is not None else None
+
             try:
                 unit_system = garmin_client.get_unit_system()
-                temp_unit = "F" if unit_system == "statute_us" else "C"
             except Exception:
-                temp_unit = None
+                unit_system = None
+
+            raw_temp = weather.get('temp')
+            raw_apparent = weather.get('apparentTemp')
+            raw_dew = weather.get('dewPoint')
+
+            if unit_system is not None and unit_system != "statute_us":
+                # Metric (or non-US-statute) account → present in Celsius.
+                temp_unit = "C"
+                out_temp, out_apparent, out_dew = (
+                    _f_to_c(raw_temp), _f_to_c(raw_apparent), _f_to_c(raw_dew)
+                )
+            else:
+                # statute_us account (or unknown) → leave the raw Fahrenheit.
+                temp_unit = "F" if unit_system == "statute_us" else None
+                out_temp, out_apparent, out_dew = raw_temp, raw_apparent, raw_dew
+
+            # Wind, unlike temperature, IS already returned in the account's
+            # display unit (verified against a local weather station: metric
+            # accounts get km/h, not mph). So don't convert it — just label it.
+            wind_unit = "mph" if unit_system == "statute_us" else (
+                "km/h" if unit_system is not None else None
+            )
 
             weather_type_dto = weather.get('weatherTypeDTO') or {}
             station_dto = weather.get('weatherStationDTO') or {}
 
             curated = {
                 "activity_id": activity_id,
-                "temperature": weather.get('temp'),
+                "temperature": out_temp,
                 "temperature_unit": temp_unit,
-                "apparent_temperature": weather.get('apparentTemp'),
-                "dew_point": weather.get('dewPoint'),
+                "apparent_temperature": out_apparent,
+                "dew_point": out_dew,
                 "humidity_percent": weather.get('relativeHumidity'),
                 "wind_speed": weather.get('windSpeed'),
+                "wind_speed_unit": wind_unit,
                 "wind_direction_degrees": weather.get('windDirection'),
                 "wind_direction_compass": weather.get('windDirectionCompassPoint'),
                 "wind_gust": weather.get('windGust'),

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -483,31 +483,54 @@ async def test_get_activity_split_summaries_tool(app_with_activity_management, m
 
 
 @pytest.mark.asyncio
-async def test_get_activity_weather_tool(app_with_activity_management, mock_garmin_client):
-    """Test get_activity_weather tool returns weather data"""
-    # Setup mock
-    weather_data = {
-        "temp": 18.0,
-        "apparentTemp": 16.0,
-        "dewPoint": 10.0,
-        "relativeHumidity": 65,
-        "windSpeed": 5.0,
-        "windDirection": 180,
-        "latitude": 40.7128,
-        "longitude": -74.0060
+async def test_get_activity_weather_metric_converts_to_celsius(
+    app_with_activity_management, mock_garmin_client
+):
+    """Garmin returns Fahrenheit; a metric account must see Celsius."""
+    import json as json_module
+
+    # Raw Garmin payload is Fahrenheit (no unit field), e.g. 57 F for Erfurt.
+    mock_garmin_client.get_activity_weather.return_value = {
+        "temp": 57, "apparentTemp": 57, "dewPoint": 50, "relativeHumidity": 77,
+        "windSpeed": 8,
     }
-    mock_garmin_client.get_activity_weather.return_value = weather_data
+    mock_garmin_client.get_unit_system.return_value = "metric"
 
-    # Call tool
-    activity_id = 12345678901
     result = await app_with_activity_management.call_tool(
-        "get_activity_weather",
-        {"activity_id": activity_id}
+        "get_activity_weather", {"activity_id": 23651251274}
     )
+    data = json_module.loads(result[0][0].text)
+    assert data["temperature_unit"] == "C"
+    assert data["temperature"] == 13.9   # 57 F -> 13.9 C, not the raw 57
+    assert data["apparent_temperature"] == 13.9
+    assert data["dew_point"] == 10.0      # 50 F -> 10 C
+    # Wind is already metric — labeled km/h, NOT converted.
+    assert data["wind_speed"] == 8
+    assert data["wind_speed_unit"] == "km/h"
 
-    # Verify
-    assert result is not None
-    mock_garmin_client.get_activity_weather.assert_called_once_with(activity_id)
+
+@pytest.mark.asyncio
+async def test_get_activity_weather_statute_us_keeps_fahrenheit(
+    app_with_activity_management, mock_garmin_client
+):
+    """A statute_us account keeps the raw Fahrenheit values."""
+    import json as json_module
+
+    mock_garmin_client.get_activity_weather.return_value = {
+        "temp": 57, "dewPoint": 50, "windSpeed": 8,
+    }
+    mock_garmin_client.get_unit_system.return_value = "statute_us"
+
+    result = await app_with_activity_management.call_tool(
+        "get_activity_weather", {"activity_id": 1}
+    )
+    data = json_module.loads(result[0][0].text)
+    assert data["temperature_unit"] == "F"
+    assert data["temperature"] == 57      # unchanged
+    assert data["dew_point"] == 50
+    assert data["wind_speed"] == 8
+    assert data["wind_speed_unit"] == "mph"
+    mock_garmin_client.get_activity_weather.assert_called_once_with(1)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
The activity-weather endpoint's values are NOT uniformly in the account's display unit (contrary to the assumption in #163). Verified against the raw API and a local weather station:

- TEMPERATURE is returned in Fahrenheit with no unit field, regardless of account. A metric account saw raw Fahrenheit mislabeled 'C' (e.g. 57 tagged C, which is impossible; 57F = 13.9C). Fix: treat as Fahrenheit and convert to the account unit (metric -> C, statute_us -> F).
- WIND is already in the account unit (station cross-check: 8 = km/h for a metric account, not mph). So it is not converted; a wind_speed_unit label (km/h metric, mph statute_us) is added instead.

Applies to temperature, apparent_temperature, dew_point.