### PR TITLE
feat: create completed strength activities with structured sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
 - ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
-- ✅ Structured Strength Activities (1 tool) - safely replace and verify completed activity sets
+- ✅ Structured Strength Activities (2 tools) - create completed strength activities or safely replace and verify their sets
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
 > **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
@@ -99,6 +99,36 @@ and is read back from Garmin for verification.
 For deterministic matching, pass exact Garmin identifiers instead:
 `{"category": "PUSH_UP", "name": "PUSH_UP"}`. `weight_kg` is converted to
 Garmin's internal unit only inside the server.
+
+`create_strength_training_activity` uses the same validated set format to
+create a completed manual strength activity. It does not create a planned
+workout for a watch. The tool first creates the private activity, attaches its
+sets, and verifies them with a read-back. By default, a newly created activity
+is deleted again if attaching or verifying its sets fails.
+
+```json
+{
+  "activity_name": "Upper Body",
+  "start_datetime": "2026-07-23T18:00:00",
+  "time_zone": "Europe/Warsaw",
+  "duration_minutes": 30,
+  "sets": [
+    {
+      "exercise": "barbell bench press",
+      "sets": 3,
+      "repetitions": 10,
+      "weight_kg": 60,
+      "duration_seconds": 35,
+      "rest_seconds": 90
+    }
+  ],
+  "dry_run": true
+}
+```
+
+Change `dry_run` to `false` and pass `confirm=true` only after reviewing the
+preview. Set `rollback_on_failure=false` only when an incomplete activity
+should deliberately remain in Garmin for manual repair.
 
 ### Intentionally Skipped Endpoints
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 
 - List recent activities with pagination support
 - Get detailed activity information
-- Edit activities: name, type, description/notes, event type, perceived effort (RPE), and feel
+- Edit activities: name, type, description/notes, event type, perceived effort (RPE), feel, and structured strength sets
 - Access health metrics (steps, heart rate, sleep, stress, respiration)
 - View body composition data
 - Track training status and readiness
@@ -41,6 +41,7 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
 - ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
+- ✅ Structured Strength Activities (1 tool) - safely replace and verify completed activity sets
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
 > **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
@@ -59,6 +60,45 @@ Two tools let you download a raw activity file to disk:
 3. Persisted config set via `set_fit_download_dir`.
 
 **First-run behavior:** if no directory is configured, `download_activity_file` returns `status: "needs_setup"`. The assistant will ask where you want to save files (suggesting the current directory as default), call `set_fit_download_dir` to persist your choice, and then retry the download automatically.
+
+### Structured Strength Activity Sets
+
+`set_activity_strength_exercise_sets` replaces the complete set list on an
+existing, completed `strength_training` activity. It is separate from
+`create_strength_workout`, which creates a planned workout for a watch.
+
+Use `dry_run=true` first. English exercise names are normalized and matched
+directly against Garmin's public exercise catalog; ambiguous matches are
+rejected rather than guessed. The catalog exposes identifier keys, not
+localized display names, so the server intentionally does not maintain a
+language-specific alias table. Callers should translate localized input to
+English or pass exact Garmin identifiers. A real update requires `confirm=true`
+and is read back from Garmin for verification.
+
+```json
+{
+  "activity_id": "12345678901",
+  "sets": [
+    {
+      "exercise": "barbell bench press",
+      "sets": 3,
+      "repetitions": 10,
+      "weight_kg": 60,
+      "duration_seconds": 35,
+      "rest_seconds": 90
+    },
+    {
+      "set_type": "REST",
+      "duration_seconds": 90
+    }
+  ],
+  "dry_run": true
+}
+```
+
+For deterministic matching, pass exact Garmin identifiers instead:
+`{"category": "PUSH_UP", "name": "PUSH_UP"}`. `weight_kg` is converted to
+Garmin's internal unit only inside the server.
 
 ### Intentionally Skipped Endpoints
 

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -29,6 +29,7 @@ from garmin_mcp import nutrition
 from garmin_mcp import workout_builders
 from garmin_mcp import courses
 from garmin_mcp import activity_analysis
+from garmin_mcp import strength_training
 
 
 def is_interactive_terminal() -> bool:
@@ -404,6 +405,7 @@ def main():
     workout_builders.configure(garmin_client)
     courses.configure(garmin_client)
     activity_analysis.configure(garmin_client)
+    strength_training.configure(garmin_client)
 
     # Create the MCP app, wrapped so the env-var filter can drop tools.
     # host/port only matter for the HTTP transports; stdio ignores them.
@@ -430,6 +432,7 @@ def main():
     app = workout_builders.register_tools(app)
     app = courses.register_tools(app)
     app = activity_analysis.register_tools(app)
+    app = strength_training.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/strength_training.py
+++ b/src/garmin_mcp/strength_training.py
@@ -1,0 +1,889 @@
+"""Structured strength-activity tools for Garmin Connect.
+
+Garmin stores completed strength sets separately from planned workouts.  This
+module owns the validation, exercise matching, timestamp handling, API payload
+construction, and read-after-write verification for that activity endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import re
+import unicodedata
+from datetime import datetime, timedelta, timezone
+from difflib import SequenceMatcher
+from functools import lru_cache
+from typing import Any, Dict, Iterable, List, Optional, Tuple, Union
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+import requests
+
+
+garmin_client = None
+
+GARMIN_EXERCISE_CATALOG_URL = (
+    "https://connect.garmin.com/web-data/exercises/Exercises.json"
+)
+
+_IDENTIFIER_RE = re.compile(r"^[A-Z0-9_]+$")
+
+
+class StrengthTrainingError(ValueError):
+    """Raised when a structured strength request is unsafe or invalid."""
+
+
+def configure(client) -> None:
+    """Configure the module with the shared Garmin client."""
+    global garmin_client
+    garmin_client = client
+
+
+def _json_result(payload: Dict[str, Any]) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False)
+
+
+def _normalise_label(value: str) -> str:
+    """Return a comparison label independent of punctuation and accents."""
+    value = unicodedata.normalize("NFKD", value)
+    value = "".join(char for char in value if not unicodedata.combining(char))
+    value = value.lower().replace("_", " ").replace("-", " ")
+    value = re.sub(r"[^a-z0-9]+", " ", value)
+    return " ".join(value.split())
+
+
+def _normalise_identifier(value: Any, field: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise StrengthTrainingError(f"{field} must be a non-empty string")
+    identifier = value.strip().upper().replace(" ", "_").replace("-", "_")
+    if not _IDENTIFIER_RE.fullmatch(identifier):
+        raise StrengthTrainingError(
+            f"{field} must contain only letters, digits, and underscores"
+        )
+    return identifier
+
+
+def _catalog_pairs_from_payload(payload: Any) -> Tuple[Tuple[str, str], ...]:
+    if not isinstance(payload, dict):
+        raise StrengthTrainingError("Garmin exercise catalog is not a JSON object")
+    categories = payload.get("categories")
+    if not isinstance(categories, dict):
+        raise StrengthTrainingError(
+            "Garmin exercise catalog does not contain categories"
+        )
+
+    pairs = set()
+    for category, category_payload in categories.items():
+        if not isinstance(category_payload, dict):
+            continue
+        exercises = category_payload.get("exercises")
+        if not isinstance(exercises, dict):
+            continue
+        category_key = _normalise_identifier(category, "catalog category")
+        for exercise_name in exercises:
+            name_key = _normalise_identifier(exercise_name, "catalog exercise name")
+            pairs.add((category_key, name_key))
+
+    if not pairs:
+        raise StrengthTrainingError("Garmin exercise catalog is empty")
+    return tuple(sorted(pairs))
+
+
+@lru_cache(maxsize=1)
+def _load_garmin_exercise_catalog() -> Tuple[Tuple[str, str], ...]:
+    """Fetch and parse Garmin's public catalog once per server process."""
+    response = requests.get(
+        GARMIN_EXERCISE_CATALOG_URL,
+        timeout=10,
+        headers={"User-Agent": "garmin-mcp/0.1"},
+    )
+    response.raise_for_status()
+    return _catalog_pairs_from_payload(response.json())
+
+
+def _catalog_or_error() -> Tuple[Tuple[str, str], ...]:
+    try:
+        return _load_garmin_exercise_catalog()
+    except StrengthTrainingError:
+        raise
+    except Exception as exc:
+        raise StrengthTrainingError(
+            "Could not load Garmin's exercise catalog. "
+            "Provide exact category/name identifiers or try again later."
+        ) from exc
+
+
+def _match_score(query: str, candidate: str) -> float:
+    query_tokens = set(query.split())
+    candidate_tokens = set(candidate.split())
+    if not query_tokens or not candidate_tokens:
+        return 0.0
+    shared = len(query_tokens & candidate_tokens)
+    if shared == 0:
+        return 0.0
+    token_f1 = (2.0 * shared) / (len(query_tokens) + len(candidate_tokens))
+    ordered_similarity = SequenceMatcher(None, query, candidate).ratio()
+    return (0.65 * ordered_similarity) + (0.35 * token_f1)
+
+
+def _exercise_suggestions(
+    query: str,
+    catalog: Iterable[Tuple[str, str]],
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    scored = []
+    for category, name in catalog:
+        name_label = _normalise_label(name)
+        category_name_label = _normalise_label(f"{category} {name}")
+        score = max(
+            _match_score(query, name_label),
+            _match_score(query, category_name_label),
+        )
+        if score > 0:
+            scored.append((score, category, name))
+    scored.sort(key=lambda item: (-item[0], item[1], item[2]))
+    return [
+        {"category": category, "name": name, "score": round(score, 3)}
+        for score, category, name in scored[:limit]
+    ]
+
+
+def _resolve_exercise_query(value: Any) -> Dict[str, Any]:
+    if not isinstance(value, str) or not value.strip():
+        raise StrengthTrainingError("exercise must be a non-empty string")
+
+    query = _normalise_label(value)
+    catalog = _catalog_or_error()
+    exact = []
+    for category, name in catalog:
+        if query in {
+            _normalise_label(name),
+            _normalise_label(f"{category} {name}"),
+        }:
+            exact.append((category, name))
+
+    if len(exact) == 1:
+        category, name = exact[0]
+        return {
+            "input": value,
+            "category": category,
+            "name": name,
+            "match_type": "catalog_exact",
+            "score": 1.0,
+        }
+    if len(exact) > 1:
+        options = ", ".join(f"{category}/{name}" for category, name in exact[:8])
+        raise StrengthTrainingError(
+            f"Exercise '{value}' is ambiguous. Use category/name. Matches: {options}"
+        )
+
+    suggestions = _exercise_suggestions(query, catalog)
+    if not suggestions:
+        raise StrengthTrainingError(
+            f"No Garmin exercise matches '{value}'. Use exact category/name identifiers."
+        )
+
+    best = suggestions[0]
+    runner_up_score = suggestions[1]["score"] if len(suggestions) > 1 else 0.0
+    if best["score"] < 0.82 or best["score"] - runner_up_score < 0.06:
+        options = ", ".join(
+            f"{item['category']}/{item['name']} ({item['score']:.3f})"
+            for item in suggestions
+        )
+        raise StrengthTrainingError(
+            f"No confident Garmin exercise match for '{value}'. "
+            f"Closest candidates: {options}"
+        )
+
+    return {
+        "input": value,
+        "category": best["category"],
+        "name": best["name"],
+        "match_type": "catalog_fuzzy",
+        "score": best["score"],
+    }
+
+
+def _resolve_exercise_spec(item: Dict[str, Any], index: int) -> Dict[str, Any]:
+    exercise = item.get("exercise")
+    if exercise not in (None, ""):
+        return _resolve_exercise_query(exercise)
+
+    if item.get("category") in (None, "") or item.get("name") in (None, ""):
+        raise StrengthTrainingError(
+            f"sets[{index}] must include exercise or exact category/name"
+        )
+
+    category = _normalise_identifier(item["category"], f"sets[{index}].category")
+    name = _normalise_identifier(item["name"], f"sets[{index}].name")
+
+    try:
+        catalog = _load_garmin_exercise_catalog()
+    except Exception:
+        # Exact identifiers remain usable when Garmin's public catalog endpoint
+        # is temporarily unavailable. The activity endpoint remains authoritative.
+        return {
+            "input": f"{category}/{name}",
+            "category": category,
+            "name": name,
+            "match_type": "provided_unverified",
+            "score": None,
+        }
+
+    if (category, name) not in set(catalog):
+        category_names = [candidate for cat, candidate in catalog if cat == category]
+        nearby = _exercise_suggestions(
+            _normalise_label(name),
+            ((category, candidate) for candidate in category_names),
+        )
+        options = ", ".join(item["name"] for item in nearby) or "none"
+        raise StrengthTrainingError(
+            f"sets[{index}] contains unknown Garmin exercise "
+            f"{category}/{name}. Closest names in that category: {options}"
+        )
+
+    return {
+        "input": f"{category}/{name}",
+        "category": category,
+        "name": name,
+        "match_type": "provided",
+        "score": 1.0,
+    }
+
+
+def _finite_number(
+    value: Any,
+    field: str,
+    *,
+    minimum: Optional[float] = None,
+    allow_none: bool = False,
+) -> Optional[float]:
+    if value in (None, "") and allow_none:
+        return None
+    if isinstance(value, bool):
+        raise StrengthTrainingError(f"{field} must be a number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError) as exc:
+        raise StrengthTrainingError(f"{field} must be a number") from exc
+    if not math.isfinite(number):
+        raise StrengthTrainingError(f"{field} must be finite")
+    if minimum is not None and number < minimum:
+        raise StrengthTrainingError(f"{field} must be at least {minimum:g}")
+    return number
+
+
+def _positive_integer(value: Any, field: str, default: int = 1) -> int:
+    if value in (None, ""):
+        return default
+    if isinstance(value, bool):
+        raise StrengthTrainingError(f"{field} must be a positive integer")
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise StrengthTrainingError(f"{field} must be a positive integer") from exc
+    if number <= 0 or str(number) != str(value).strip():
+        raise StrengthTrainingError(f"{field} must be a positive integer")
+    return number
+
+
+def _non_negative_integer(
+    value: Any,
+    field: str,
+    *,
+    allow_none: bool = True,
+) -> Optional[int]:
+    if value in (None, "") and allow_none:
+        return None
+    if isinstance(value, bool):
+        raise StrengthTrainingError(f"{field} must be a non-negative integer")
+    try:
+        number = int(value)
+    except (TypeError, ValueError) as exc:
+        raise StrengthTrainingError(
+            f"{field} must be a non-negative integer"
+        ) from exc
+    if number < 0 or str(number) != str(value).strip():
+        raise StrengthTrainingError(f"{field} must be a non-negative integer")
+    return number
+
+
+def _parse_local_datetime(value: Any, time_zone: str, field: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise StrengthTrainingError(f"{field} must be a non-empty ISO date-time")
+    try:
+        zone = ZoneInfo(time_zone)
+    except ZoneInfoNotFoundError as exc:
+        raise StrengthTrainingError(f"Unknown IANA time zone '{time_zone}'") from exc
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise StrengthTrainingError(f"{field} must be an ISO date-time") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=zone)
+    return parsed.astimezone(zone)
+
+
+def _parse_gmt_datetime(value: Any, field: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise StrengthTrainingError(f"{field} is missing")
+    try:
+        parsed = datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise StrengthTrainingError(f"{field} is not an ISO date-time") from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc)
+
+
+def _parse_set_start_time(value: Any, activity_start: datetime) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise StrengthTrainingError("start_time must be a non-empty string")
+    raw = value.strip()
+
+    clock_match = re.fullmatch(
+        r"(?P<hour>\d{1,2}):(?P<minute>\d{2})(?::(?P<second>\d{2}))?",
+        raw,
+    )
+    if clock_match:
+        hour = int(clock_match.group("hour"))
+        minute = int(clock_match.group("minute"))
+        second = int(clock_match.group("second") or 0)
+        if hour > 23 or minute > 59 or second > 59:
+            raise StrengthTrainingError(
+                "start_time clock must be HH:MM or HH:MM:SS"
+            )
+        return activity_start.replace(
+            hour=hour,
+            minute=minute,
+            second=second,
+            microsecond=0,
+        )
+
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise StrengthTrainingError(
+            "start_time must be ISO date-time, HH:MM, or HH:MM:SS"
+        ) from exc
+    if parsed.tzinfo is None:
+        return parsed.replace(tzinfo=activity_start.tzinfo)
+    return parsed.astimezone(activity_start.tzinfo)
+
+
+def _garmin_utc_timestamp(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.0")
+
+
+def _activity_type_key(activity: Dict[str, Any]) -> Optional[str]:
+    for key in ("activityTypeDTO", "activityType"):
+        value = activity.get(key)
+        if isinstance(value, dict) and value.get("typeKey"):
+            return str(value["typeKey"])
+    return None
+
+
+def _activity_start(
+    activity: Dict[str, Any],
+    provided_start: Optional[str],
+    time_zone: str,
+) -> datetime:
+    if provided_start:
+        return _parse_local_datetime(
+            provided_start, time_zone, "activity_start_datetime"
+        )
+
+    summary = activity.get("summaryDTO")
+    if not isinstance(summary, dict):
+        summary = {}
+
+    gmt_value = summary.get("startTimeGMT") or activity.get("startTimeGMT")
+    if gmt_value:
+        return _parse_gmt_datetime(gmt_value, "activity startTimeGMT")
+
+    local_value = summary.get("startTimeLocal") or activity.get("startTimeLocal")
+    if local_value:
+        return _parse_local_datetime(
+            str(local_value).replace(" ", "T"),
+            time_zone,
+            "activity startTimeLocal",
+        )
+
+    raise StrengthTrainingError(
+        "Activity start time is unavailable. Provide activity_start_datetime."
+    )
+
+
+def _prepare_strength_sets(
+    set_specs: List[Dict[str, Any]],
+    activity_start: datetime,
+) -> Tuple[List[Dict[str, Any]], List[Dict[str, Any]]]:
+    if not isinstance(set_specs, list) or not set_specs:
+        raise StrengthTrainingError("sets must be a non-empty list")
+    if activity_start.tzinfo is None:
+        raise StrengthTrainingError("activity_start must include a time zone")
+
+    exercise_sets: List[Dict[str, Any]] = []
+    matches: List[Dict[str, Any]] = []
+    cursor = activity_start
+    previous_end: Optional[datetime] = None
+
+    for index, raw_item in enumerate(set_specs):
+        if not isinstance(raw_item, dict):
+            raise StrengthTrainingError(f"sets[{index}] must be an object")
+        item = dict(raw_item)
+
+        set_type = str(item.get("set_type", "ACTIVE")).strip().upper()
+        if set_type not in {"ACTIVE", "REST"}:
+            raise StrengthTrainingError(
+                f"sets[{index}].set_type must be ACTIVE or REST"
+            )
+
+        repeat_count = _positive_integer(
+            item.get("sets"), f"sets[{index}].sets"
+        )
+        repetitions = _non_negative_integer(
+            item.get("repetitions"),
+            f"sets[{index}].repetitions",
+        )
+        weight_kg = _finite_number(
+            item.get("weight_kg"),
+            f"sets[{index}].weight_kg",
+            minimum=0,
+            allow_none=True,
+        )
+        default_duration = 90.0 if set_type == "REST" else 30.0
+        duration_seconds = _finite_number(
+            item.get("duration_seconds", default_duration),
+            f"sets[{index}].duration_seconds",
+            minimum=0.001,
+        )
+        default_rest = 0.0 if set_type == "REST" else 90.0
+        rest_seconds = _finite_number(
+            item.get("rest_seconds", default_rest),
+            f"sets[{index}].rest_seconds",
+            minimum=0,
+        )
+
+        if set_type == "ACTIVE":
+            match = _resolve_exercise_spec(item, index)
+            matches.append({**match, "input_index": index})
+        else:
+            if any(
+                item.get(field) not in (None, "")
+                for field in ("exercise", "category", "name")
+            ):
+                raise StrengthTrainingError(
+                    f"sets[{index}] is REST and must not specify an exercise"
+                )
+            if repetitions is not None or weight_kg is not None:
+                raise StrengthTrainingError(
+                    f"sets[{index}] is REST and must not specify repetitions or weight_kg"
+                )
+            match = None
+
+        if item.get("start_time") not in (None, ""):
+            first_start = _parse_set_start_time(
+                item["start_time"], activity_start
+            )
+        elif item.get("offset_seconds") not in (None, ""):
+            offset_seconds = _finite_number(
+                item["offset_seconds"],
+                f"sets[{index}].offset_seconds",
+                minimum=0,
+            )
+            first_start = activity_start + timedelta(seconds=offset_seconds)
+        elif item.get("offset_minutes") not in (None, ""):
+            offset_minutes = _finite_number(
+                item["offset_minutes"],
+                f"sets[{index}].offset_minutes",
+                minimum=0,
+            )
+            first_start = activity_start + timedelta(minutes=offset_minutes)
+        else:
+            first_start = cursor
+
+        if (
+            item.get("offset_seconds") not in (None, "")
+            and item.get("offset_minutes") not in (None, "")
+        ):
+            raise StrengthTrainingError(
+                f"sets[{index}] cannot specify both offset_seconds and offset_minutes"
+            )
+        if item.get("start_time") not in (None, "") and any(
+            item.get(field) not in (None, "")
+            for field in ("offset_seconds", "offset_minutes")
+        ):
+            raise StrengthTrainingError(
+                f"sets[{index}] cannot combine start_time with an offset"
+            )
+
+        for repeat_index in range(repeat_count):
+            set_start = first_start + timedelta(
+                seconds=repeat_index * (duration_seconds + rest_seconds)
+            )
+            if set_start < activity_start:
+                raise StrengthTrainingError(
+                    f"sets[{index}] starts before the activity"
+                )
+            if previous_end is not None and set_start < previous_end:
+                raise StrengthTrainingError(
+                    f"sets[{index}] overlaps or precedes the previous set"
+                )
+
+            if set_type == "ACTIVE":
+                exercises = [
+                    {
+                        "category": match["category"],
+                        "name": match["name"],
+                        "probability": 100.0,
+                    }
+                ]
+                internal_weight = (
+                    float(weight_kg) * 1000.0
+                    if weight_kg is not None and weight_kg > 0
+                    else -1.0
+                )
+            else:
+                exercises = []
+                internal_weight = None
+
+            exercise_sets.append(
+                {
+                    "exercises": exercises,
+                    "duration": float(duration_seconds),
+                    "repetitionCount": (
+                        repetitions if set_type == "ACTIVE" else None
+                    ),
+                    "weight": internal_weight,
+                    "setType": set_type,
+                    "startTime": _garmin_utc_timestamp(set_start),
+                    "wktStepIndex": None,
+                    "messageIndex": None,
+                }
+            )
+            cursor = max(
+                cursor,
+                set_start + timedelta(seconds=duration_seconds + rest_seconds),
+            )
+            previous_end = set_start + timedelta(seconds=duration_seconds)
+
+    return exercise_sets, matches
+
+
+def _validate_sets_within_activity(
+    activity: Dict[str, Any],
+    activity_start: datetime,
+    exercise_sets: List[Dict[str, Any]],
+) -> None:
+    summary = activity.get("summaryDTO")
+    if not isinstance(summary, dict):
+        summary = {}
+    raw_duration = summary.get("duration") or activity.get("duration")
+    if raw_duration in (None, ""):
+        return
+    duration = _finite_number(
+        raw_duration,
+        "activity duration",
+        minimum=0.001,
+    )
+    activity_end = activity_start.astimezone(timezone.utc) + timedelta(
+        seconds=duration
+    )
+    for index, item in enumerate(exercise_sets):
+        set_start = _parse_gmt_datetime(
+            item.get("startTime"),
+            f"exerciseSets[{index}].startTime",
+        )
+        set_end = set_start + timedelta(seconds=float(item["duration"]))
+        if set_end > activity_end + timedelta(seconds=1):
+            overrun = (set_end - activity_end).total_seconds()
+            raise StrengthTrainingError(
+                f"exerciseSets[{index}] ends {overrun:.1f}s after the activity. "
+                "Adjust set timing/rests or the activity duration."
+            )
+
+
+def _display_exercise_sets(exercise_sets: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    displayed = []
+    for item in exercise_sets:
+        converted = dict(item)
+        internal_weight = converted.pop("weight", None)
+        if converted.get("setType") == "ACTIVE":
+            converted["weightKg"] = (
+                internal_weight / 1000.0
+                if isinstance(internal_weight, (int, float))
+                and internal_weight > 0
+                else None
+            )
+        displayed.append(converted)
+    return displayed
+
+
+def _extract_readback_sets(value: Any) -> Optional[List[Dict[str, Any]]]:
+    if isinstance(value, dict):
+        sets = value.get("exerciseSets")
+        if isinstance(sets, list):
+            return sets
+    if isinstance(value, list):
+        return value
+    return None
+
+
+def _numbers_equal(left: Any, right: Any, tolerance: float = 0.01) -> bool:
+    if left is None or right is None:
+        return left is None and right is None
+    try:
+        return abs(float(left) - float(right)) <= tolerance
+    except (TypeError, ValueError):
+        return False
+
+
+def _weight_key(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return math.inf
+    return None if number <= 0 else round(number, 3)
+
+
+def _timestamp_key(value: Any) -> Optional[str]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.astimezone(timezone.utc).replace(microsecond=0).isoformat()
+
+
+def _verify_exercise_sets(
+    expected: List[Dict[str, Any]],
+    readback: Any,
+) -> Tuple[bool, List[str]]:
+    actual = _extract_readback_sets(readback)
+    if actual is None:
+        return False, ["read-back response does not contain exerciseSets"]
+    if len(actual) != len(expected):
+        return False, [
+            f"set count differs: expected {len(expected)}, got {len(actual)}"
+        ]
+
+    differences = []
+    for index, (wanted, received) in enumerate(zip(expected, actual)):
+        prefix = f"exerciseSets[{index}]"
+        if not isinstance(received, dict):
+            differences.append(f"{prefix} is not an object")
+            continue
+        if received.get("setType") != wanted.get("setType"):
+            differences.append(
+                f"{prefix}.setType expected {wanted.get('setType')}, "
+                f"got {received.get('setType')}"
+            )
+        if not _numbers_equal(received.get("duration"), wanted.get("duration")):
+            differences.append(f"{prefix}.duration differs")
+        if received.get("repetitionCount") != wanted.get("repetitionCount"):
+            differences.append(f"{prefix}.repetitionCount differs")
+        if _weight_key(received.get("weight")) != _weight_key(wanted.get("weight")):
+            differences.append(f"{prefix}.weight differs")
+        if _timestamp_key(received.get("startTime")) != _timestamp_key(
+            wanted.get("startTime")
+        ):
+            differences.append(f"{prefix}.startTime differs")
+
+        wanted_exercises = wanted.get("exercises") or []
+        received_exercises = received.get("exercises") or []
+        if wanted_exercises:
+            wanted_pair = (
+                wanted_exercises[0].get("category"),
+                wanted_exercises[0].get("name"),
+            )
+            received_pairs = {
+                (item.get("category"), item.get("name"))
+                for item in received_exercises
+                if isinstance(item, dict)
+            }
+            if wanted_pair not in received_pairs:
+                differences.append(
+                    f"{prefix}.exercises does not contain "
+                    f"{wanted_pair[0]}/{wanted_pair[1]}"
+                )
+        elif received_exercises:
+            differences.append(f"{prefix}.exercises expected an empty list")
+
+    return not differences, differences
+
+
+def _response_summary(response: Any) -> Any:
+    if response is None or isinstance(
+        response, (str, int, float, bool, dict, list)
+    ):
+        return response
+    status_code = getattr(response, "status_code", None)
+    return {"status_code": status_code} if status_code is not None else str(response)
+
+
+def _replace_activity_strength_sets(
+    activity_id: int,
+    exercise_sets: List[Dict[str, Any]],
+) -> Any:
+    base_url = getattr(
+        garmin_client,
+        "garmin_connect_activity",
+        "/activity-service/activity",
+    )
+    url = f"{base_url}/{activity_id}/exerciseSets"
+    payload = {"activityId": activity_id, "exerciseSets": exercise_sets}
+    return garmin_client.client.put(
+        "connectapi",
+        url,
+        json=payload,
+        api=True,
+    )
+
+
+def _validate_activity_id(activity_id: Union[int, str]) -> int:
+    if isinstance(activity_id, bool):
+        raise StrengthTrainingError("activity_id must be a positive integer")
+    try:
+        parsed = int(activity_id)
+    except (TypeError, ValueError) as exc:
+        raise StrengthTrainingError("activity_id must be a positive integer") from exc
+    if parsed <= 0:
+        raise StrengthTrainingError("activity_id must be a positive integer")
+    return parsed
+
+
+def register_tools(app):
+    """Register structured strength-activity tools."""
+
+    @app.tool()
+    async def set_activity_strength_exercise_sets(
+        activity_id: Union[int, str],
+        sets: List[Dict[str, Any]],
+        activity_start_datetime: Optional[str] = None,
+        time_zone: str = "UTC",
+        confirm: bool = False,
+        dry_run: bool = False,
+    ) -> str:
+        """Replace all structured sets on a completed Garmin strength activity.
+
+        This is a full replacement, not a partial patch. Use dry_run=true first
+        to validate exercise matching, weights, repetitions, and timestamps
+        without writing. A real update requires confirm=true and is verified by
+        reading the saved sets back from Garmin.
+
+        Each item in sets may contain:
+          - exercise: an English name matched against Garmin's catalog; or
+          - category and name: exact Garmin catalog identifiers
+          - sets: number of identical sets to expand (default 1)
+          - repetitions: non-negative repetition count
+          - weight_kg: external load in kilograms; omit for bodyweight
+          - duration_seconds: set duration (default 30; REST default 90)
+          - rest_seconds: spacing before the next automatic set (default 90)
+          - set_type: ACTIVE or REST (default ACTIVE)
+          - start_time: ISO date-time, HH:MM, or HH:MM:SS
+          - offset_seconds or offset_minutes: offset from activity start
+
+        Garmin's public exercise catalog is used for name matching. It exposes
+        identifier keys rather than localized labels, so callers should
+        translate localized input to English or pass exact category/name
+        identifiers. Ambiguous matches are rejected instead of guessed.
+
+        Args:
+            activity_id: Existing Garmin strength activity ID
+            sets: Complete replacement list of strength set specifications
+            activity_start_datetime: Optional ISO start time used for offsets
+            time_zone: IANA zone for naive/local times (default UTC)
+            confirm: Must be true for a write
+            dry_run: Validate and preview without changing Garmin
+        """
+        try:
+            parsed_activity_id = _validate_activity_id(activity_id)
+            if not dry_run and not confirm:
+                raise StrengthTrainingError(
+                    "confirm=true is required because this replaces all "
+                    "exercise sets on the activity"
+                )
+
+            activity = garmin_client.get_activity(parsed_activity_id)
+            if not isinstance(activity, dict) or not activity:
+                raise StrengthTrainingError(
+                    f"Activity {parsed_activity_id} was not found"
+                )
+            type_key = _activity_type_key(activity)
+            if type_key and type_key != "strength_training":
+                raise StrengthTrainingError(
+                    f"Activity {parsed_activity_id} has type '{type_key}', "
+                    "not 'strength_training'"
+                )
+
+            start = _activity_start(
+                activity,
+                activity_start_datetime,
+                time_zone,
+            )
+            exercise_sets, matches = _prepare_strength_sets(sets, start)
+            _validate_sets_within_activity(activity, start, exercise_sets)
+            preview = {
+                "activityId": parsed_activity_id,
+                "exerciseSets": _display_exercise_sets(exercise_sets),
+            }
+
+            if dry_run:
+                return _json_result(
+                    {
+                        "success": True,
+                        "dry_run": True,
+                        "activity_id": parsed_activity_id,
+                        "replacement_set_count": len(exercise_sets),
+                        "matches": matches,
+                        "preview": preview,
+                        "warning": (
+                            "No changes were made. A confirmed call replaces "
+                            "the activity's complete exercise-set list."
+                        ),
+                    }
+                )
+
+            response = _replace_activity_strength_sets(
+                parsed_activity_id,
+                exercise_sets,
+            )
+            readback = garmin_client.get_activity_exercise_sets(
+                parsed_activity_id
+            )
+            verified, differences = _verify_exercise_sets(
+                exercise_sets,
+                readback,
+            )
+            result = {
+                "success": verified,
+                "written": True,
+                "verified": verified,
+                "activity_id": parsed_activity_id,
+                "replacement_set_count": len(exercise_sets),
+                "matches": matches,
+                "api_response": _response_summary(response),
+                "exercise_sets": readback,
+            }
+            if differences:
+                result["verification_errors"] = differences
+                result["error"] = (
+                    "Garmin accepted the update, but read-back verification failed"
+                )
+            return _json_result(result)
+        except Exception as exc:
+            return _json_result(
+                {
+                    "success": False,
+                    "activity_id": str(activity_id),
+                    "error": str(exc),
+                }
+            )
+
+    return app

--- a/src/garmin_mcp/strength_training.py
+++ b/src/garmin_mcp/strength_training.py
@@ -375,6 +375,10 @@ def _garmin_utc_timestamp(value: datetime) -> str:
     return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.0")
 
 
+def _garmin_local_timestamp(value: datetime) -> str:
+    return value.replace(tzinfo=None).strftime("%Y-%m-%dT%H:%M:%S.000")
+
+
 def _activity_type_key(activity: Dict[str, Any]) -> Optional[str]:
     for key in ("activityTypeDTO", "activityType"):
         value = activity.get(key)
@@ -727,6 +731,31 @@ def _response_summary(response: Any) -> Any:
     return {"status_code": status_code} if status_code is not None else str(response)
 
 
+def _find_activity_id(value: Any) -> Optional[int]:
+    """Find a positive activityId in the small response returned by Garmin."""
+    if isinstance(value, dict):
+        for key in ("activityId", "activity_id"):
+            candidate = value.get(key)
+            if isinstance(candidate, bool):
+                continue
+            try:
+                parsed = int(candidate)
+            except (TypeError, ValueError):
+                continue
+            if parsed > 0:
+                return parsed
+        for candidate in value.values():
+            found = _find_activity_id(candidate)
+            if found is not None:
+                return found
+    elif isinstance(value, list):
+        for candidate in value:
+            found = _find_activity_id(candidate)
+            if found is not None:
+                return found
+    return None
+
+
 def _replace_activity_strength_sets(
     activity_id: int,
     exercise_sets: List[Dict[str, Any]],
@@ -882,6 +911,168 @@ def register_tools(app):
                 {
                     "success": False,
                     "activity_id": str(activity_id),
+                    "error": str(exc),
+                }
+            )
+
+    @app.tool()
+    async def create_strength_training_activity(
+        activity_name: str,
+        start_datetime: str,
+        time_zone: str,
+        duration_minutes: float,
+        sets: List[Dict[str, Any]],
+        confirm: bool = False,
+        dry_run: bool = False,
+        rollback_on_failure: bool = True,
+    ) -> str:
+        """Create a completed manual strength activity with structured sets.
+
+        This creates an activity record, not a planned workout for a watch.
+        Use dry_run=true first to validate the exercise matches and complete
+        timeline without changing Garmin. A real create requires confirm=true.
+
+        The activity is created as private `strength_training`, then its full
+        exercise-set list is written and read back for verification. If the set
+        write or verification fails, rollback_on_failure=true removes the new
+        empty/incomplete activity.
+
+        Set fields are identical to set_activity_strength_exercise_sets:
+        exercise or exact category/name, sets, repetitions, weight_kg,
+        duration_seconds, rest_seconds, set_type, start_time, and offsets.
+
+        Args:
+            activity_name: Name shown in Garmin Connect
+            start_datetime: ISO local or timezone-aware activity start
+            time_zone: IANA time zone, e.g. Europe/Warsaw
+            duration_minutes: Positive activity duration in minutes
+            sets: Complete structured set specification
+            confirm: Must be true for a real create
+            dry_run: Validate and preview without changing Garmin
+            rollback_on_failure: Delete a newly created incomplete activity
+        """
+        created_activity_id: Optional[int] = None
+        activity_response: Any = None
+        matches: List[Dict[str, Any]] = []
+        try:
+            name = activity_name.strip()
+            if not name:
+                raise StrengthTrainingError(
+                    "activity_name must be a non-empty string"
+                )
+            duration = _finite_number(
+                duration_minutes,
+                "duration_minutes",
+                minimum=0.001,
+            )
+            if not dry_run and not confirm:
+                raise StrengthTrainingError(
+                    "confirm=true is required to create a Garmin activity"
+                )
+
+            local_start = _parse_local_datetime(
+                start_datetime,
+                time_zone,
+                "start_datetime",
+            )
+            exercise_sets, matches = _prepare_strength_sets(sets, local_start)
+            _validate_sets_within_activity(
+                {"summaryDTO": {"duration": duration * 60.0}},
+                local_start,
+                exercise_sets,
+            )
+            preview = {
+                "activityName": name,
+                "activityType": "strength_training",
+                "startTimeLocal": _garmin_local_timestamp(local_start),
+                "timeZone": time_zone,
+                "durationMinutes": duration,
+                "exerciseSets": _display_exercise_sets(exercise_sets),
+            }
+
+            if dry_run:
+                return _json_result(
+                    {
+                        "success": True,
+                        "dry_run": True,
+                        "set_count": len(exercise_sets),
+                        "matches": matches,
+                        "preview": preview,
+                        "warning": "No activity was created.",
+                    }
+                )
+
+            activity_response = garmin_client.create_manual_activity(
+                start_datetime=_garmin_local_timestamp(local_start),
+                time_zone=time_zone,
+                type_key="strength_training",
+                distance_km=0.0,
+                duration_min=duration,
+                activity_name=name,
+            )
+            created_activity_id = _find_activity_id(activity_response)
+            if created_activity_id is None:
+                raise StrengthTrainingError(
+                    "Garmin created an activity response without an activityId; "
+                    "structured sets could not be attached"
+                )
+
+            try:
+                write_response = _replace_activity_strength_sets(
+                    created_activity_id,
+                    exercise_sets,
+                )
+                readback = garmin_client.get_activity_exercise_sets(
+                    created_activity_id
+                )
+                verified, differences = _verify_exercise_sets(
+                    exercise_sets,
+                    readback,
+                )
+                if not verified:
+                    details = "; ".join(differences)
+                    raise StrengthTrainingError(
+                        "Read-back verification failed after creating the "
+                        f"activity: {details}"
+                    )
+            except Exception as attach_error:
+                failure = {
+                    "success": False,
+                    "activity_created": True,
+                    "activity_id": created_activity_id,
+                    "error": str(attach_error),
+                    "matches": matches,
+                }
+                if rollback_on_failure:
+                    try:
+                        garmin_client.delete_activity(created_activity_id)
+                        failure["rolled_back"] = True
+                    except Exception as rollback_error:
+                        failure["rolled_back"] = False
+                        failure["rollback_error"] = str(rollback_error)
+                else:
+                    failure["rolled_back"] = False
+                return _json_result(failure)
+
+            return _json_result(
+                {
+                    "success": True,
+                    "activity_created": True,
+                    "verified": True,
+                    "activity_id": created_activity_id,
+                    "set_count": len(exercise_sets),
+                    "matches": matches,
+                    "activity_response": _response_summary(activity_response),
+                    "set_write_response": _response_summary(write_response),
+                    "exercise_sets": readback,
+                }
+            )
+        except Exception as exc:
+            return _json_result(
+                {
+                    "success": False,
+                    "activity_id": created_activity_id,
+                    "activity_response": _response_summary(activity_response),
                     "error": str(exc),
                 }
             )

--- a/tests/integration/test_strength_training_tools.py
+++ b/tests/integration/test_strength_training_tools.py
@@ -1,0 +1,315 @@
+"""Integration tests for structured strength activity MCP tools."""
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import strength_training
+
+
+CATALOG = (
+    ("PULL_UP", "PULL_UP"),
+    ("PUSH_UP", "PUSH_UP"),
+    ("SQUAT", "BARBELL_BACK_SQUAT"),
+)
+
+
+@pytest.fixture
+def strength_client(monkeypatch):
+    client = Mock()
+    client.garmin_connect_activity = "/activity-service/activity"
+    client.client = Mock()
+    client.client.put = Mock(return_value={"accepted": True})
+    client.get_activity = Mock(
+        return_value={
+            "activityId": 12345678901,
+            "activityTypeDTO": {"typeKey": "strength_training"},
+            "summaryDTO": {
+                "startTimeGMT": "2026-07-23T08:00:00.0",
+                "startTimeLocal": "2026-07-23T10:00:00.0",
+                "duration": 3600.0,
+            },
+        }
+    )
+    client.get_activity_exercise_sets = Mock(return_value={})
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", lambda: CATALOG
+    )
+    strength_training.configure(client)
+    return client
+
+
+@pytest.fixture
+def strength_app(strength_client):
+    app = FastMCP("Test Structured Strength")
+    return strength_training.register_tools(app)
+
+
+def _data(result):
+    return json.loads(result[0][0].text)
+
+
+@pytest.mark.asyncio
+async def test_dry_run_resolves_and_expands_sets_without_writing(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": "12345678901",
+            "sets": [
+                {
+                    "exercise": "push up",
+                    "sets": 3,
+                    "repetitions": 10,
+                    "duration_seconds": 35,
+                    "rest_seconds": 85,
+                }
+            ],
+            "dry_run": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is True
+    assert data["dry_run"] is True
+    assert data["replacement_set_count"] == 3
+    assert data["matches"][0]["category"] == "PUSH_UP"
+    assert len(data["preview"]["exerciseSets"]) == 3
+    strength_client.get_activity.assert_called_once_with(12345678901)
+    strength_client.client.put.assert_not_called()
+    strength_client.get_activity_exercise_sets.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_write_requires_explicit_confirmation(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [{"exercise": "push up", "repetitions": 10}],
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "confirm=true is required" in data["error"]
+    strength_client.get_activity.assert_not_called()
+    strength_client.client.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_confirmed_write_uses_exercise_sets_endpoint_and_verifies_readback(
+    strength_app, strength_client
+):
+    written_payload = {}
+
+    def capture_put(service, url, *, json, api):
+        written_payload.update(json)
+        assert service == "connectapi"
+        assert url == "/activity-service/activity/12345678901/exerciseSets"
+        assert api is True
+        return {"accepted": True}
+
+    strength_client.client.put.side_effect = capture_put
+    strength_client.get_activity_exercise_sets.side_effect = (
+        lambda activity_id: written_payload
+    )
+
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": "12345678901",
+            "sets": [
+                {
+                    "category": "PUSH_UP",
+                    "name": "PUSH_UP",
+                    "sets": 2,
+                    "repetitions": 12,
+                    "weight_kg": 5,
+                    "duration_seconds": 40,
+                    "rest_seconds": 80,
+                }
+            ],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is True
+    assert data["written"] is True
+    assert data["verified"] is True
+    assert written_payload["activityId"] == 12345678901
+    assert len(written_payload["exerciseSets"]) == 2
+    assert written_payload["exerciseSets"][0]["weight"] == 5000.0
+    assert written_payload["exerciseSets"][0]["startTime"] == (
+        "2026-07-23T08:00:00.0"
+    )
+    assert written_payload["exerciseSets"][1]["startTime"] == (
+        "2026-07-23T08:02:00.0"
+    )
+    strength_client.get_activity_exercise_sets.assert_called_once_with(
+        12345678901
+    )
+
+
+@pytest.mark.asyncio
+async def test_non_strength_activity_is_rejected(
+    strength_app, strength_client
+):
+    strength_client.get_activity.return_value["activityTypeDTO"] = {
+        "typeKey": "running"
+    }
+
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [{"exercise": "push up"}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "not 'strength_training'" in data["error"]
+    strength_client.client.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_activity_id_is_rejected_before_api_calls(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": "not-an-id",
+            "sets": [{"exercise": "push up"}],
+            "dry_run": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "positive integer" in data["error"]
+    strength_client.get_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_invalid_exercise_prevents_write(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [{"exercise": "definitely not a real exercise"}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "No Garmin exercise" in data["error"]
+    strength_client.client.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_readback_mismatch_is_reported_as_written_but_unverified(
+    strength_app, strength_client
+):
+    strength_client.get_activity_exercise_sets.return_value = {
+        "activityId": 12345678901,
+        "exerciseSets": [],
+    }
+
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [{"exercise": "push up", "repetitions": 10}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert data["written"] is True
+    assert data["verified"] is False
+    assert "read-back verification failed" in data["error"]
+    assert "set count differs" in data["verification_errors"][0]
+
+
+@pytest.mark.asyncio
+async def test_explicit_start_datetime_overrides_activity_timestamp(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [{"exercise": "push up"}],
+            "activity_start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "dry_run": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["preview"]["exerciseSets"][0]["startTime"] == (
+        "2026-07-23T16:00:00.0"
+    )
+
+
+@pytest.mark.asyncio
+async def test_set_timeline_cannot_extend_past_activity_duration(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [
+                {
+                    "exercise": "push up",
+                    "start_time": "09:59:50",
+                    "duration_seconds": 30,
+                }
+            ],
+            "dry_run": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "after the activity" in data["error"]
+    strength_client.client.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_exact_identifiers_work_when_catalog_fetch_fails(
+    strength_app, strength_client, monkeypatch
+):
+    def unavailable():
+        raise RuntimeError("catalog unavailable")
+
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", unavailable
+    )
+
+    result = await strength_app.call_tool(
+        "set_activity_strength_exercise_sets",
+        {
+            "activity_id": 12345678901,
+            "sets": [{"category": "PUSH_UP", "name": "PUSH_UP"}],
+            "dry_run": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is True
+    assert data["matches"][0]["match_type"] == "provided_unverified"

--- a/tests/integration/test_strength_training_tools.py
+++ b/tests/integration/test_strength_training_tools.py
@@ -34,6 +34,8 @@ def strength_client(monkeypatch):
         }
     )
     client.get_activity_exercise_sets = Mock(return_value={})
+    client.create_manual_activity = Mock(return_value={"activityId": 987654321})
+    client.delete_activity = Mock(return_value={})
     monkeypatch.setattr(
         strength_training, "_load_garmin_exercise_catalog", lambda: CATALOG
     )
@@ -313,3 +315,280 @@ async def test_exact_identifiers_work_when_catalog_fetch_fails(
     data = _data(result)
     assert data["success"] is True
     assert data["matches"][0]["match_type"] == "provided_unverified"
+
+
+@pytest.mark.asyncio
+async def test_create_strength_activity_dry_run_does_not_create_or_write(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [
+                {
+                    "exercise": "push up",
+                    "sets": 3,
+                    "repetitions": 10,
+                    "duration_seconds": 30,
+                    "rest_seconds": 60,
+                }
+            ],
+            "dry_run": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is True
+    assert data["dry_run"] is True
+    assert data["set_count"] == 3
+    assert data["preview"]["startTimeLocal"] == "2026-07-23T18:00:00.000"
+    assert data["preview"]["exerciseSets"][0]["startTime"] == (
+        "2026-07-23T16:00:00.0"
+    )
+    strength_client.create_manual_activity.assert_not_called()
+    strength_client.client.put.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_strength_activity_requires_confirmation(
+    strength_app, strength_client
+):
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [{"exercise": "push up"}],
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "confirm=true is required" in data["error"]
+    strength_client.create_manual_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_confirmed_create_attaches_sets_and_verifies(
+    strength_app, strength_client
+):
+    written_payload = {}
+
+    def capture_put(service, url, *, json, api):
+        written_payload.update(json)
+        assert service == "connectapi"
+        assert url == "/activity-service/activity/987654321/exerciseSets"
+        assert api is True
+        return {"accepted": True}
+
+    strength_client.client.put.side_effect = capture_put
+    strength_client.get_activity_exercise_sets.side_effect = (
+        lambda activity_id: written_payload
+    )
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [
+                {
+                    "exercise": "push up",
+                    "sets": 2,
+                    "repetitions": 12,
+                    "weight_kg": 5,
+                    "duration_seconds": 40,
+                    "rest_seconds": 80,
+                }
+            ],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is True
+    assert data["activity_created"] is True
+    assert data["verified"] is True
+    assert data["activity_id"] == 987654321
+    strength_client.create_manual_activity.assert_called_once_with(
+        start_datetime="2026-07-23T18:00:00.000",
+        time_zone="Europe/Warsaw",
+        type_key="strength_training",
+        distance_km=0.0,
+        duration_min=30.0,
+        activity_name="Upper Body",
+    )
+    assert written_payload["activityId"] == 987654321
+    assert len(written_payload["exerciseSets"]) == 2
+    strength_client.delete_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_rolls_back_when_attaching_sets_fails(
+    strength_app, strength_client
+):
+    strength_client.client.put.side_effect = RuntimeError("write failed")
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [{"exercise": "push up"}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert data["activity_created"] is True
+    assert data["rolled_back"] is True
+    assert "write failed" in data["error"]
+    strength_client.delete_activity.assert_called_once_with(987654321)
+
+
+@pytest.mark.asyncio
+async def test_create_reports_rollback_failure(
+    strength_app, strength_client
+):
+    strength_client.client.put.side_effect = RuntimeError("write failed")
+    strength_client.delete_activity.side_effect = RuntimeError("delete failed")
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [{"exercise": "push up"}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert data["rolled_back"] is False
+    assert data["rollback_error"] == "delete failed"
+
+
+@pytest.mark.asyncio
+async def test_create_can_leave_incomplete_activity_when_rollback_disabled(
+    strength_app, strength_client
+):
+    strength_client.client.put.side_effect = RuntimeError("write failed")
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [{"exercise": "push up"}],
+            "confirm": True,
+            "rollback_on_failure": False,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert data["rolled_back"] is False
+    assert data["activity_id"] == 987654321
+    strength_client.delete_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_create_rolls_back_when_readback_does_not_match(
+    strength_app, strength_client
+):
+    strength_client.get_activity_exercise_sets.return_value = {
+        "activityId": 987654321,
+        "exerciseSets": [],
+    }
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [{"exercise": "push up"}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert data["rolled_back"] is True
+    assert "Read-back verification failed" in data["error"]
+    strength_client.delete_activity.assert_called_once_with(987654321)
+
+
+@pytest.mark.asyncio
+async def test_create_stops_when_garmin_response_has_no_activity_id(
+    strength_app, strength_client
+):
+    strength_client.create_manual_activity.return_value = {"accepted": True}
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        {
+            "activity_name": "Upper Body",
+            "start_datetime": "2026-07-23T18:00:00",
+            "time_zone": "Europe/Warsaw",
+            "duration_minutes": 30,
+            "sets": [{"exercise": "push up"}],
+            "confirm": True,
+        },
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert "without an activityId" in data["error"]
+    strength_client.client.put.assert_not_called()
+    strength_client.delete_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"activity_name": "  "}, "non-empty"),
+        ({"duration_minutes": 0}, "at least"),
+        ({"time_zone": "Mars/Olympus"}, "Unknown IANA"),
+    ],
+)
+async def test_create_validates_activity_fields_before_mutation(
+    strength_app, strength_client, overrides, message
+):
+    arguments = {
+        "activity_name": "Upper Body",
+        "start_datetime": "2026-07-23T18:00:00",
+        "time_zone": "Europe/Warsaw",
+        "duration_minutes": 30,
+        "sets": [{"exercise": "push up"}],
+        "confirm": True,
+        **overrides,
+    }
+
+    result = await strength_app.call_tool(
+        "create_strength_training_activity",
+        arguments,
+    )
+
+    data = _data(result)
+    assert data["success"] is False
+    assert message in data["error"]
+    strength_client.create_manual_activity.assert_not_called()

--- a/tests/unit/test_strength_training.py
+++ b/tests/unit/test_strength_training.py
@@ -1,0 +1,387 @@
+"""Unit tests for structured strength activity helpers."""
+
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+import pytest
+
+from garmin_mcp import strength_training
+
+
+CATALOG = (
+    ("BENCH_PRESS", "BARBELL_BENCH_PRESS"),
+    ("DEADLIFT", "BARBELL_DEADLIFT"),
+    ("FLYE", "INCLINE_REVERSE_FLYE"),
+    ("HIP_STABILITY", "DEAD_BUG"),
+    ("PLANK", "SIDE_PLANK"),
+    ("PULL_UP", "PULL_UP"),
+    ("PUSH_UP", "PUSH_UP"),
+    ("ROW", "BENT_OVER_ROW_WITH_DUMBELL"),
+    ("SHOULDER_PRESS", "DUMBBELL_SHOULDER_PRESS"),
+    ("SQUAT", "BARBELL_BACK_SQUAT"),
+)
+
+
+@pytest.fixture(autouse=True)
+def use_test_catalog(monkeypatch):
+    loader = strength_training._load_garmin_exercise_catalog
+    loader.cache_clear()
+    monkeypatch.setattr(
+        strength_training,
+        "_load_garmin_exercise_catalog",
+        lambda: CATALOG,
+    )
+    yield
+    loader.cache_clear()
+
+
+def test_catalog_parser_extracts_category_name_pairs():
+    payload = {
+        "categories": {
+            "PUSH_UP": {
+                "primaryMuscles": ["CHEST"],
+                "exercises": {
+                    "PUSH_UP": {"primaryMuscles": ["CHEST"]},
+                    "DIAMOND_PUSH_UP": {"primaryMuscles": ["TRICEPS"]},
+                },
+            }
+        }
+    }
+
+    assert strength_training._catalog_pairs_from_payload(payload) == (
+        ("PUSH_UP", "DIAMOND_PUSH_UP"),
+        ("PUSH_UP", "PUSH_UP"),
+    )
+
+
+@pytest.mark.parametrize(
+    ("query", "expected"),
+    [
+        ("push up", ("PUSH_UP", "PUSH_UP")),
+        ("barbell bench press", ("BENCH_PRESS", "BARBELL_BENCH_PRESS")),
+        ("dead bug", ("HIP_STABILITY", "DEAD_BUG")),
+    ],
+)
+def test_english_names_are_matched_directly_from_catalog(query, expected):
+    match = strength_training._resolve_exercise_query(query)
+
+    assert (match["category"], match["name"]) == expected
+    assert match["match_type"] == "catalog_exact"
+
+
+def test_localized_names_are_not_maintained_as_manual_aliases():
+    with pytest.raises(
+        strength_training.StrengthTrainingError,
+        match="No Garmin exercise matches",
+    ):
+        strength_training._resolve_exercise_query("pompki")
+
+
+def test_catalog_exact_match(monkeypatch):
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", lambda: CATALOG
+    )
+
+    match = strength_training._resolve_exercise_query(
+        "BENT_OVER_ROW_WITH_DUMBELL"
+    )
+
+    assert match["category"] == "ROW"
+    assert match["name"] == "BENT_OVER_ROW_WITH_DUMBELL"
+    assert match["match_type"] == "catalog_exact"
+
+
+def test_ambiguous_catalog_name_is_rejected(monkeypatch):
+    monkeypatch.setattr(
+        strength_training,
+        "_load_garmin_exercise_catalog",
+        lambda: (("ROW", "GENERIC_MOVEMENT"), ("CORE", "GENERIC_MOVEMENT")),
+    )
+
+    with pytest.raises(
+        strength_training.StrengthTrainingError, match="ambiguous"
+    ):
+        strength_training._resolve_exercise_query("generic movement")
+
+
+def test_low_confidence_match_returns_candidates_instead_of_guessing(monkeypatch):
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", lambda: CATALOG
+    )
+
+    with pytest.raises(
+        strength_training.StrengthTrainingError, match="No confident"
+    ) as exc:
+        strength_training._resolve_exercise_query("shoulder movement machine")
+
+    assert "Closest candidates" in str(exc.value)
+
+
+def test_exact_category_name_is_validated(monkeypatch):
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", lambda: CATALOG
+    )
+
+    match = strength_training._resolve_exercise_spec(
+        {"category": "push_up", "name": "push-up"},
+        0,
+    )
+
+    assert match["category"] == "PUSH_UP"
+    assert match["name"] == "PUSH_UP"
+    assert match["match_type"] == "provided"
+
+
+def test_exact_category_name_remains_available_when_catalog_is_down(monkeypatch):
+    def unavailable():
+        raise RuntimeError("network down")
+
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", unavailable
+    )
+
+    match = strength_training._resolve_exercise_spec(
+        {"category": "PUSH_UP", "name": "PUSH_UP"},
+        0,
+    )
+
+    assert match["match_type"] == "provided_unverified"
+
+
+def test_unknown_exact_identifier_is_rejected_with_category_suggestions(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        strength_training, "_load_garmin_exercise_catalog", lambda: CATALOG
+    )
+
+    with pytest.raises(
+        strength_training.StrengthTrainingError, match="unknown Garmin exercise"
+    ):
+        strength_training._resolve_exercise_spec(
+            {"category": "PUSH_UP", "name": "PUSH_DOWN"},
+            0,
+        )
+
+
+def test_prepare_sets_expands_repeats_and_converts_kg_and_time_zone():
+    activity_start = datetime(
+        2026, 7, 23, 10, 0, tzinfo=ZoneInfo("Europe/Warsaw")
+    )
+
+    payload, matches = strength_training._prepare_strength_sets(
+        [
+            {
+                "exercise": "push up",
+                "sets": 2,
+                "repetitions": 10,
+                "weight_kg": 12.5,
+                "duration_seconds": 40,
+                "rest_seconds": 80,
+            },
+            {"set_type": "REST", "duration_seconds": 60},
+        ],
+        activity_start,
+    )
+
+    assert len(payload) == 3
+    assert len(matches) == 1
+    assert payload[0] == {
+        "exercises": [
+            {
+                "category": "PUSH_UP",
+                "name": "PUSH_UP",
+                "probability": 100.0,
+            }
+        ],
+        "duration": 40.0,
+        "repetitionCount": 10,
+        "weight": 12500.0,
+        "setType": "ACTIVE",
+        "startTime": "2026-07-23T08:00:00.0",
+        "wktStepIndex": None,
+        "messageIndex": None,
+    }
+    assert payload[1]["startTime"] == "2026-07-23T08:02:00.0"
+    assert payload[2]["startTime"] == "2026-07-23T08:04:00.0"
+    assert payload[2]["setType"] == "REST"
+    assert payload[2]["exercises"] == []
+    assert payload[2]["weight"] is None
+
+
+def test_bodyweight_is_encoded_as_unset_weight():
+    payload, _ = strength_training._prepare_strength_sets(
+        [{"exercise": "push up", "repetitions": 12}],
+        datetime(2026, 7, 23, 9, 0, tzinfo=ZoneInfo("UTC")),
+    )
+
+    assert payload[0]["weight"] == -1.0
+    assert strength_training._display_exercise_sets(payload)[0]["weightKg"] is None
+
+
+def test_clock_start_time_uses_activity_date_and_zone():
+    payload, _ = strength_training._prepare_strength_sets(
+        [{"exercise": "push up", "start_time": "18:30:15"}],
+        datetime(
+            2026, 12, 10, 9, 0, tzinfo=ZoneInfo("Europe/Warsaw")
+        ),
+    )
+
+    assert payload[0]["startTime"] == "2026-12-10T17:30:15.0"
+
+
+def test_out_of_order_or_overlapping_sets_are_rejected():
+    with pytest.raises(
+        strength_training.StrengthTrainingError, match="overlaps or precedes"
+    ):
+        strength_training._prepare_strength_sets(
+            [
+                {
+                    "exercise": "push up",
+                    "start_time": "10:05:00",
+                    "duration_seconds": 60,
+                },
+                {
+                    "exercise": "push up",
+                    "start_time": "10:04:30",
+                    "duration_seconds": 30,
+                },
+            ],
+            datetime(
+                2026, 7, 23, 10, 0, tzinfo=ZoneInfo("Europe/Warsaw")
+            ),
+        )
+
+
+@pytest.mark.parametrize(
+    ("spec", "message"),
+    [
+        ({"exercise": "push up", "sets": 0}, "positive integer"),
+        ({"exercise": "push up", "repetitions": -1}, "non-negative"),
+        ({"exercise": "push up", "weight_kg": -1}, "at least 0"),
+        ({"exercise": "push up", "duration_seconds": 0}, "at least"),
+        ({"exercise": "push up", "set_type": "WARMUP"}, "ACTIVE or REST"),
+        (
+            {"set_type": "REST", "exercise": "push up"},
+            "must not specify an exercise",
+        ),
+        (
+            {
+                "exercise": "push up",
+                "offset_seconds": 10,
+                "offset_minutes": 1,
+            },
+            "cannot specify both",
+        ),
+    ],
+)
+def test_invalid_set_specs_are_rejected(spec, message):
+    with pytest.raises(strength_training.StrengthTrainingError, match=message):
+        strength_training._prepare_strength_sets(
+            [spec],
+            datetime(2026, 7, 23, 9, 0, tzinfo=ZoneInfo("UTC")),
+        )
+
+
+def test_readback_verification_accepts_garmin_bodyweight_normalisation():
+    expected, _ = strength_training._prepare_strength_sets(
+        [{"exercise": "push up", "repetitions": 12}],
+        datetime(2026, 7, 23, 9, 0, tzinfo=ZoneInfo("UTC")),
+    )
+    readback = {
+        "activityId": 123,
+        "exerciseSets": [
+            {
+                **expected[0],
+                "weight": 0.0,
+                "messageIndex": 7,
+                "exercises": [
+                    {
+                        "category": "PUSH_UP",
+                        "name": "PUSH_UP",
+                        "probability": 84.0,
+                    },
+                    {
+                        "category": "TRICEPS_EXTENSION",
+                        "name": "BENCH_DIP",
+                        "probability": 40.0,
+                    },
+                ],
+            }
+        ],
+    }
+
+    verified, differences = strength_training._verify_exercise_sets(
+        expected, readback
+    )
+
+    assert verified is True
+    assert differences == []
+
+
+def test_readback_verification_reports_material_differences():
+    expected, _ = strength_training._prepare_strength_sets(
+        [{"exercise": "push up", "repetitions": 12}],
+        datetime(2026, 7, 23, 9, 0, tzinfo=ZoneInfo("UTC")),
+    )
+    readback = {
+        "exerciseSets": [
+            {
+                **expected[0],
+                "repetitionCount": 10,
+                "exercises": [
+                    {
+                        "category": "PULL_UP",
+                        "name": "PULL_UP",
+                        "probability": 100,
+                    }
+                ],
+            }
+        ]
+    }
+
+    verified, differences = strength_training._verify_exercise_sets(
+        expected, readback
+    )
+
+    assert verified is False
+    assert any("repetitionCount" in difference for difference in differences)
+    assert any("PUSH_UP/PUSH_UP" in difference for difference in differences)
+
+
+def test_activity_start_prefers_gmt_and_treats_naive_value_as_utc():
+    activity = {
+        "summaryDTO": {
+            "startTimeGMT": "2026-07-23T08:00:00.0",
+            "startTimeLocal": "2026-07-23T10:00:00.0",
+        }
+    }
+
+    start = strength_training._activity_start(
+        activity, None, "Europe/Warsaw"
+    )
+
+    assert start.isoformat() == "2026-07-23T08:00:00+00:00"
+
+
+def test_sets_must_fit_inside_known_activity_duration():
+    activity_start = datetime(2026, 7, 23, 8, 0, tzinfo=ZoneInfo("UTC"))
+    exercise_sets, _ = strength_training._prepare_strength_sets(
+        [
+            {
+                "exercise": "push up",
+                "start_time": "08:09:50",
+                "duration_seconds": 20,
+            }
+        ],
+        activity_start,
+    )
+
+    with pytest.raises(
+        strength_training.StrengthTrainingError, match="after the activity"
+    ):
+        strength_training._validate_sets_within_activity(
+            {"summaryDTO": {"duration": 600}},
+            activity_start,
+            exercise_sets,
+        )

--- a/tests/unit/test_strength_training.py
+++ b/tests/unit/test_strength_training.py
@@ -364,6 +364,32 @@ def test_activity_start_prefers_gmt_and_treats_naive_value_as_utc():
     assert start.isoformat() == "2026-07-23T08:00:00+00:00"
 
 
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        ({"activityId": 123}, 123),
+        ({"activity": {"activity_id": "456"}}, 456),
+        ({"results": [{"activityId": 789}]}, 789),
+        ({"activityId": 0}, None),
+        ({"activityId": True}, None),
+        ({"unrelatedId": 123}, None),
+    ],
+)
+def test_find_activity_id_handles_known_response_shapes(response, expected):
+    assert strength_training._find_activity_id(response) == expected
+
+
+def test_local_garmin_timestamp_drops_offset_without_changing_wall_clock():
+    value = datetime(
+        2026, 7, 23, 18, 5, 7, tzinfo=ZoneInfo("Europe/Warsaw")
+    )
+
+    assert (
+        strength_training._garmin_local_timestamp(value)
+        == "2026-07-23T18:05:07.000"
+    )
+
+
 def test_sets_must_fit_inside_known_activity_duration():
     activity_start = datetime(2026, 7, 23, 8, 0, tzinfo=ZoneInfo("UTC"))
     exercise_sets, _ = strength_training._prepare_strength_sets(


### PR DESCRIPTION
## Dependency

This PR is intentionally stacked on #208, which adds the validated strength-set writer used here. Please review and merge #208 first. Until then, GitHub shows both commits in this PR; after #208 merges, this PR's diff against `main` will reduce to the activity-creation commit.

For the incremental diff, use the
[fork branch comparison](https://github.com/pn/garmin_mcp/compare/feat/set-strength-exercise-sets...feat/create-strength-training-activity).

## Summary

- add `create_strength_training_activity` for creating a completed private Garmin strength activity with structured exercise sets
- reuse the same validated set format, catalog-based exercise matching, timing rules, and read-back verification introduced in #208
- support a mutation-free dry run before creation
- roll back a newly created activity by default if attaching or verifying its sets fails

## Why this does not duplicate existing tools

`create_manual_activity`, added in #157, creates the basic completed activity record only. It does not attach structured strength sets or verify them.

`create_strength_workout` and the strength changes merged through #201 create or correct a planned workout for a watch. They do not create a completed activity in the user's activity history.

This tool composes the existing manual-activity API with the completed-activity set writer from #208 and adds transactional failure handling around the two-step private Garmin API flow.

## Creation flow

1. Validate the activity name, duration, IANA time zone, local start time, set timeline, exercise matches, repetitions, and weights.
2. Return a complete preview when `dry_run=true`.
3. Require `confirm=true` for a real mutation.
4. Create a private manual activity with type `strength_training`.
5. Extract the returned activity ID, including nested response forms.
6. Attach the full structured set list.
7. Read the sets back and compare all relevant fields.
8. Delete the new activity when set attachment or read-back verification fails, unless `rollback_on_failure=false` was explicitly requested.

The result distinguishes creation, set-write, verification, and rollback outcomes so callers can tell whether any incomplete activity remains.

## Testing

- `python -m pytest tests/integration tests/unit -q` — 459 passed for the stacked branch
- 54 targeted unit and FastMCP integration tests for the two structured strength tools
- `uv lock --check`
- `git diff --check`
- live Garmin Connect end-to-end validation:
  - dry-run preview
  - create a disposable private `strength_training` activity
  - attach four active/rest, bodyweight, and weighted sets
  - independently read back the activity type, name, timing, repetitions, and weight
  - replace the set list through #208 and verify the changed values
  - delete the activity and verify that a subsequent read returned 404

The live test activity was clearly marked as disposable and was removed successfully.
