### PR TITLE
fix(workouts): canonicalize running pace target bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,24 @@ For a named Garmin HR zone, use the same target type with `zoneNumber` instead:
   "zoneNumber": 3
 }
 ```
+
+Running pace ranges use target type ID `6` with `pace.zone`. The values are
+speeds in metres per second, in Garmin's pace order: the faster (higher) speed
+goes in `targetValueOne`, and the slower (lower) speed in `targetValueTwo`.
+`upload_workout` and `upload_workouts` normalize reversed running bounds before
+upload.
+
+```json
+{
+  "targetType": {
+    "workoutTargetTypeId": 6,
+    "workoutTargetTypeKey": "pace.zone"
+  },
+  "targetValueOne": 4.878,
+  "targetValueTwo": 4.651
+}
+```
+
 ## One-click Install (Claude Desktop)
 
 The easiest way to add this server to Claude Desktop is via the `.dxt` Desktop Extension file — no JSON editing required.

--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -262,7 +262,7 @@ WORKOUT_STRUCTURE_REFERENCE = {
         "1": {"workoutTargetTypeKey": "no.target", "description": "No specific target"},
         "2": {"workoutTargetTypeKey": "power.zone", "description": "Cycling power zone 1-7 (use zoneNumber; based on FTP %). Do NOT use for absolute watt targets."},
         "4": {"workoutTargetTypeKey": "heart.rate.zone", "description": "Heart rate zone (use zoneNumber 1-5 for named zones, or targetValueOne/targetValueTwo for custom bpm range)"},
-        "6 (running/swim)": {"workoutTargetTypeKey": "pace.zone", "description": "Pace zone for running or swimming (use zoneNumber)"},
+        "6 (running/swim)": {"workoutTargetTypeKey": "pace.zone", "description": "Running pace range uses targetValueOne=fast speed and targetValueTwo=slow speed in m/s; swim pace is stored in secondary target fields"},
         "6 (cycling)": {"workoutTargetTypeKey": "power.between", "description": "Cycling absolute watt range (use targetValueOne=low_watts, targetValueTwo=high_watts). Use this instead of power.zone when targeting specific watts, NOT zone numbers."}
     },
     "sportType_values": {

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -120,6 +120,53 @@ def _fix_repeat_group_step(step: dict) -> None:
         _fix_repeat_group_step(nested)
 
 
+def _normalize_running_pace_target_step(step: dict) -> None:
+    """Put running pace bounds in Garmin's native fast-to-slow order.
+
+    Garmin represents running pace ranges as speed in metres per second, but
+    unlike ordinary numeric ranges it expects the faster (larger) speed in
+    targetValueOne and the slower (smaller) speed in targetValueTwo.
+    Garmin-authored running workouts consistently use this canonical order.
+    """
+    target_type = step.get('targetType')
+    if (
+        isinstance(target_type, dict)
+        and target_type.get('workoutTargetTypeKey') == 'pace.zone'
+    ):
+        value_one = step.get('targetValueOne')
+        value_two = step.get('targetValueTwo')
+        if (
+            isinstance(value_one, (int, float))
+            and not isinstance(value_one, bool)
+            and isinstance(value_two, (int, float))
+            and not isinstance(value_two, bool)
+            and value_one < value_two
+        ):
+            step['targetValueOne'], step['targetValueTwo'] = value_two, value_one
+
+    for nested in step.get('workoutSteps', []):
+        _normalize_running_pace_target_step(nested)
+
+
+def _sport_type_key(container: dict) -> Optional[str]:
+    """Return a workout sport key without assuming Garmin's nested shape."""
+    sport_type = container.get('sportType')
+    if not isinstance(sport_type, dict):
+        return None
+    return sport_type.get('sportTypeKey')
+
+
+def _normalize_running_pace_targets(workout_data: dict) -> None:
+    """Normalize primary pace targets in running segments before upload."""
+    workout_sport = _sport_type_key(workout_data)
+    for segment in workout_data.get('workoutSegments', []):
+        segment_sport = _sport_type_key(segment)
+        if (segment_sport or workout_sport) != 'running':
+            continue
+        for step in segment.get('workoutSteps', []):
+            _normalize_running_pace_target_step(step)
+
+
 def _fix_hr_zone_steps(workout_data: dict) -> None:
     """Walk all workout steps and fix HR zone target mistakes."""
     for segment in workout_data.get('workoutSegments', []):
@@ -615,7 +662,12 @@ def register_tools(app):
         - Custom HR range (e.g. 105-143 bpm): set targetType to "heart.rate.zone" and use
           "targetValueOne" (low bpm) / "targetValueTwo" (high bpm). Do NOT set "zoneNumber".
           This matches Garmin Connect's "Custom" heart rate target.
-        For non-HR targets (pace, power, cadence), use targetValueOne/targetValueTwo directly.
+        Running pace targets use primary targetType/targetValueOne/targetValueTwo.
+        The values are speeds in metres per second. Garmin's native order is
+        targetValueOne=fast (higher m/s), targetValueTwo=slow (lower m/s);
+        reversed input is normalized automatically before upload. Swimming pace
+        targets use the secondaryTargetType/secondaryTargetValueOne/
+        secondaryTargetValueTwo fields and are not changed by this normalization.
 
         Note: a safety check converts targetValueOne 1-5 to zoneNumber when zoneNumber is missing,
         to catch the common mistake of putting a zone index in targetValueOne. Typical bpm values
@@ -712,6 +764,7 @@ def register_tools(app):
             _fix_hr_zone_steps(workout_data)
             _validate_end_condition_steps(workout_data)
             _validate_target_type_steps(workout_data)
+            _normalize_running_pace_targets(workout_data)
 
             # Pass dict directly - library handles conversion
             result = garmin_client.upload_workout(workout_data)
@@ -749,6 +802,10 @@ def register_tools(app):
         IMPORTANT: For named heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
         For custom heart-rate ranges, use targetType {"workoutTargetTypeId": 4,
         "workoutTargetTypeKey": "heart.rate.zone"} with targetValueOne/targetValueTwo.
+        For running pace ranges, use primary targetType "pace.zone" with
+        targetValueOne=fast (higher m/s) and targetValueTwo=slow (lower m/s).
+        Reversed running pace bounds are normalized automatically. Swimming pace
+        targets use secondaryTargetType/secondaryTargetValueOne/secondaryTargetValueTwo.
         For cycling power zone targets (zone-based), use workoutTargetTypeId 2, key "power.zone".
         For cycling absolute watt range targets, use workoutTargetTypeId 6, key "power.between",
         with targetValueOne (low watts) and targetValueTwo (high watts).
@@ -767,6 +824,7 @@ def register_tools(app):
                 _fix_hr_zone_steps(workout_data)
                 _validate_end_condition_steps(workout_data)
                 _validate_target_type_steps(workout_data)
+                _normalize_running_pace_targets(workout_data)
                 result = garmin_client.upload_workout(workout_data)
                 if isinstance(result, dict):
                     entry = {
@@ -1082,6 +1140,7 @@ def register_tools(app):
                     _fix_hr_zone_steps(workout_data)
                     _validate_end_condition_steps(workout_data)
                     _validate_target_type_steps(workout_data)
+                    _normalize_running_pace_targets(workout_data)
                     upload_result = garmin_client.upload_workout(workout_data)
                     if not isinstance(upload_result, dict) or upload_result.get('workoutId') is None:
                         results.append({

--- a/tests/e2e/test_running_pace_target_live.py
+++ b/tests/e2e/test_running_pace_target_live.py
@@ -1,0 +1,141 @@
+"""Live canonicalization test for running pace targets (GitHub issue #210).
+
+Requires valid Garmin tokens at ~/.garminconnect/garmin_tokens.json.
+The test uploads one temporary workout through the real MCP server, verifies
+Garmin's stored JSON and generated FIT workout, and always deletes the workout.
+The stored-JSON assertion gates the canonicalization. The FIT assertion verifies
+that canonicalization preserves the intended range; it does not reproduce the
+Connect preview or physical-device symptom reported in the issue.
+
+Run with:
+    pytest tests/e2e/test_running_pace_target_live.py -m e2e -s
+"""
+
+import asyncio
+from io import BytesIO
+import json
+import os
+import sys
+
+from fitparse import FitFile
+from garminconnect import Garmin
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+import pytest
+
+
+TOKEN_PATH = os.path.expanduser("~/.garminconnect")
+
+pytestmark = pytest.mark.e2e
+
+
+def _issue_210_workout() -> dict:
+    pace_target = {
+        "workoutTargetTypeId": 6,
+        "workoutTargetTypeKey": "pace.zone",
+    }
+    return {
+        "workoutName": "e2e issue 210 pace target - DELETE ME",
+        "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
+        "workoutSegments": [{
+            "segmentOrder": 1,
+            "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
+            "workoutSteps": [
+                {
+                    "type": "ExecutableStepDTO",
+                    "stepOrder": 1,
+                    "stepType": {
+                        "stepTypeId": 3,
+                        "stepTypeKey": "interval",
+                    },
+                    "endCondition": {
+                        "conditionTypeId": 3,
+                        "conditionTypeKey": "distance",
+                    },
+                    "endConditionValue": 400,
+                    "targetType": pace_target,
+                    "targetValueOne": 4.651,
+                    "targetValueTwo": 4.878,
+                },
+                {
+                    "type": "ExecutableStepDTO",
+                    "stepOrder": 2,
+                    "stepType": {
+                        "stepTypeId": 3,
+                        "stepTypeKey": "interval",
+                    },
+                    "endCondition": {
+                        "conditionTypeId": 2,
+                        "conditionTypeKey": "time",
+                    },
+                    "endConditionValue": 1500,
+                    "targetType": pace_target,
+                    "targetValueOne": 4.651,
+                    "targetValueTwo": 4.878,
+                },
+            ],
+        }],
+    }
+
+
+def _fit_pace_steps(fit_data: bytes) -> list[dict]:
+    steps = []
+    for message in FitFile(BytesIO(fit_data)).get_messages("workout_step"):
+        fields = {field.name: field.value for field in message}
+        if fields.get("target_type") == "speed":
+            steps.append(fields)
+    return steps
+
+
+@pytest.mark.asyncio
+@pytest.mark.timeout(90)
+async def test_running_pace_bounds_are_canonicalized_without_changing_fit_range():
+    if not os.path.isdir(TOKEN_PATH):
+        pytest.skip("No Garmin token store found")
+
+    garmin = Garmin()
+    garmin.login(TOKEN_PATH)
+    workout_id = None
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "garmin_mcp"],
+        env=None,
+    )
+
+    try:
+        async with asyncio.timeout(75):
+            async with stdio_client(server_params) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    result = await session.call_tool(
+                        "upload_workout",
+                        arguments={"workout_data": _issue_210_workout()},
+                    )
+
+        assert result is not None
+        assert result.content
+        result_data = json.loads(result.content[0].text)
+        workout_id = result_data.get("workout_id")
+        assert result_data["status"] == "success"
+        assert workout_id is not None
+
+        stored = garmin.get_workout_by_id(workout_id)
+        stored_steps = stored["workoutSegments"][0]["workoutSteps"]
+        assert len(stored_steps) == 2
+        for step in stored_steps:
+            assert step["targetType"]["workoutTargetTypeKey"] == "pace.zone"
+            assert step["targetValueOne"] == pytest.approx(4.878)
+            assert step["targetValueTwo"] == pytest.approx(4.651)
+
+        fit_steps = _fit_pace_steps(garmin.download_workout(workout_id))
+        assert len(fit_steps) == 2
+        for step in fit_steps:
+            assert step["custom_target_speed_low"] == pytest.approx(
+                4.651, abs=0.001
+            )
+            assert step["custom_target_speed_high"] == pytest.approx(
+                4.878, abs=0.001
+            )
+    finally:
+        if workout_id is not None:
+            garmin.delete_workout(workout_id)

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -516,6 +516,214 @@ async def test_upload_workout_accepts_custom_hr_range(app_with_workouts, mock_ga
 
 
 @pytest.mark.asyncio
+async def test_upload_workout_normalizes_running_pace_bounds(
+    app_with_workouts, mock_garmin_client
+):
+    """Running pace ranges use Garmin's fast-to-slow speed ordering."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123462,
+        "workoutName": "Running Pace Range",
+    }
+    pace_target = {
+        "workoutTargetTypeId": 6,
+        "workoutTargetTypeKey": "pace.zone",
+    }
+    distance_step = _timed_interval_step(pace_target)
+    distance_step["endCondition"] = {
+        "conditionTypeId": 3,
+        "conditionTypeKey": "distance",
+    }
+    distance_step["endConditionValue"] = 400
+    distance_step["targetValueOne"] = 4.651
+    distance_step["targetValueTwo"] = 4.878
+
+    time_step = _timed_interval_step(pace_target)
+    time_step["stepOrder"] = 2
+    time_step["endConditionValue"] = 1500
+    time_step["targetValueOne"] = 4.878
+    time_step["targetValueTwo"] = 4.651
+    workout_data = _running_workout_with_steps(
+        [distance_step, time_step],
+        name="Running Pace Range",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    assert result is not None
+    called_steps = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"]
+    assert called_steps[0]["targetValueOne"] == 4.878
+    assert called_steps[0]["targetValueTwo"] == 4.651
+    assert called_steps[1]["targetValueOne"] == 4.878
+    assert called_steps[1]["targetValueTwo"] == 4.651
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_normalizes_nested_running_pace_bounds(
+    app_with_workouts, mock_garmin_client
+):
+    """Pace normalization reaches intervals nested in repeat groups."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123463,
+        "workoutName": "Nested Running Pace Range",
+    }
+    interval = _timed_interval_step(
+        {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
+    )
+    interval["targetValueOne"] = 4.651
+    interval["targetValueTwo"] = 4.878
+    workout_data = _running_workout_with_steps(
+        [{
+            "type": "RepeatGroupDTO",
+            "stepOrder": 1,
+            "numberOfIterations": 2,
+            "endCondition": {
+                "conditionTypeId": 7,
+                "conditionTypeKey": "iterations",
+            },
+            "workoutSteps": [interval],
+        }],
+        name="Nested Running Pace Range",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    assert result is not None
+    called_interval = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]["workoutSteps"][0]
+    assert called_interval["targetValueOne"] == 4.878
+    assert called_interval["targetValueTwo"] == 4.651
+
+
+@pytest.mark.parametrize(
+    "target_fields",
+    [
+        {"zoneNumber": 4},
+        {"targetValueOne": 4.651},
+        {"targetValueOne": 4.651, "targetValueTwo": None},
+        {"targetValueOne": "4.651", "targetValueTwo": "4.878"},
+        {"targetValueOne": 4.651, "targetValueTwo": 4.651},
+    ],
+)
+@pytest.mark.asyncio
+async def test_upload_workout_leaves_non_range_pace_targets_unchanged(
+    app_with_workouts, mock_garmin_client, target_fields
+):
+    """Incomplete, zone, non-numeric, and equal pace targets are not rewritten."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123464,
+        "workoutName": "Non-range Running Pace Target",
+    }
+    step = _timed_interval_step(
+        {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
+    )
+    step.pop("targetValueOne")
+    step.pop("targetValueTwo")
+    step.update(target_fields)
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Non-range Running Pace Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    assert result is not None
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    for field, value in target_fields.items():
+        assert called_step[field] == value
+
+
+@pytest.mark.parametrize(
+    ("workout_sport", "segment_sport", "expected_values"),
+    [
+        ("running", None, (4.651, 4.878)),
+        (
+            {"sportTypeId": 1, "sportTypeKey": "running"},
+            "running",
+            (4.878, 4.651),
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_upload_workout_tolerates_non_object_sport_type(
+    app_with_workouts,
+    mock_garmin_client,
+    workout_sport,
+    segment_sport,
+    expected_values,
+):
+    """Malformed sportType values retain the pre-normalizer upload behavior."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 123465,
+        "workoutName": "Malformed Sport Type",
+    }
+    step = _timed_interval_step(
+        {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
+    )
+    step["targetValueOne"] = 4.651
+    step["targetValueTwo"] = 4.878
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Malformed Sport Type",
+    )
+    workout_data["sportType"] = workout_sport
+    if segment_sport is None:
+        workout_data["workoutSegments"][0].pop("sportType")
+    else:
+        workout_data["workoutSegments"][0]["sportType"] = segment_sport
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    assert result is not None
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert (
+        called_step["targetValueOne"],
+        called_step["targetValueTwo"],
+    ) == expected_values
+
+
+@pytest.mark.asyncio
+async def test_rejected_upload_does_not_normalize_running_pace_bounds(
+    app_with_workouts, mock_garmin_client
+):
+    """Validation happens before normalization mutates the caller's payload."""
+    step = _timed_interval_step(
+        {"workoutTargetTypeId": 4, "workoutTargetTypeKey": "pace.zone"}
+    )
+    step["targetValueOne"] = 4.651
+    step["targetValueTwo"] = 4.878
+    workout_data = _running_workout_with_steps([step], name="Invalid Pace Target")
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    assert "targetType mismatch" in result[0][0].text
+    assert step["targetValueOne"] == 4.651
+    assert step["targetValueTwo"] == 4.878
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
 async def test_upload_workout_rejects_nested_end_condition_mismatch(
     app_with_workouts, mock_garmin_client
 ):
@@ -645,6 +853,8 @@ async def test_upload_workout_accepts_secondary_target_type_with_null_primary(
     called_step = called_data["workoutSegments"][0]["workoutSteps"][0]
     assert called_step["targetType"] is None
     assert called_step["secondaryTargetType"]["workoutTargetTypeKey"] == "pace.zone"
+    assert called_step["secondaryTargetValueOne"] == 0.45
+    assert called_step["secondaryTargetValueTwo"] == 0.6916667
 
     result_data = json_module.loads(result[0][0].text)
     assert result_data["status"] == "success"
@@ -1247,6 +1457,35 @@ async def test_upload_workouts_single(app_with_workouts, mock_garmin_client):
 
 
 @pytest.mark.asyncio
+async def test_upload_workouts_normalizes_running_pace_bounds(
+    app_with_workouts, mock_garmin_client
+):
+    """Batch uploads apply the same running pace normalization."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 112,
+        "workoutName": "Batch Pace Range",
+    }
+    step = _timed_interval_step(
+        {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
+    )
+    step["targetValueOne"] = 4.651
+    step["targetValueTwo"] = 4.878
+    workout = _running_workout_with_steps([step], name="Batch Pace Range")
+
+    result = await app_with_workouts.call_tool(
+        "upload_workouts",
+        {"workouts": [workout]},
+    )
+
+    assert result is not None
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["targetValueOne"] == 4.878
+    assert called_step["targetValueTwo"] == 4.651
+
+
+@pytest.mark.asyncio
 async def test_upload_workouts_multiple(app_with_workouts, mock_garmin_client):
     """Test upload_workouts with multiple workouts"""
     import json as json_module
@@ -1623,7 +1862,12 @@ async def test_schedule_workouts_inline_upload(app_with_workouts, mock_garmin_cl
     schedule_response.status_code = 200
     mock_garmin_client.client.post.return_value = schedule_response
 
-    inline_data = {"workoutName": "Easy Run", "sportType": {"sportTypeId": 1, "sportTypeKey": "running"}}
+    pace_step = _timed_interval_step(
+        {"workoutTargetTypeId": 6, "workoutTargetTypeKey": "pace.zone"}
+    )
+    pace_step["targetValueOne"] = 4.651
+    pace_step["targetValueTwo"] = 4.878
+    inline_data = _running_workout_with_steps([pace_step], name="Easy Run")
     result = await app_with_workouts.call_tool(
         "schedule_workouts",
         {"schedules": [{"workout_data": inline_data, "calendar_date": "2024-02-01"}]}
@@ -1640,6 +1884,11 @@ async def test_schedule_workouts_inline_upload(app_with_workouts, mock_garmin_cl
     assert entry["scheduled_date"] == "2024-02-01"
     assert entry["workout_name"] == "Easy Run"
     mock_garmin_client.upload_workout.assert_called_once_with(inline_data)
+    uploaded_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert uploaded_step["targetValueOne"] == 4.878
+    assert uploaded_step["targetValueTwo"] == 4.651
     mock_garmin_client.client.post.assert_called_once_with(
         "connectapi", "workout-service/schedule/999001", json={"date": "2024-02-01"}
     )


### PR DESCRIPTION
> **Status after real-device verification:** the reported failure could not be reproduced. Both the reported and canonical bound orders displayed and enforced the correct pace range on a Forerunner 255. This PR is being closed because its normalization is not demonstrated to fix #210 and would add behavior without a confirmed need.

## Summary

- canonicalize primary running `pace.zone` ranges before upload so Garmin receives the faster (higher m/s) bound in `targetValueOne` and the slower bound in `targetValueTwo`
- apply the same behavior to `upload_workout`, `upload_workouts`, and inline `schedule_workouts` uploads, including steps nested in repeat groups
- leave canonical, incomplete, zone-based, non-numeric, swimming-secondary, and non-running targets unchanged
- document the running primary-target order and the separate swimming secondary-target field family

## Original hypothesis

Issue #210 reports that an ascending running speed range is accepted by Garmin, but Garmin Connect shows `0:00` bounds and the watch provides no pace guidance.

Garmin-authored running workouts consistently store pace ranges in pace order:

```text
targetValueOne = faster boundary (higher m/s)
targetValueTwo = slower boundary (lower m/s)
```

Live API probing showed that Garmin preserves the submitted order in stored workout JSON, while FIT export normalizes either order to equivalent low/high speed fields. This PR tested whether canonicalizing MCP output would avoid the reported presentation/device failure.

## Verification result

Two otherwise identical workouts were uploaded, scheduled, synced, and tested on a Forerunner 255:

- reported order: `4.651` / `4.878`
- canonical order: `4.878` / `4.651`

Garmin Connect Mobile and the watch displayed the correct approximately `3:25–3:35/km` range for both. Target guidance was active for both. The `0:00` preview and missing watch target from #210 did not occur.

No `garmin_mcp` change was merged between the issue report and this verification that could explain the different result. A Garmin service/app change remains possible but unverified. The remaining likely variables are the reporter's complete workout payload, device/firmware, app version/platform, or sync state.

## Implementation and tests retained in this branch

- normalization is restricted to primary `pace.zone` targets in running segments
- segment sport takes precedence, with workout sport used as fallback
- malformed `sportType` shapes retain their previous pass-through behavior
- validation runs before normalization, so rejected payloads are not mutated
- swimming pace targets in `secondaryTargetType` fields are not modified
- `416` unit and integration tests passed
- a live MCP → Garmin JSON → FIT test passed and cleaned up its temporary workout

These tests establish that the implementation is internally safe; they do not establish that normalization is necessary or fixes #210.

## Interaction with PR #194

This change is functionally independent from #194, which corrects cycling watt target encoding. Both branches touch target-type documentation, but #194 remains unrelated to the reported running-pace behavior.

Related to #210.
