### PR TITLE
fix: map virtual challenge fields

### DIFF
--- a/src/garmin_mcp/challenges.py
+++ b/src/garmin_mcp/challenges.py
@@ -134,8 +134,8 @@ def _parse_iso_date(iso_string: str) -> str:
     return iso_string.split("T")[0] if "T" in iso_string else iso_string
 
 
-def _first_non_none(data: dict, *keys: str):
-    """Return the first present, non-None value for the supplied keys."""
+def _first_non_none(data: dict, *keys: str) -> Any:
+    """Return the first non-None value for the supplied keys."""
     for key in keys:
         value = data.get(key)
         if value is not None:
@@ -576,12 +576,9 @@ def register_tools(app):
             curated_challenges = []
             for challenge in challenge_list:
                 curated = {
-                    "name": _first_non_none(
-                        challenge,
-                        "badgeChallengeName",
-                        "name",
-                        "challengeName",
-                    ),
+                    "name": challenge.get("badgeChallengeName")
+                    or challenge.get("name")
+                    or challenge.get("challengeName"),
                     "uuid": challenge.get("uuid"),
                     "start_date": _parse_iso_date(challenge.get("startDate")),
                     "end_date": _parse_iso_date(challenge.get("endDate")),
@@ -600,11 +597,18 @@ def register_tools(app):
                     "target",
                     "targetValue",
                 )
-                if progress is not None and target is not None:
-                    curated["progress_meters"] = progress
-                    curated["target_meters"] = target
-                    curated["progress_km"] = f"{progress / 1000:.2f} km"
-                    curated["target_km"] = f"{target / 1000:.2f} km"
+                if progress is not None and target is not None and target > 0:
+                    unit_id = challenge.get("badgeUnitId")
+                    if unit_id in (None, 1):
+                        # Preserve the existing output contract for distance
+                        # challenges and legacy payloads without unit metadata.
+                        curated["progress_meters"] = progress
+                        curated["target_meters"] = target
+                        curated["progress_km"] = f"{progress / 1000:.2f} km"
+                        curated["target_km"] = f"{target / 1000:.2f} km"
+                    else:
+                        curated["progress"] = _format_badge_value(progress, unit_id)
+                        curated["target"] = _format_badge_value(target, unit_id)
                     curated["progress_percent"] = _calculate_progress_percent(
                         progress, target
                     )

--- a/src/garmin_mcp/challenges.py
+++ b/src/garmin_mcp/challenges.py
@@ -134,6 +134,15 @@ def _parse_iso_date(iso_string: str) -> str:
     return iso_string.split("T")[0] if "T" in iso_string else iso_string
 
 
+def _first_non_none(data: dict, *keys: str):
+    """Return the first present, non-None value for the supplied keys."""
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            return value
+    return None
+
+
 def _format_badge_value(value: float, unit_id: int) -> str:
     """Format a badge progress/target value based on its unit type"""
     if value is None:
@@ -567,15 +576,30 @@ def register_tools(app):
             curated_challenges = []
             for challenge in challenge_list:
                 curated = {
-                    "name": challenge.get("name") or challenge.get("challengeName"),
+                    "name": _first_non_none(
+                        challenge,
+                        "badgeChallengeName",
+                        "name",
+                        "challengeName",
+                    ),
                     "uuid": challenge.get("uuid"),
                     "start_date": _parse_iso_date(challenge.get("startDate")),
                     "end_date": _parse_iso_date(challenge.get("endDate")),
                 }
 
                 # Add progress if available
-                progress = challenge.get("progress") or challenge.get("progressValue")
-                target = challenge.get("target") or challenge.get("targetValue")
+                progress = _first_non_none(
+                    challenge,
+                    "badgeProgressValue",
+                    "progress",
+                    "progressValue",
+                )
+                target = _first_non_none(
+                    challenge,
+                    "badgeTargetValue",
+                    "target",
+                    "targetValue",
+                )
                 if progress is not None and target is not None:
                     curated["progress_meters"] = progress
                     curated["target_meters"] = target

--- a/tests/integration/test_challenges_tools.py
+++ b/tests/integration/test_challenges_tools.py
@@ -3,6 +3,8 @@ Integration tests for challenges module MCP tools
 
 Tests all 9 challenges and badges tools using FastMCP integration with mocked Garmin API responses.
 """
+import json
+
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
@@ -267,15 +269,17 @@ async def test_get_race_predictions_tool(app_with_challenges, mock_garmin_client
 @pytest.mark.asyncio
 async def test_get_inprogress_virtual_challenges_tool(app_with_challenges, mock_garmin_client):
     """Test get_inprogress_virtual_challenges tool"""
-    # Setup mock
+    # Match the payload shape returned by Garmin for an active expedition.
     virtual_challenges = [
         {
             "uuid": "GHI789",
-            "name": "Virtual NYC Marathon",
-            "startDate": "2024-01-01T00:00:00.0",
-            "endDate": "2024-01-31T23:59:59.0",
-            "progress": 28000.0,
-            "target": 42195.0,
+            "badgeChallengeName": "Camino de Santiago",
+            "startDate": None,
+            "endDate": None,
+            "badgeUnitId": 1,
+            "badgeProgressValue": 159.0,
+            "badgeTargetValue": 784000.0,
+            "userJoined": True,
         }
     ]
     mock_garmin_client.get_inprogress_virtual_challenges.return_value = virtual_challenges
@@ -289,6 +293,23 @@ async def test_get_inprogress_virtual_challenges_tool(app_with_challenges, mock_
     # Verify
     assert result is not None
     mock_garmin_client.get_inprogress_virtual_challenges.assert_called_once_with(1, 20)
+    payload = json.loads(result[0][0].text)
+    assert payload == {
+        "total": 1,
+        "challenges": [
+            {
+                "name": "Camino de Santiago",
+                "uuid": "GHI789",
+                "start_date": None,
+                "end_date": None,
+                "progress_meters": 159.0,
+                "target_meters": 784000.0,
+                "progress_km": "0.16 km",
+                "target_km": "784.00 km",
+                "progress_percent": "0.0%",
+            }
+        ],
+    }
 
 
 # Error handling tests

--- a/tests/integration/test_challenges_tools.py
+++ b/tests/integration/test_challenges_tools.py
@@ -312,6 +312,140 @@ async def test_get_inprogress_virtual_challenges_tool(app_with_challenges, mock_
     }
 
 
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("legacy_fields", "expected_name", "expected_progress", "expected_percent"),
+    [
+        (
+            {
+                "name": "Legacy Expedition",
+                "progress": 28000.0,
+                "target": 42195.0,
+            },
+            "Legacy Expedition",
+            28000.0,
+            "66.4%",
+        ),
+        (
+            {
+                "challengeName": "Alternate Legacy Expedition",
+                "progressValue": 0.0,
+                "targetValue": 42195.0,
+            },
+            "Alternate Legacy Expedition",
+            0.0,
+            "0.0%",
+        ),
+    ],
+)
+async def test_get_inprogress_virtual_challenges_legacy_fields(
+    app_with_challenges,
+    mock_garmin_client,
+    legacy_fields,
+    expected_name,
+    expected_progress,
+    expected_percent,
+):
+    """Legacy virtual-challenge field names remain supported."""
+    mock_garmin_client.get_inprogress_virtual_challenges.return_value = [
+        {
+            "uuid": "LEGACY123",
+            "startDate": "2024-01-01T00:00:00.0",
+            "endDate": "2024-01-31T23:59:59.0",
+            **legacy_fields,
+        }
+    ]
+
+    result = await app_with_challenges.call_tool(
+        "get_inprogress_virtual_challenges",
+        {},
+    )
+
+    payload = json.loads(result[0][0].text)
+    assert payload["challenges"][0] == {
+        "name": expected_name,
+        "uuid": "LEGACY123",
+        "start_date": "2024-01-01",
+        "end_date": "2024-01-31",
+        "progress_meters": expected_progress,
+        "target_meters": 42195.0,
+        "progress_km": f"{expected_progress / 1000:.2f} km",
+        "target_km": "42.20 km",
+        "progress_percent": expected_percent,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("unit_id", "progress", "target", "formatted_progress", "formatted_target"),
+    [
+        (2, 120.0, 1000.0, "120 m", "1000 m"),
+        (5, 120000.0, 200000.0, "120,000", "200,000"),
+        (7, 3600.0, 7200.0, "1:00:00", "2:00:00"),
+    ],
+)
+async def test_get_inprogress_virtual_challenges_non_distance_units(
+    app_with_challenges,
+    mock_garmin_client,
+    unit_id,
+    progress,
+    target,
+    formatted_progress,
+    formatted_target,
+):
+    """Non-distance virtual challenges are not labeled as meters or kilometers."""
+    mock_garmin_client.get_inprogress_virtual_challenges.return_value = [
+        {
+            "uuid": "NON_DISTANCE",
+            "badgeChallengeName": "Non-distance Expedition",
+            "badgeUnitId": unit_id,
+            "badgeProgressValue": progress,
+            "badgeTargetValue": target,
+        }
+    ]
+
+    result = await app_with_challenges.call_tool(
+        "get_inprogress_virtual_challenges",
+        {},
+    )
+
+    payload = json.loads(result[0][0].text)
+    challenge = payload["challenges"][0]
+    assert challenge["progress"] == formatted_progress
+    assert challenge["target"] == formatted_target
+    assert "progress_meters" not in challenge
+    assert "target_meters" not in challenge
+    assert "progress_km" not in challenge
+    assert "target_km" not in challenge
+
+
+@pytest.mark.asyncio
+async def test_get_inprogress_virtual_challenges_skips_zero_target(
+    app_with_challenges, mock_garmin_client
+):
+    """A zero target does not produce a partial progress block."""
+    mock_garmin_client.get_inprogress_virtual_challenges.return_value = [
+        {
+            "uuid": "ZERO_TARGET",
+            "badgeChallengeName": "",
+            "name": "Fallback Name",
+            "badgeUnitId": 1,
+            "badgeProgressValue": 0.0,
+            "badgeTargetValue": 0.0,
+        }
+    ]
+
+    result = await app_with_challenges.call_tool(
+        "get_inprogress_virtual_challenges",
+        {},
+    )
+
+    payload = json.loads(result[0][0].text)
+    challenge = payload["challenges"][0]
+    assert challenge["name"] == "Fallback Name"
+    assert set(challenge) == {"name", "uuid", "start_date", "end_date"}
+
+
 # Error handling tests
 @pytest.mark.asyncio
 async def test_get_goals_no_data(app_with_challenges, mock_garmin_client):


### PR DESCRIPTION
## Summary
- map the live Garmin expedition fields badgeChallengeName, badgeProgressValue, and badgeTargetValue
- preserve both legacy field families and legitimate zero-valued progress
- format elevation, step, and time challenges with their actual units instead of labeling them as distance
- strengthen integration coverage with the payload shape observed from an active expedition

## Root cause
The virtual challenge curator expected generic challenge fields, but Garmin returns the badge-challenge field shape for active expeditions. This caused the name and all progress fields to be discarded. startDate and endDate remain null because Garmin itself returns null for non-expiring expeditions.

## Validation
- reproduced against an active expedition on a device-synced Garmin account
- verified that the patched mapper returns the expedition name and progress from the same live endpoint
- covered distance, elevation, steps, time, zero progress, zero target, and both legacy field families
- ran the full CI test selection: 411 passed

Fixes #212