### PR TITLE
fix: preserve misplaced workout target bounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -239,7 +239,9 @@ treats the numeric ID as authoritative: a mismatched payload such as
 `pace.zone`, because ID `6` means `pace.zone`.
 
 For a custom heart-rate range, use target type ID `4` with `heart.rate.zone` and
-put the bpm range in `targetValueOne` / `targetValueTwo`:
+put the bpm range in `targetValueOne` / `targetValueTwo`. These value fields
+belong on the workout step, alongside `targetType`; do not nest them inside the
+`targetType` object:
 
 ```json
 {
@@ -251,6 +253,25 @@ put the bpm range in `targetValueOne` / `targetValueTwo`:
   "targetValueTwo": 157
 }
 ```
+
+The same shape applies to a custom running pace range. Pace bounds use meters
+per second:
+
+```json
+{
+  "targetType": {
+    "workoutTargetTypeId": 6,
+    "workoutTargetTypeKey": "pace.zone"
+  },
+  "targetValueOne": 2.0833333,
+  "targetValueTwo": 1.9607843
+}
+```
+
+That example represents `8:00–8:30 min/km`. Garmin silently discards values
+nested inside `targetType`, leaving a pace target with no active range. The
+upload tools repair that unambiguous nesting mistake, but reject the request if
+nested and step-level values conflict.
 
 For a named Garmin HR zone, use the same target type with `zoneNumber` instead:
 

--- a/README.md
+++ b/README.md
@@ -263,15 +263,16 @@ per second:
     "workoutTargetTypeId": 6,
     "workoutTargetTypeKey": "pace.zone"
   },
-  "targetValueOne": 2.0833333,
-  "targetValueTwo": 1.9607843
+  "targetValueOne": 1.9607843,
+  "targetValueTwo": 2.0833333
 }
 ```
 
-That example represents `8:00–8:30 min/km`. Garmin silently discards values
-nested inside `targetType`, leaving a pace target with no active range. The
-upload tools repair that unambiguous nesting mistake, but reject the request if
-nested and step-level values conflict.
+That example represents `8:00–8:30 min/km`. The lower numeric bound is listed
+first for consistency with the heart-rate example; Garmin normalizes either
+bound order. Garmin silently discards values nested inside `targetType`, leaving
+a pace target with no active range. The upload tools repair that unambiguous
+nesting mistake, but reject the request if nested and step-level values conflict.
 
 For a named Garmin HR zone, use the same target type with `zoneNumber` instead:
 
@@ -284,6 +285,11 @@ For a named Garmin HR zone, use the same target type with `zoneNumber` instead:
   "zoneNumber": 3
 }
 ```
+
+Use either `zoneNumber` or `targetValueOne` / `targetValueTwo` on a target, not
+both. Garmin treats the named zone as authoritative and silently discards a
+coexisting custom range, so the upload tools reject that ambiguous shape.
+
 ## One-click Install (Claude Desktop)
 
 The easiest way to add this server to Claude Desktop is via the `.dxt` Desktop Extension file — no JSON editing required.

--- a/src/garmin_mcp/workout_templates.py
+++ b/src/garmin_mcp/workout_templates.py
@@ -262,7 +262,14 @@ WORKOUT_STRUCTURE_REFERENCE = {
         "1": {"workoutTargetTypeKey": "no.target", "description": "No specific target"},
         "2": {"workoutTargetTypeKey": "power.zone", "description": "Cycling power zone 1-7 (use zoneNumber; based on FTP %). Do NOT use for absolute watt targets."},
         "4": {"workoutTargetTypeKey": "heart.rate.zone", "description": "Heart rate zone (use zoneNumber 1-5 for named zones, or targetValueOne/targetValueTwo for custom bpm range)"},
-        "6 (running/swim)": {"workoutTargetTypeKey": "pace.zone", "description": "Pace zone for running or swimming (use zoneNumber)"},
+        "6 (running/swim)": {
+            "workoutTargetTypeKey": "pace.zone",
+            "description": (
+                "Pace zone for running or swimming (use zoneNumber, or "
+                "step-level targetValueOne/targetValueTwo in m/s for a "
+                "custom range)"
+            ),
+        },
         "6 (cycling)": {"workoutTargetTypeKey": "power.between", "description": "Cycling absolute watt range (use targetValueOne=low_watts, targetValueTwo=high_watts). Use this instead of power.zone when targeting specific watts, NOT zone numbers."}
     },
     "sportType_values": {

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -60,39 +60,101 @@ def configure(client):
     garmin_client = client
 
 
-_PRIMARY_TARGET_VALUE_FIELDS = (
-    'targetValueOne',
-    'targetValueTwo',
-)
+_TARGET_FIELD_LAYOUTS = {
+    'targetType': {
+        'bounds': ('targetValueOne', 'targetValueTwo'),
+        'zone': 'zoneNumber',
+    },
+    'secondaryTargetType': {
+        'bounds': ('secondaryTargetValueOne', 'secondaryTargetValueTwo'),
+        'zone': 'secondaryZoneNumber',
+    },
+}
 
 
-def _fix_nested_target_values_step(step: dict, path: str) -> None:
-    """Move target values out of targetType, where Garmin silently ignores them."""
-    target_type = step.get('targetType')
-    if isinstance(target_type, dict):
-        nested_fields = [
-            field
-            for field in _PRIMARY_TARGET_VALUE_FIELDS
-            if field in target_type
-        ]
-
-        for field in nested_fields:
-            if field in step and step[field] != target_type[field]:
-                raise ValueError(
-                    f"{path}.{field} conflicts with "
-                    f"{path}.targetType.{field}"
-                )
-
-        for field in nested_fields:
-            if field not in step:
-                step[field] = target_type[field]
-            target_type.pop(field)
-
+def _iter_step_tree(step: dict, path: str):
+    """Yield a workout step and every nested step with its request path."""
+    yield step, path
     for index, nested in enumerate(step.get('workoutSteps', [])):
-        _fix_nested_target_values_step(
+        yield from _iter_step_tree(
             nested,
             f"{path}.workoutSteps[{index}]",
         )
+
+
+def _iter_workout_steps(workout_data: dict):
+    """Yield every workout step with a stable request path."""
+    for segment_index, segment in enumerate(
+        workout_data.get('workoutSegments', [])
+    ):
+        for step_index, step in enumerate(segment.get('workoutSteps', [])):
+            path = (
+                f"workoutSegments[{segment_index}]"
+                f".workoutSteps[{step_index}]"
+            )
+            yield from _iter_step_tree(step, path)
+
+
+def _validate_nested_target_fields(step: dict, path: str) -> None:
+    """Reject conflicting or ambiguous target fields before any repair."""
+    for target_field, layout in _TARGET_FIELD_LAYOUTS.items():
+        target_type = step.get(target_field)
+        if not isinstance(target_type, dict):
+            continue
+
+        fields = (*layout['bounds'], layout['zone'])
+        for field in fields:
+            nested_value = target_type.get(field)
+            if (
+                nested_value is not None
+                and step.get(field) is not None
+                and step[field] != nested_value
+            ):
+                raise ValueError(
+                    f"{path}.{field}={step[field]!r} conflicts with "
+                    f"{path}.{target_field}.{field}={nested_value!r}; "
+                    f"keep only the step-level {field}"
+                )
+
+        zone_field = layout['zone']
+        zone_value = step.get(zone_field)
+        if zone_value is None:
+            zone_value = target_type.get(zone_field)
+
+        bound_values = []
+        for field in layout['bounds']:
+            value = step.get(field)
+            if value is None:
+                value = target_type.get(field)
+            if value is not None:
+                bound_values.append((field, value))
+
+        if zone_value is not None and bound_values:
+            bounds = ", ".join(
+                f"{field}={value!r}"
+                for field, value in bound_values
+            )
+            raise ValueError(
+                f"{path} mixes {zone_field}={zone_value!r} with custom "
+                f"range fields ({bounds}); use either a named zone or a "
+                f"custom range"
+            )
+
+
+def _move_nested_target_fields(step: dict) -> None:
+    """Move target fields to the step level, where Garmin reads them."""
+    for target_field, layout in _TARGET_FIELD_LAYOUTS.items():
+        target_type = step.get(target_field)
+        if not isinstance(target_type, dict):
+            continue
+
+        fields = (*layout['bounds'], layout['zone'])
+        for field in fields:
+            if field not in target_type:
+                continue
+            value = target_type.pop(field)
+            if value is not None and step.get(field) is None:
+                step[field] = value
 
 
 def _fix_hr_zone_step(step: dict) -> None:
@@ -105,8 +167,12 @@ def _fix_hr_zone_step(step: dict) -> None:
     Custom HR bpm ranges (e.g. targetValueOne=105, targetValueTwo=143) are left
     unchanged — these are legitimate custom heart rate targets in Garmin Connect.
     """
-    target_type = step.get('targetType') or {}
-    target_key = target_type.get('workoutTargetTypeKey', '')
+    target_type = step.get('targetType')
+    target_key = (
+        target_type.get('workoutTargetTypeKey', '')
+        if isinstance(target_type, dict)
+        else ''
+    )
 
     if target_key == 'heart.rate.zone' and 'zoneNumber' not in step:
         zone = step.get('targetValueOne')
@@ -157,15 +223,18 @@ def _fix_repeat_group_step(step: dict) -> None:
 
 def _normalize_workout_steps(workout_data: dict) -> None:
     """Repair recoverable step-shape mistakes before validation and upload."""
-    for segment_index, segment in enumerate(
-        workout_data.get('workoutSegments', [])
-    ):
-        for step_index, step in enumerate(segment.get('workoutSteps', [])):
-            path = (
-                f"workoutSegments[{segment_index}]"
-                f".workoutSteps[{step_index}]"
-            )
-            _fix_nested_target_values_step(step, path)
+    steps = list(_iter_workout_steps(workout_data))
+
+    # Preflight the complete workout so a later conflict cannot leave an
+    # earlier step partially repaired.
+    for step, path in steps:
+        _validate_nested_target_fields(step, path)
+    for step, _ in steps:
+        _move_nested_target_fields(step)
+
+    # These helpers recurse, so invoke them only for top-level steps.
+    for segment in workout_data.get('workoutSegments', []):
+        for step in segment.get('workoutSteps', []):
             _fix_hr_zone_step(step)
             _fix_repeat_group_step(step)
 
@@ -660,6 +729,8 @@ def register_tools(app):
         For non-HR targets (pace, power, cadence), use targetValueOne/targetValueTwo directly.
         Target values are fields on the workout step, alongside targetType; do not put
         targetValueOne, targetValueTwo, or zoneNumber inside the targetType object.
+        Use either zoneNumber or targetValueOne/targetValueTwo, not both. Garmin silently
+        discards a custom range when a named zone is also present.
 
         Note: a safety check converts targetValueOne 1-5 to zoneNumber when zoneNumber is missing,
         to catch the common mistake of putting a zone index in targetValueOne. Typical bpm values

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -60,6 +60,41 @@ def configure(client):
     garmin_client = client
 
 
+_PRIMARY_TARGET_VALUE_FIELDS = (
+    'targetValueOne',
+    'targetValueTwo',
+)
+
+
+def _fix_nested_target_values_step(step: dict, path: str) -> None:
+    """Move target values out of targetType, where Garmin silently ignores them."""
+    target_type = step.get('targetType')
+    if isinstance(target_type, dict):
+        nested_fields = [
+            field
+            for field in _PRIMARY_TARGET_VALUE_FIELDS
+            if field in target_type
+        ]
+
+        for field in nested_fields:
+            if field in step and step[field] != target_type[field]:
+                raise ValueError(
+                    f"{path}.{field} conflicts with "
+                    f"{path}.targetType.{field}"
+                )
+
+        for field in nested_fields:
+            if field not in step:
+                step[field] = target_type[field]
+            target_type.pop(field)
+
+    for index, nested in enumerate(step.get('workoutSteps', [])):
+        _fix_nested_target_values_step(
+            nested,
+            f"{path}.workoutSteps[{index}]",
+        )
+
+
 def _fix_hr_zone_step(step: dict) -> None:
     """Fix a common mistake where HR zone targets use targetValueOne instead of zoneNumber.
 
@@ -120,10 +155,17 @@ def _fix_repeat_group_step(step: dict) -> None:
         _fix_repeat_group_step(nested)
 
 
-def _fix_hr_zone_steps(workout_data: dict) -> None:
-    """Walk all workout steps and fix HR zone target mistakes."""
-    for segment in workout_data.get('workoutSegments', []):
-        for step in segment.get('workoutSteps', []):
+def _normalize_workout_steps(workout_data: dict) -> None:
+    """Repair recoverable step-shape mistakes before validation and upload."""
+    for segment_index, segment in enumerate(
+        workout_data.get('workoutSegments', [])
+    ):
+        for step_index, step in enumerate(segment.get('workoutSteps', [])):
+            path = (
+                f"workoutSegments[{segment_index}]"
+                f".workoutSteps[{step_index}]"
+            )
+            _fix_nested_target_values_step(step, path)
             _fix_hr_zone_step(step)
             _fix_repeat_group_step(step)
 
@@ -616,6 +658,8 @@ def register_tools(app):
           "targetValueOne" (low bpm) / "targetValueTwo" (high bpm). Do NOT set "zoneNumber".
           This matches Garmin Connect's "Custom" heart rate target.
         For non-HR targets (pace, power, cadence), use targetValueOne/targetValueTwo directly.
+        Target values are fields on the workout step, alongside targetType; do not put
+        targetValueOne, targetValueTwo, or zoneNumber inside the targetType object.
 
         Note: a safety check converts targetValueOne 1-5 to zoneNumber when zoneNumber is missing,
         to catch the common mistake of putting a zone index in targetValueOne. Typical bpm values
@@ -708,8 +752,7 @@ def register_tools(app):
             workout_data: Dictionary containing workout structure (name, sport type, segments, etc.)
         """
         try:
-            # Fix common mistake: HR zone targets using targetValueOne instead of zoneNumber
-            _fix_hr_zone_steps(workout_data)
+            _normalize_workout_steps(workout_data)
             _validate_end_condition_steps(workout_data)
             _validate_target_type_steps(workout_data)
 
@@ -749,6 +792,7 @@ def register_tools(app):
         IMPORTANT: For named heart rate zone targets, use "zoneNumber" (1-5), NOT targetValueOne/targetValueTwo.
         For custom heart-rate ranges, use targetType {"workoutTargetTypeId": 4,
         "workoutTargetTypeKey": "heart.rate.zone"} with targetValueOne/targetValueTwo.
+        Target values belong on the workout step, alongside targetType, not inside it.
         For cycling power zone targets (zone-based), use workoutTargetTypeId 2, key "power.zone".
         For cycling absolute watt range targets, use workoutTargetTypeId 6, key "power.between",
         with targetValueOne (low watts) and targetValueTwo (high watts).
@@ -764,7 +808,7 @@ def register_tools(app):
         results = []
         for workout_data in workouts:
             try:
-                _fix_hr_zone_steps(workout_data)
+                _normalize_workout_steps(workout_data)
                 _validate_end_condition_steps(workout_data)
                 _validate_target_type_steps(workout_data)
                 result = garmin_client.upload_workout(workout_data)
@@ -1028,7 +1072,8 @@ def register_tools(app):
                 - calendar_date (str): Date to schedule the workout in YYYY-MM-DD format (required)
                 - workout_id (int): ID of an existing workout to schedule (required unless workout_data is provided)
                 - workout_data (dict): Inline workout JSON to upload first, then schedule (optional).
-                  When provided, workout_id is not required. Uses the same structure as upload_workout.
+                  When provided, workout_id is not required. Uses the same structure and
+                  target-value rules as upload_workout.
 
         Examples:
             Schedule existing workouts by ID:
@@ -1079,7 +1124,7 @@ def register_tools(app):
 
                 if workout_data is not None:
                     # Upload the workout first, then use the returned ID to schedule
-                    _fix_hr_zone_steps(workout_data)
+                    _normalize_workout_steps(workout_data)
                     _validate_end_condition_steps(workout_data)
                     _validate_target_type_steps(workout_data)
                     upload_result = garmin_client.upload_workout(workout_data)

--- a/tests/e2e/test_nested_workout_target_values_live.py
+++ b/tests/e2e/test_nested_workout_target_values_live.py
@@ -7,6 +7,7 @@ pytest tests/e2e/test_nested_workout_target_values_live.py -m e2e -s
 import asyncio
 import json
 import sys
+import warnings
 from io import BytesIO
 
 import pytest
@@ -15,6 +16,65 @@ from mcp import ClientSession, StdioServerParameters
 from mcp.client.stdio import stdio_client
 
 from garmin_mcp import email, init_api, password
+
+
+async def _cleanup_scheduled_workout(session, workout_id):
+    """Best-effort cleanup that cannot hide the test's real failure."""
+    failures = []
+    scheduled_workout_id = None
+
+    try:
+        for attempt in range(3):
+            result = await session.call_tool(
+                "get_scheduled_workouts",
+                arguments={
+                    "start_date": "2099-01-01",
+                    "end_date": "2099-01-01",
+                },
+            )
+            try:
+                scheduled = json.loads(result.content[0].text)
+            except json.JSONDecodeError:
+                scheduled = {}
+            scheduled_workout_id = next(
+                (
+                    item.get("scheduled_workout_id")
+                    for item in scheduled.get("scheduled_workouts", [])
+                    if item.get("workout_id") == workout_id
+                ),
+                None,
+            )
+            if scheduled_workout_id is not None or attempt == 2:
+                break
+            await asyncio.sleep(1)
+    except Exception as error:
+        failures.append(f"calendar lookup failed: {error}")
+
+    if scheduled_workout_id is not None:
+        try:
+            result = await session.call_tool(
+                "unschedule_workout",
+                arguments={"scheduled_workout_id": scheduled_workout_id},
+            )
+            data = json.loads(result.content[0].text)
+            if data.get("status") != "success":
+                failures.append(f"unschedule failed: {data}")
+        except Exception as error:
+            failures.append(f"unschedule failed: {error}")
+
+    try:
+        result = await session.call_tool(
+            "delete_workout",
+            arguments={"workout_id": workout_id},
+        )
+        data = json.loads(result.content[0].text)
+        if data.get("status") != "success":
+            failures.append(f"delete failed: {data}")
+    except Exception as error:
+        failures.append(f"delete failed: {error}")
+
+    if failures:
+        warnings.warn("; ".join(failures), stacklevel=2)
 
 
 @pytest.mark.e2e
@@ -48,8 +108,8 @@ async def test_nested_pace_bounds_survive_inline_schedule_and_fit_export():
                 "targetType": {
                     "workoutTargetTypeId": 6,
                     "workoutTargetTypeKey": "pace.zone",
-                    "targetValueOne": 2.0833333,
-                    "targetValueTwo": 1.9607843,
+                    "targetValueOne": 1.9607843,
+                    "targetValueTwo": 2.0833333,
                 },
             }],
         }],
@@ -76,17 +136,24 @@ async def test_nested_pace_bounds_survive_inline_schedule_and_fit_export():
                 workout_id = result_data["results"][0].get("workout_id")
                 assert workout_id is not None
 
-                client = init_api(email, password)
-                assert client is not None
-                stored = client.get_workout_by_id(workout_id)
-                stored_step = stored["workoutSegments"][0]["workoutSteps"][0]
-                assert stored_step["targetValueOne"] == pytest.approx(
-                    2.0833333,
+                stored_result = await session.call_tool(
+                    "get_workout_by_id",
+                    arguments={"workout_id": workout_id},
                 )
-                assert stored_step["targetValueTwo"] == pytest.approx(
+                stored = json.loads(stored_result.content[0].text)
+                stored_step = stored["segments"][0]["steps"][0]
+                assert stored_step["target_value_low"] == pytest.approx(
                     1.9607843,
                 )
+                assert stored_step["target_value_high"] == pytest.approx(
+                    2.0833333,
+                )
 
+                # The MCP download tool intentionally returns metadata rather
+                # than FIT bytes, so use a direct client only for FIT parsing.
+                # All MCP and direct-client calls remain sequential.
+                client = init_api(email, password)
+                assert client is not None
                 fit_bytes = client.download_workout(workout_id)
                 fit_steps = list(
                     FitFile(BytesIO(fit_bytes)).get_messages("workout_step")
@@ -108,9 +175,7 @@ async def test_nested_pace_bounds_survive_inline_schedule_and_fit_export():
             finally:
                 if workout_id is not None:
                     async with asyncio.timeout(20):
-                        delete_result = await session.call_tool(
-                            "delete_workout",
-                            arguments={"workout_id": workout_id},
+                        await _cleanup_scheduled_workout(
+                            session,
+                            workout_id,
                         )
-                    delete_data = json.loads(delete_result.content[0].text)
-                    assert delete_data["status"] == "success"

--- a/tests/e2e/test_nested_workout_target_values_live.py
+++ b/tests/e2e/test_nested_workout_target_values_live.py
@@ -1,0 +1,116 @@
+"""Live regression test for target values misplaced inside targetType.
+
+Run with:
+pytest tests/e2e/test_nested_workout_target_values_live.py -m e2e -s
+"""
+
+import asyncio
+import json
+import sys
+from io import BytesIO
+
+import pytest
+from fitparse import FitFile
+from mcp import ClientSession, StdioServerParameters
+from mcp.client.stdio import stdio_client
+
+from garmin_mcp import email, init_api, password
+
+
+@pytest.mark.e2e
+@pytest.mark.asyncio
+@pytest.mark.timeout(90)
+async def test_nested_pace_bounds_survive_inline_schedule_and_fit_export():
+    """MCP repairs issue #210's payload before Garmin silently drops its bounds."""
+    server_params = StdioServerParameters(
+        command=sys.executable,
+        args=["-m", "garmin_mcp"],
+        env=None,
+    )
+    workout_data = {
+        "workoutName": "e2e nested target values - DELETE ME",
+        "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
+        "workoutSegments": [{
+            "segmentOrder": 1,
+            "sportType": {"sportTypeId": 1, "sportTypeKey": "running"},
+            "workoutSteps": [{
+                "type": "ExecutableStepDTO",
+                "stepOrder": 1,
+                "stepType": {
+                    "stepTypeId": 3,
+                    "stepTypeKey": "interval",
+                },
+                "endCondition": {
+                    "conditionTypeId": 3,
+                    "conditionTypeKey": "distance",
+                },
+                "endConditionValue": 400,
+                "targetType": {
+                    "workoutTargetTypeId": 6,
+                    "workoutTargetTypeKey": "pace.zone",
+                    "targetValueOne": 2.0833333,
+                    "targetValueTwo": 1.9607843,
+                },
+            }],
+        }],
+    }
+
+    workout_id = None
+    async with stdio_client(server_params) as (read, write):
+        async with ClientSession(read, write) as session:
+            await session.initialize()
+            try:
+                async with asyncio.timeout(60):
+                    result = await session.call_tool(
+                        "schedule_workouts",
+                        arguments={
+                            "schedules": [{
+                                "calendar_date": "2099-01-01",
+                                "workout_data": workout_data,
+                            }]
+                        },
+                    )
+                result_data = json.loads(result.content[0].text)
+                assert result_data["succeeded"] == 1
+                assert result_data["failed"] == 0
+                workout_id = result_data["results"][0].get("workout_id")
+                assert workout_id is not None
+
+                client = init_api(email, password)
+                assert client is not None
+                stored = client.get_workout_by_id(workout_id)
+                stored_step = stored["workoutSegments"][0]["workoutSteps"][0]
+                assert stored_step["targetValueOne"] == pytest.approx(
+                    2.0833333,
+                )
+                assert stored_step["targetValueTwo"] == pytest.approx(
+                    1.9607843,
+                )
+
+                fit_bytes = client.download_workout(workout_id)
+                fit_steps = list(
+                    FitFile(BytesIO(fit_bytes)).get_messages("workout_step")
+                )
+                assert len(fit_steps) == 1
+                fields = {
+                    field.name: field.value
+                    for field in fit_steps[0]
+                }
+                assert fields["target_type"] == "speed"
+                assert fields["custom_target_speed_low"] == pytest.approx(
+                    1.961,
+                    abs=0.001,
+                )
+                assert fields["custom_target_speed_high"] == pytest.approx(
+                    2.083,
+                    abs=0.001,
+                )
+            finally:
+                if workout_id is not None:
+                    async with asyncio.timeout(20):
+                        delete_result = await session.call_tool(
+                            "delete_workout",
+                            arguments={"workout_id": workout_id},
+                        )
+                    delete_data = json.loads(delete_result.content[0].text)
+                    assert delete_data["status"] == "success"

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -9,8 +9,8 @@ from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import workouts
 from garmin_mcp.workouts import (
-    _fix_nested_target_values_step,
     _fix_repeat_group_step,
+    _normalize_workout_steps,
 )
 from tests.fixtures.garmin_responses import (
     MOCK_WORKOUTS,
@@ -420,9 +420,135 @@ async def test_upload_workout_rejects_conflicting_nested_and_step_bounds(
 
     message = result[0][0].text
     assert (
-        "workoutSegments[0].workoutSteps[0].targetValueOne conflicts with "
-        "workoutSegments[0].workoutSteps[0].targetType.targetValueOne"
+        "workoutSegments[0].workoutSteps[0].targetValueOne=2.5 conflicts with "
+        "workoutSegments[0].workoutSteps[0].targetType.targetValueOne="
+        "2.0833333"
     ) in message
+    assert "keep only the step-level targetValueOne" in message
+    mock_garmin_client.upload_workout.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_promotes_zone_nested_inside_target_type(
+    app_with_workouts, mock_garmin_client
+):
+    """Garmin drops zoneNumber inside targetType, so move it to the step."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210005,
+        "workoutName": "Nested HR Zone",
+    }
+    step = _distance_pace_step_with_nested_bounds()
+    step["targetType"] = {
+        "workoutTargetTypeId": 4,
+        "workoutTargetTypeKey": "heart.rate.zone",
+        "zoneNumber": 3,
+    }
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Nested HR Zone",
+    )
+
+    await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["zoneNumber"] == 3
+    assert "zoneNumber" not in called_step["targetType"]
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_promotes_nested_hr_zone_value_before_hr_fix(
+    app_with_workouts, mock_garmin_client
+):
+    """Pin the order: move a mistaken HR value first, then convert it to a zone."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210006,
+        "workoutName": "Nested HR Target Value",
+    }
+    step = _distance_pace_step_with_nested_bounds()
+    step["targetType"] = {
+        "workoutTargetTypeId": 4,
+        "workoutTargetTypeKey": "heart.rate.zone",
+        "targetValueOne": 3,
+    }
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Nested HR Target Value",
+    )
+
+    await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["zoneNumber"] == 3
+    assert "targetValueOne" not in called_step
+    assert "targetValueOne" not in called_step["targetType"]
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_promotes_bounds_nested_inside_secondary_target_type(
+    app_with_workouts, mock_garmin_client
+):
+    """Secondary target bounds have the same Garmin step-level shape."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210007,
+        "workoutName": "Nested Secondary Pace",
+    }
+    step = _distance_pace_step_with_nested_bounds()
+    step["targetType"] = None
+    step["secondaryTargetType"] = {
+        "workoutTargetTypeId": 6,
+        "workoutTargetTypeKey": "pace.zone",
+        "secondaryTargetValueOne": 0.45,
+        "secondaryTargetValueTwo": 0.6916667,
+    }
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Nested Secondary Pace",
+    )
+
+    await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["secondaryTargetValueOne"] == 0.45
+    assert called_step["secondaryTargetValueTwo"] == 0.6916667
+    assert "secondaryTargetValueOne" not in called_step["secondaryTargetType"]
+    assert "secondaryTargetValueTwo" not in called_step["secondaryTargetType"]
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_zone_mixed_with_custom_range(
+    app_with_workouts, mock_garmin_client
+):
+    """Do not guess whether a named zone or custom range should win."""
+    step = _distance_pace_step_with_nested_bounds()
+    step["zoneNumber"] = 3
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Ambiguous Pace Target",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    message = result[0][0].text
+    assert "mixes zoneNumber=3 with custom range fields" in message
+    assert "use either a named zone or a custom range" in message
     mock_garmin_client.upload_workout.assert_not_called()
 
 
@@ -1961,14 +2087,81 @@ async def test_schedule_workouts_inline_upload_no_id_returned(app_with_workouts,
 def test_nested_target_conflict_does_not_partially_mutate_step():
     step = _distance_pace_step_with_nested_bounds()
     step["targetValueOne"] = 2.5
+    workout_data = _running_workout_with_steps([step])
 
-    with pytest.raises(ValueError, match="targetValueOne conflicts"):
-        _fix_nested_target_values_step(step, "workoutSteps[0]")
+    with pytest.raises(ValueError, match="targetValueOne=.*conflicts"):
+        _normalize_workout_steps(workout_data)
 
     assert step["targetValueOne"] == 2.5
     assert "targetValueTwo" not in step
     assert step["targetType"]["targetValueOne"] == 2.0833333
     assert step["targetType"]["targetValueTwo"] == 1.9607843
+
+
+def test_nested_target_conflict_does_not_mutate_earlier_workout_step():
+    first_step = _distance_pace_step_with_nested_bounds()
+    second_step = _distance_pace_step_with_nested_bounds()
+    second_step["targetValueOne"] = 2.5
+    workout_data = _running_workout_with_steps([first_step, second_step])
+
+    with pytest.raises(ValueError, match="targetValueOne=.*conflicts"):
+        _normalize_workout_steps(workout_data)
+
+    assert "targetValueOne" not in first_step
+    assert first_step["targetType"]["targetValueOne"] == 2.0833333
+    assert first_step["targetType"]["targetValueTwo"] == 1.9607843
+
+
+def test_nested_target_fields_promote_single_bound_and_deduplicate_equal_value():
+    step = {
+        "targetValueOne": 2.0833333,
+        "targetType": {
+            "targetValueOne": 2.0833333,
+            "targetValueTwo": 1.9607843,
+        },
+    }
+    workout_data = _running_workout_with_steps([step])
+
+    _normalize_workout_steps(workout_data)
+
+    assert step["targetValueOne"] == 2.0833333
+    assert step["targetValueTwo"] == 1.9607843
+    assert step["targetType"] == {}
+
+
+def test_nested_null_target_field_is_removed_without_injecting_step_null():
+    step = {"targetType": {"targetValueOne": None}}
+    workout_data = _running_workout_with_steps([step])
+
+    _normalize_workout_steps(workout_data)
+
+    assert step == {"targetType": {}}
+
+
+def test_nested_value_replaces_explicit_step_null():
+    step = {
+        "targetValueOne": None,
+        "targetType": {"targetValueOne": 2.0833333},
+    }
+    workout_data = _running_workout_with_steps([step])
+
+    _normalize_workout_steps(workout_data)
+
+    assert step["targetValueOne"] == 2.0833333
+    assert step["targetType"] == {}
+
+
+@pytest.mark.parametrize("target_type", [None, "pace.zone", []])
+def test_nested_target_repair_ignores_missing_or_non_dict_target_type(
+    target_type,
+):
+    step = {} if target_type is None else {"targetType": target_type}
+    original = step.copy()
+    workout_data = _running_workout_with_steps([step])
+
+    _normalize_workout_steps(workout_data)
+
+    assert step == original
 
 
 def test_fix_repeat_group_adds_missing_condition_type_id():

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -8,7 +8,10 @@ from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import workouts
-from garmin_mcp.workouts import _fix_repeat_group_step
+from garmin_mcp.workouts import (
+    _fix_nested_target_values_step,
+    _fix_repeat_group_step,
+)
 from tests.fixtures.garmin_responses import (
     MOCK_WORKOUTS,
     MOCK_WORKOUT_DETAILS,
@@ -54,6 +57,21 @@ def _timed_interval_step(target_type):
         "targetValueTwo": 157,
     }
 
+
+def _distance_pace_step_with_nested_bounds():
+    return {
+        "type": "ExecutableStepDTO",
+        "stepOrder": 1,
+        "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
+        "endCondition": {"conditionTypeId": 3, "conditionTypeKey": "distance"},
+        "endConditionValue": 400,
+        "targetType": {
+            "workoutTargetTypeId": 6,
+            "workoutTargetTypeKey": "pace.zone",
+            "targetValueOne": 2.0833333,
+            "targetValueTwo": 1.9607843,
+        },
+    }
 
 
 @pytest.mark.asyncio
@@ -309,6 +327,103 @@ async def test_upload_workout_tool(app_with_workouts, mock_garmin_client):
     # Verify - dict is passed directly to the API
     assert result is not None
     mock_garmin_client.upload_workout.assert_called_once_with(workout_data)
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_promotes_bounds_nested_inside_target_type(
+    app_with_workouts, mock_garmin_client
+):
+    """Repair the exact payload shape that caused issue #210."""
+    import json as json_module
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210001,
+        "workoutName": "Issue 210",
+    }
+    workout_data = _running_workout_with_steps(
+        [_distance_pace_step_with_nested_bounds()],
+        name="Issue 210",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["status"] == "success"
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["targetValueOne"] == 2.0833333
+    assert called_step["targetValueTwo"] == 1.9607843
+    assert "targetValueOne" not in called_step["targetType"]
+    assert "targetValueTwo" not in called_step["targetType"]
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_promotes_nested_bounds_inside_repeat_group(
+    app_with_workouts, mock_garmin_client
+):
+    """Repair misplaced bounds recursively in the original nested shape."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210002,
+        "workoutName": "Issue 210 Repeat",
+    }
+    workout_data = _running_workout_with_steps(
+        [{
+            "type": "RepeatGroupDTO",
+            "stepOrder": 1,
+            "numberOfIterations": 3,
+            "endCondition": {
+                "conditionTypeId": 7,
+                "conditionTypeKey": "iterations",
+            },
+            "endConditionValue": 3,
+            "workoutSteps": [_distance_pace_step_with_nested_bounds()],
+        }],
+        name="Issue 210 Repeat",
+    )
+
+    await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]["workoutSteps"][0]
+    assert called_step["targetValueOne"] == 2.0833333
+    assert called_step["targetValueTwo"] == 1.9607843
+    assert set(called_step["targetType"]) == {
+        "workoutTargetTypeId",
+        "workoutTargetTypeKey",
+    }
+
+
+@pytest.mark.asyncio
+async def test_upload_workout_rejects_conflicting_nested_and_step_bounds(
+    app_with_workouts, mock_garmin_client
+):
+    """Do not guess when malformed and canonical fields disagree."""
+    step = _distance_pace_step_with_nested_bounds()
+    step["targetValueOne"] = 2.5
+    workout_data = _running_workout_with_steps(
+        [step],
+        name="Conflicting Pace Bounds",
+    )
+
+    result = await app_with_workouts.call_tool(
+        "upload_workout",
+        {"workout_data": workout_data},
+    )
+
+    message = result[0][0].text
+    assert (
+        "workoutSegments[0].workoutSteps[0].targetValueOne conflicts with "
+        "workoutSegments[0].workoutSteps[0].targetType.targetValueOne"
+    ) in message
+    mock_garmin_client.upload_workout.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -1247,6 +1362,34 @@ async def test_upload_workouts_single(app_with_workouts, mock_garmin_client):
 
 
 @pytest.mark.asyncio
+async def test_upload_workouts_promotes_bounds_nested_inside_target_type(
+    app_with_workouts, mock_garmin_client
+):
+    """Batch uploads use the same issue #210 repair as upload_workout."""
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210003,
+        "workoutName": "Issue 210 Batch",
+    }
+    workout_data = _running_workout_with_steps(
+        [_distance_pace_step_with_nested_bounds()],
+        name="Issue 210 Batch",
+    )
+
+    await app_with_workouts.call_tool(
+        "upload_workouts",
+        {"workouts": [workout_data]},
+    )
+
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["targetValueOne"] == 2.0833333
+    assert called_step["targetValueTwo"] == 1.9607843
+    assert "targetValueOne" not in called_step["targetType"]
+    assert "targetValueTwo" not in called_step["targetType"]
+
+
+@pytest.mark.asyncio
 async def test_upload_workouts_multiple(app_with_workouts, mock_garmin_client):
     """Test upload_workouts with multiple workouts"""
     import json as json_module
@@ -1646,6 +1789,44 @@ async def test_schedule_workouts_inline_upload(app_with_workouts, mock_garmin_cl
 
 
 @pytest.mark.asyncio
+async def test_schedule_workouts_inline_promotes_nested_target_bounds(
+    app_with_workouts, mock_garmin_client
+):
+    """The issue #210 schedule_workouts path repairs bounds before upload."""
+    from unittest.mock import MagicMock
+
+    mock_garmin_client.upload_workout.return_value = {
+        "workoutId": 210004,
+        "workoutName": "Issue 210 Inline",
+    }
+    schedule_response = MagicMock()
+    schedule_response.status_code = 200
+    mock_garmin_client.client.post.return_value = schedule_response
+    inline_data = _running_workout_with_steps(
+        [_distance_pace_step_with_nested_bounds()],
+        name="Issue 210 Inline",
+    )
+
+    await app_with_workouts.call_tool(
+        "schedule_workouts",
+        {
+            "schedules": [{
+                "workout_data": inline_data,
+                "calendar_date": "2024-02-01",
+            }]
+        },
+    )
+
+    called_step = mock_garmin_client.upload_workout.call_args[0][0][
+        "workoutSegments"
+    ][0]["workoutSteps"][0]
+    assert called_step["targetValueOne"] == 2.0833333
+    assert called_step["targetValueTwo"] == 1.9607843
+    assert "targetValueOne" not in called_step["targetType"]
+    assert "targetValueTwo" not in called_step["targetType"]
+
+
+@pytest.mark.asyncio
 async def test_schedule_workouts_inline_upload_rejects_end_condition_mismatch(
     app_with_workouts, mock_garmin_client
 ):
@@ -1773,8 +1954,22 @@ async def test_schedule_workouts_inline_upload_no_id_returned(app_with_workouts,
 
 
 # ---------------------------------------------------------------------------
-# _fix_repeat_group_step (unit tests)
+# Target/repeat normalization helper tests
 # ---------------------------------------------------------------------------
+
+
+def test_nested_target_conflict_does_not_partially_mutate_step():
+    step = _distance_pace_step_with_nested_bounds()
+    step["targetValueOne"] = 2.5
+
+    with pytest.raises(ValueError, match="targetValueOne conflicts"):
+        _fix_nested_target_values_step(step, "workoutSteps[0]")
+
+    assert step["targetValueOne"] == 2.5
+    assert "targetValueTwo" not in step
+    assert step["targetType"]["targetValueOne"] == 2.0833333
+    assert step["targetType"]["targetValueTwo"] == 1.9607843
+
 
 def test_fix_repeat_group_adds_missing_condition_type_id():
     """Adds conditionTypeId:7 when conditionTypeKey is 'iterations' but id is absent."""


### PR DESCRIPTION
## Summary

Fix #210 by repairing workout target bounds that are mistakenly nested inside
`targetType`.

Garmin accepts that malformed payload without an API error and preserves
`pace.zone`, but silently discards the bounds. The resulting workout can still
show descriptive text such as `8:00–8:30/km`, while the device has no
machine-readable target range to track.

This change:

- moves nested bounds and zone numbers from `targetType` and
  `secondaryTargetType` to their canonical step-level positions;
- applies the repair recursively inside repeat groups;
- preflights the complete workout before mutation and reports both conflicting
  values with an actionable path;
- rejects targets that mix a named zone with a custom range instead of relying
  on Garmin's silent zone precedence;
- covers `upload_workout`, `upload_workouts`, and inline `schedule_workouts`;
- documents the correct sibling-field shape and the m/s units used by custom
  running pace ranges.

## Root cause and reproduction

The issue body originally showed the canonical shape:

```json
{
  "targetType": {
    "workoutTargetTypeId": 6,
    "workoutTargetTypeKey": "pace.zone"
  },
  "targetValueOne": 2.0833333,
  "targetValueTwo": 1.9607843
}
```

The later complete payloads revealed that the actual uploaded shape was:

```json
{
  "targetType": {
    "workoutTargetTypeId": 6,
    "workoutTargetTypeKey": "pace.zone",
    "targetValueOne": 2.0833333,
    "targetValueTwo": 1.9607843
  }
}
```

A live API and Forerunner 255 A/B test reproduced the difference:

| Case | Stored Garmin JSON | FIT export | Device |
|---|---|---|---|
| Bounds nested inside `targetType` | both bounds `null` | no target fields | preview says no target; descriptive screen remains, but no range tracking |
| Bounds beside `targetType` | both bounds preserved | `target_type=speed`, range `1.961–2.083 m/s` | preview shows `8:00–8:30/km`; range tracking works |

This rules out repeat-group nesting, bound ordering, and device-family behavior
as the cause of the reported symptom.

## Safety behavior

Unambiguous malformed input is repaired:

```json
{
  "targetType": {
    "workoutTargetTypeId": 6,
    "workoutTargetTypeKey": "pace.zone",
    "targetValueOne": 2.0833333
  }
}
```

becomes:

```json
{
  "targetType": {
    "workoutTargetTypeId": 6,
    "workoutTargetTypeKey": "pace.zone"
  },
  "targetValueOne": 2.0833333
}
```

If both positions are present with different values, the request is rejected
before upload with the exact workout-step path and both values. The complete
workout is preflighted before nested target fields are moved, so a conflict in a
later step cannot leave an earlier step partially normalized.

Named zones and custom ranges are mutually exclusive. Live API verification
showed that Garmin keeps `zoneNumber` and silently discards coexisting custom
bounds; the tools reject that ambiguous shape instead.

## Verification

- focused workout integration tests: `82 passed`
- Python 3.10.20: `422 passed`
- Python 3.11.15: `422 passed`
- Python 3.12.13: `422 passed`
- Python 3.13.13: `422 passed`
- live API probes confirmed:
  - nested primary `zoneNumber` is discarded while its step-level form survives;
  - a named zone takes precedence and causes coexisting custom bounds to be discarded;
  - nested secondary bounds are discarded while their step-level forms survive;
- live E2E on the exact inline `schedule_workouts` path:
  - malformed nested input sent through the MCP;
  - stored Garmin JSON preserved both repaired bounds;
  - downloaded FIT contained the intended speed range;
- `uv lock --check`
- `git diff --check`

## Related open work

No currently open PR overlaps this fix.

#214 adds an `update_workout` tool but is still open and not part of current
`main`. If #214 merges first, this branch should be rebased and that new
caller-supplied update path should invoke the same normalization helper before
validation.

Closes #210.
