### PR TITLE
fix(workouts): omit invalid hardcoded category on strength workout steps (closes #196)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,16 @@ Returns: `{"status": "success", "workout_id": 1234567890, ...}`
 
 ### `create_strength_workout`
 
-Creates a strength workout from a list of exercises. Unknown names fall back to a generic step with the original name preserved.
+Creates a strength workout from a list of exercises. Each becomes a reps-based step, with the
+name kept in the step description. The name is also sent as `exerciseName`, but Garmin only
+retains that when it matches one of its own exercise keys (e.g. `FARMERS_CARRY`) — any other
+value is accepted and then stored empty.
+
+`category` is optional and passed straight through. Omit it and the key is left out of the
+payload entirely, which Garmin accepts. Supply it and it must be one of Garmin's exercise
+categories — anything else, including `OTHER` and `UNASSIGNED`, is rejected with
+`400 - Invalid category`. The full list is published at
+[`Exercises.json`](https://connect.garmin.com/web-data/exercises/Exercises.json).
 
 ```json
 {
@@ -146,7 +155,8 @@ Creates a strength workout from a list of exercises. Unknown names fall back to 
   "exercises": [
     {"name": "Sentadillas", "sets": 3, "reps": 12, "rest_seconds": 90},
     {"name": "Flexiones",   "sets": 3, "reps": 15, "rest_seconds": 60},
-    {"name": "Peso muerto", "sets": 3, "reps": 10, "rest_seconds": 90}
+    {"name": "Peso muerto", "sets": 3, "reps": 10, "rest_seconds": 90},
+    {"name": "Farmers Carry 40m", "sets": 3, "reps": 1, "rest_seconds": 90, "category": "CARRY"}
   ]
 }
 ```

--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -223,19 +223,23 @@ def build_z2_walk_json(
     }
 
 
-# Simplified internal exercise catalog (English → Garmin exerciseName key or fallback)
-# Garmin strength workouts use exerciseName as a free-text label when the exercise
-# is not in their catalog. For structured strength, we use "Other" (generic) and
-# put the user name in description / exerciseName.
-
 def build_strength_json(
     name: str,
     exercises: List[Dict[str, Any]],
 ) -> dict:
     """Build the Garmin Connect JSON for a strength workout.
 
-    Each exercise maps to a generic step; if the name is not recognised in the
-    Garmin catalog we use 'Other' and put the original name in exerciseName.
+    Each exercise becomes a reps-based work step. The name is preserved in the step
+    "description", which is what survives the round trip. It is also sent as
+    "exerciseName", but Garmin only retains that when it matches one of its own
+    exercise keys (e.g. "FARMERS_CARRY"); any other value is accepted and then
+    stored as an empty string.
+
+    "category" is optional and only emitted when the caller supplies one, uppercased
+    and otherwise passed through untouched. Garmin validates it against its own enum
+    and rejects anything outside it, including "UNASSIGNED" and "OTHER"; omitting the
+    key is accepted. Valid values come from Garmin's published catalog:
+    https://connect.garmin.com/web-data/exercises/Exercises.json
     """
     steps: List[dict] = []
     step_order = 1
@@ -247,7 +251,7 @@ def build_strength_json(
         rest_seconds = int(ex.get("rest_seconds", 60))
 
         # Work step
-        steps.append({
+        step = {
             "type": "ExecutableStepDTO",
             "stepOrder": step_order,
             "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
@@ -255,9 +259,21 @@ def build_strength_json(
             "endCondition": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
             "endConditionValue": float(reps),
             "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
-            "category": "UNASSIGNED",
             "exerciseName": ex_name,
-        })
+        }
+
+        # Only set when the caller asked for it: Garmin rejects values outside its own
+        # enum, and an absent category is accepted, so an unknown one stays absent
+        # rather than being guessed into a wrong record.
+        category = ex.get("category")
+        if category is not None:
+            if not isinstance(category, str) or not category.strip():
+                raise ValueError(
+                    f"category for exercise {ex_name!r} must be a non-empty string"
+                )
+            step["category"] = category.strip().upper()
+
+        steps.append(step)
         step_order += 1
 
         # Rest step (skip after last exercise)
@@ -426,12 +442,19 @@ def register_tools(app):
     ) -> str:
         """Create a strength workout and upload it to Garmin Connect.
 
-        Each exercise is mapped to a generic step; unsupported names fallback to
-        "Other" with the original name stored in exerciseName.
+        Each exercise becomes a reps-based step. The name is kept in the step
+        description; it is also sent as exerciseName, which Garmin only retains when
+        it matches one of its own exercise keys (e.g. "FARMERS_CARRY").
 
         Args:
             name: Workout name
-            exercises: List of dicts with keys: name, sets, reps, rest_seconds
+            exercises: List of dicts with keys: name, sets, reps, rest_seconds and an
+                optional category. Category is omitted from the payload when not
+                given; Garmin accepts that. When given it must be one of Garmin's
+                exercise categories (e.g. SQUAT, DEADLIFT, PUSH_UP, CARRY, SLED) —
+                anything else, including "UNASSIGNED" and "OTHER", is rejected with
+                400 Invalid category. Full list:
+                https://connect.garmin.com/web-data/exercises/Exercises.json
         """
         try:
             workout_json = build_strength_json(name=name, exercises=exercises)

--- a/tests/unit/test_workout_builders.py
+++ b/tests/unit/test_workout_builders.py
@@ -1,6 +1,8 @@
 import json
 import os
 
+import pytest
+
 from garmin_mcp.workout_builders import (
     build_walk_run_json,
     build_z2_walk_json,
@@ -85,3 +87,55 @@ def test_build_strength_json_structure():
     assert len(steps) == 3
     assert steps[0]["exerciseName"] == "Sentadillas"
     assert steps[2]["exerciseName"] == "Flexiones"
+
+
+# ---------------------------------------------------------------------------
+# Strength step categories
+#
+# Garmin validates "category" against its own enum. A value outside it — the
+# previously hardcoded "UNASSIGNED" — fails every upload with `400 - Invalid
+# category`, while omitting the key is accepted.
+# ---------------------------------------------------------------------------
+
+
+def _work_steps(result):
+    """Only the exercise steps; rest steps are recovery steps and carry no category."""
+    steps = result["workoutSegments"][0]["workoutSteps"]
+    return [s for s in steps if s["stepType"]["stepTypeKey"] == "interval"]
+
+
+def test_strength_omits_category_when_not_supplied():
+    result = build_strength_json(
+        name="No categories",
+        exercises=[
+            {"name": "Back Squat", "sets": 3, "reps": 5, "rest_seconds": 120},
+            {"name": "Zercher Whatever", "sets": 3, "reps": 8, "rest_seconds": 60},
+        ],
+    )
+    for step in _work_steps(result):
+        assert "category" not in step
+    # The name survives the Garmin round trip in the description, not exerciseName.
+    assert _work_steps(result)[0]["description"].startswith("Back Squat:")
+
+
+def test_strength_passes_through_supplied_category():
+    result = build_strength_json(
+        name="Mixed",
+        exercises=[
+            {"name": "Farmers Carry 40m", "sets": 3, "reps": 1, "category": "carry"},
+            {"name": "Back Squat", "sets": 3, "reps": 5},
+        ],
+    )
+    first, second = _work_steps(result)
+    assert first["category"] == "CARRY"
+    assert first["exerciseName"] == "Farmers Carry 40m"
+    assert "category" not in second
+
+
+def test_strength_rejects_empty_category():
+    for bad in ("", "   ", 5):
+        with pytest.raises(ValueError):
+            build_strength_json(
+                name="Bad",
+                exercises=[{"name": "Back Squat", "sets": 1, "reps": 1, "category": bad}],
+            )


### PR DESCRIPTION
Fixes #196 (regression introduced in batch PR #201).

Applies the changes from contributor PR #213 (by @lriverawong). The previous fix for reps-based strength workouts hardcoded `"category": "UNASSIGNED"`, which Garmin rejects as an invalid value, causing strength workout uploads to fail.

## Changes
- `workout_builders.py`: remove the hardcoded `"category": "UNASSIGNED"` from strength steps; category is now an optional parameter — only included when explicitly provided and non-empty
- `README.md`: document the optional `category` parameter

## Tests
- 3 new unit tests: `test_strength_omits_category_when_not_supplied`, `test_strength_passes_through_supplied_category`, `test_strength_rejects_empty_category`
- All 7 workout builder tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)