### PR TITLE
fix: cap mcp <2 so fresh installs stop resolving to the 2.x API

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,9 @@ dependencies = [
     "python-dotenv==1.2.2",
     "garminconnect==0.3.2",
     "requests==2.33.0",
-    "mcp>=1.28.1",
+    # mcp 2.x renamed mcp.server.fastmcp -> mcp.server.mcpserver (FastMCP ->
+    # MCPServer). Cap until the server is ported to the new API.
+    "mcp>=1.28.1,<2",
     "fitparse>=1.2.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -358,7 +358,7 @@ dev = [
 requires-dist = [
     { name = "fitparse", specifier = ">=1.2.0" },
     { name = "garminconnect", specifier = "==0.3.2" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "requests", specifier = "==2.33.0" },
 ]


### PR DESCRIPTION
Fixes #226.

`mcp` 2.0.0 is now on PyPI and renamed the `mcp.server.fastmcp` package to `mcp.server.mcpserver` (`FastMCP` -> `MCPServer`). Because the dependency is declared as an open-ended `mcp>=1.28.1`, every fresh resolve picks up 2.x and the server dies at import:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

This hits any `uvx --from git+...` launch, which re-resolves on each run — including the DXT / Claude Desktop entry point — so installs that worked yesterday break with no local change and no obvious cause (Claude Desktop only reports a generic disconnect).

This is the fix suggested in #226: cap at `<2` until the server is ported to the `MCPServer` API. `uv.lock` already resolves mcp 1.28.1, so only the requirement string changes there.

## Verification

- `uvx --refresh --from . --python 3.12 garmin-mcp` starts again (fails on `main` with the traceback above).
- 455 integration + unit tests pass.

Note this is a stopgap — the real follow-up is porting `mcp.server.fastmcp.FastMCP` to `mcp.server.mcpserver.MCPServer`, which I have not attempted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)