### PR TITLE
feat(training): fall back to profile VO2 max when trend history is unavailable

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -4,7 +4,7 @@ Training and performance functions for Garmin Connect MCP Server
 
 import json
 import datetime
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 # The garmin_client will be set by the main file
 garmin_client = None
@@ -25,29 +25,41 @@ def _as_dict(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def _extract_vo2_value(data: Any) -> Optional[float]:
-    """Find a VO2 max value in known Garmin response shapes."""
+def _extract_vo2_measurement(data: Any) -> Optional[Tuple[float, str]]:
+    """Find a VO2 max value and sport in known Garmin response shapes."""
+    if isinstance(data, list):
+        for item in data:
+            measurement = _extract_vo2_measurement(item)
+            if measurement is not None:
+                return measurement
+        return None
+
     data = _as_dict(data)
+    # Garmin uses "generic" for its running/non-cycling VO2 max series.
     candidate_paths = (
-        ("vo2MaxRunning",),
-        ("vo2MaxCycling",),
-        ("vo2Max",),
-        ("vo2MaxValue",),
-        ("vo2MaxPreciseValue",),
-        ("mostRecentVO2Max", "generic", "vo2MaxValue"),
-        ("mostRecentVO2Max", "generic", "vo2MaxPreciseValue"),
-        ("mostRecentVO2Max", "cycling", "vo2MaxValue"),
-        ("mostRecentVO2Max", "cycling", "vo2MaxPreciseValue"),
-        ("userData", "vo2MaxRunning"),
-        ("userData", "vo2MaxCycling"),
+        (("vo2MaxRunning",), "running"),
+        (("vo2MaxCycling",), "cycling"),
+        (("vo2Max",), "running"),
+        (("vo2MaxValue",), "running"),
+        (("vo2MaxPreciseValue",), "running"),
+        (("generic", "vo2MaxValue"), "running"),
+        (("generic", "vo2MaxPreciseValue"), "running"),
+        (("cycling", "vo2MaxValue"), "cycling"),
+        (("cycling", "vo2MaxPreciseValue"), "cycling"),
+        (("mostRecentVO2Max", "generic", "vo2MaxValue"), "running"),
+        (("mostRecentVO2Max", "generic", "vo2MaxPreciseValue"), "running"),
+        (("mostRecentVO2Max", "cycling", "vo2MaxValue"), "cycling"),
+        (("mostRecentVO2Max", "cycling", "vo2MaxPreciseValue"), "cycling"),
+        (("userData", "vo2MaxRunning"), "running"),
+        (("userData", "vo2MaxCycling"), "cycling"),
     )
 
-    for path in candidate_paths:
+    for path, sport in candidate_paths:
         current: Any = data
         for key in path:
             current = _as_dict(current).get(key)
-        if isinstance(current, (int, float)):
-            return float(current)
+        if isinstance(current, (int, float)) and not isinstance(current, bool):
+            return float(current), sport
     return None
 
 
@@ -1025,6 +1037,9 @@ def register_tools(app):
         Note: VO2 max estimates are smoothed and update gradually — daily changes of <0.5
         are within normal noise. Focus on the 4-6 week trend direction.
 
+        If historical values are unavailable, the current profile estimate is returned
+        separately and is not represented as a historical trend point.
+
         Recommended range: 4-12 weeks. Maximum: 90 days.
 
         Args:
@@ -1046,29 +1061,39 @@ def register_tools(app):
 
         trend = []
         last_vo2 = None
+        selected_sport = None
         current = start
         while current <= end:
             date_str = current.isoformat()
-            vo2 = None
+            measurement = None
             source = None
 
             for method_name in (
-                "get_max_metrics",
-                "get_fitnessage_data",
                 "get_training_status",
+                "get_max_metrics",
             ):
                 method = getattr(garmin_client, method_name, None)
                 if not method:
                     continue
                 try:
-                    vo2 = _extract_vo2_value(method(date_str))
+                    candidate = _extract_vo2_measurement(method(date_str))
                 except Exception:
                     continue
-                if vo2 is not None:
-                    source = method_name
-                    break
+                if candidate is None:
+                    continue
 
-            if vo2 is not None:
+                candidate_vo2, candidate_sport = candidate
+                if selected_sport is not None and candidate_sport != selected_sport:
+                    continue
+
+                measurement = (candidate_vo2, candidate_sport)
+                source = method_name
+                break
+
+            if measurement is not None:
+                vo2, sport = measurement
+                if selected_sport is None:
+                    selected_sport = sport
                 vo2_rounded = round(vo2, 1)
                 if vo2_rounded != last_vo2:  # deduplicate unchanged values
                     trend.append(
@@ -1081,27 +1106,24 @@ def register_tools(app):
                     last_vo2 = vo2_rounded
             current += datetime.timedelta(days=1)
 
+        current_estimate = None
         if not trend:
             try:
                 profile = garmin_client.get_user_profile()
             except Exception:
                 profile = None
 
-            current_vo2 = _extract_vo2_value(profile)
-            if current_vo2 is None:
+            current_estimate = _extract_vo2_measurement(profile)
+            if current_estimate is None:
                 return f"No VO2 max data found between {start_date} and {end_date}."
-
-            trend.append(
-                {
-                    "date": end_date,
-                    "vo2_max": round(current_vo2, 1),
-                    "source": "get_user_profile",
-                }
-            )
 
         first_vo2 = trend[0]["vo2_max"] if trend else None
         latest_vo2 = trend[-1]["vo2_max"] if trend else None
-        change = round(latest_vo2 - first_vo2, 1) if (first_vo2 and latest_vo2) else None
+        change = (
+            round(latest_vo2 - first_vo2, 1)
+            if (first_vo2 is not None and latest_vo2 is not None)
+            else None
+        )
 
         response = {
             "start_date": start_date,
@@ -1112,10 +1134,19 @@ def register_tools(app):
             "change": change,
             "trend": trend,
         }
-        if trend and trend[-1].get("source") == "get_user_profile":
+        if selected_sport is not None:
+            response["sport"] = selected_sport
+
+        if current_estimate is not None:
+            current_vo2, current_sport = current_estimate
+            response["current_vo2_max_estimate"] = {
+                "vo2_max": round(current_vo2, 1),
+                "sport": current_sport,
+                "source": "get_user_profile",
+            }
             response["note"] = (
-                "Historical VO2 max values were not available from Garmin's "
-                "training status endpoint; returning the current profile estimate."
+                "Historical VO2 max values were not available from Garmin; "
+                "returning the current profile estimate separately."
             )
 
         return json.dumps(response, indent=2)

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -4,6 +4,7 @@ Training and performance functions for Garmin Connect MCP Server
 
 import json
 import datetime
+import math
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 # The garmin_client will be set by the main file
@@ -25,14 +26,14 @@ def _as_dict(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def _extract_vo2_measurement(data: Any) -> Optional[Tuple[float, str]]:
-    """Find a VO2 max value and sport in known Garmin response shapes."""
+def _extract_vo2_measurements(data: Any) -> Dict[str, float]:
+    """Find all VO2 max values by sport in known Garmin response shapes."""
     if isinstance(data, list):
+        measurements: Dict[str, float] = {}
         for item in data:
-            measurement = _extract_vo2_measurement(item)
-            if measurement is not None:
-                return measurement
-        return None
+            for sport, value in _extract_vo2_measurements(item).items():
+                measurements.setdefault(sport, value)
+        return measurements
 
     data = _as_dict(data)
     # Garmin uses "generic" for its running/non-cycling VO2 max series.
@@ -54,13 +55,54 @@ def _extract_vo2_measurement(data: Any) -> Optional[Tuple[float, str]]:
         (("userData", "vo2MaxCycling"), "cycling"),
     )
 
+    measurements = {}
     for path, sport in candidate_paths:
         current: Any = data
         for key in path:
             current = _as_dict(current).get(key)
-        if isinstance(current, (int, float)) and not isinstance(current, bool):
-            return float(current), sport
-    return None
+        if (
+            sport not in measurements
+            and isinstance(current, (int, float))
+            and not isinstance(current, bool)
+            and math.isfinite(current)
+        ):
+            measurements[sport] = float(current)
+    return measurements
+
+
+def _extract_dated_vo2_measurements(data: Any) -> Dict[str, Dict[str, float]]:
+    """Index max-metrics range values by calendar date and sport."""
+    by_date: Dict[str, Dict[str, float]] = {}
+
+    def collect(item: Any) -> None:
+        if isinstance(item, list):
+            for nested_item in item:
+                collect(nested_item)
+            return
+
+        item = _as_dict(item)
+        measurements = _extract_vo2_measurements(item)
+        for sport, value in measurements.items():
+            section_name = "generic" if sport == "running" else "cycling"
+            section = _as_dict(item.get(section_name))
+            calendar_date = section.get("calendarDate") or item.get("calendarDate")
+            if isinstance(calendar_date, str):
+                by_date.setdefault(calendar_date, {}).setdefault(sport, value)
+
+    collect(data)
+    return by_date
+
+
+def _get_max_metrics_range(
+    client: Any, start_date: str, end_date: str
+) -> Tuple[bool, Any]:
+    """Fetch max metrics for a range when the Garmin client supports it."""
+    connectapi = getattr(client, "connectapi", None)
+    metrics_url = getattr(client, "garmin_connect_metrics_url", None)
+    if not callable(connectapi) or not isinstance(metrics_url, str) or not metrics_url:
+        return False, None
+
+    return True, connectapi(f"{metrics_url}/{start_date}/{end_date}")
 
 
 def _get_activity_type_mapping() -> Dict[int, str]:
@@ -1059,62 +1101,93 @@ def register_tools(app):
         if days < 1:
             return "end_date must be on or after start_date."
 
-        trend = []
-        last_vo2 = None
-        selected_sport = None
+        histories: Dict[str, List[Dict[str, Any]]] = {
+            "running": [],
+            "cycling": [],
+        }
+        range_measurements: Optional[Dict[str, Dict[str, float]]] = None
+        try:
+            range_supported, range_data = _get_max_metrics_range(
+                garmin_client, start_date, end_date
+            )
+            if range_supported:
+                range_measurements = _extract_dated_vo2_measurements(range_data)
+        except Exception:
+            # The range endpoint exists but failed. Continue with training status
+            # without retrying the same max-metrics endpoint once per day.
+            range_measurements = {}
+
         current = start
         while current <= end:
             date_str = current.isoformat()
-            measurement = None
+            measurements: Dict[str, float] = {}
             source = None
 
-            for method_name in (
-                "get_training_status",
-                "get_max_metrics",
-            ):
+            if range_measurements is not None:
+                measurements = range_measurements.get(date_str, {})
+                if measurements:
+                    source = "get_max_metrics"
+                method_names = ("get_training_status",) if not measurements else ()
+            else:
+                method_names = ("get_training_status", "get_max_metrics")
+
+            for method_name in method_names:
                 method = getattr(garmin_client, method_name, None)
-                if not method:
+                if not callable(method):
                     continue
                 try:
-                    candidate = _extract_vo2_measurement(method(date_str))
+                    measurements = _extract_vo2_measurements(method(date_str))
                 except Exception:
                     continue
-                if candidate is None:
+                if not measurements:
                     continue
-
-                candidate_vo2, candidate_sport = candidate
-                if selected_sport is not None and candidate_sport != selected_sport:
-                    continue
-
-                measurement = (candidate_vo2, candidate_sport)
                 source = method_name
                 break
 
-            if measurement is not None:
-                vo2, sport = measurement
-                if selected_sport is None:
-                    selected_sport = sport
-                vo2_rounded = round(vo2, 1)
-                if vo2_rounded != last_vo2:  # deduplicate unchanged values
-                    trend.append(
-                        {
-                            "date": date_str,
-                            "vo2_max": vo2_rounded,
-                            "source": source,
-                        }
-                    )
-                    last_vo2 = vo2_rounded
+            for sport, vo2 in measurements.items():
+                histories[sport].append(
+                    {
+                        "date": date_str,
+                        "vo2_max": round(vo2, 1),
+                        "source": source,
+                    }
+                )
             current += datetime.timedelta(days=1)
 
+        selected_sport = None
+        if any(histories.values()):
+            # Prefer the sport with the best coverage; make ties deterministic.
+            selected_sport = max(
+                histories,
+                key=lambda sport: (
+                    len(histories[sport]),
+                    sport == "running",
+                ),
+            )
+
+        trend = []
+        last_vo2 = None
+        if selected_sport is not None:
+            for entry in histories[selected_sport]:
+                if entry["vo2_max"] != last_vo2:
+                    trend.append(entry)
+                    last_vo2 = entry["vo2_max"]
+
         current_estimate = None
+        current_sport = None
         if not trend:
             try:
                 profile = garmin_client.get_user_profile()
             except Exception:
                 profile = None
 
-            current_estimate = _extract_vo2_measurement(profile)
-            if current_estimate is None:
+            profile_measurements = _extract_vo2_measurements(profile)
+            if profile_measurements:
+                current_sport = (
+                    "running" if "running" in profile_measurements else "cycling"
+                )
+                current_estimate = profile_measurements[current_sport]
+            else:
                 return f"No VO2 max data found between {start_date} and {end_date}."
 
         first_vo2 = trend[0]["vo2_max"] if trend else None
@@ -1138,9 +1211,8 @@ def register_tools(app):
             response["sport"] = selected_sport
 
         if current_estimate is not None:
-            current_vo2, current_sport = current_estimate
             response["current_vo2_max_estimate"] = {
-                "vo2_max": round(current_vo2, 1),
+                "vo2_max": round(current_estimate, 1),
                 "sport": current_sport,
                 "source": "get_user_profile",
             }

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -20,6 +20,37 @@ def configure(client):
     _activity_type_cache = None  # Reset cache when client changes
 
 
+def _as_dict(value: Any) -> Dict[str, Any]:
+    """Return a dict for Garmin sections that may be null or another shape."""
+    return value if isinstance(value, dict) else {}
+
+
+def _extract_vo2_value(data: Any) -> Optional[float]:
+    """Find a VO2 max value in known Garmin response shapes."""
+    data = _as_dict(data)
+    candidate_paths = (
+        ("vo2MaxRunning",),
+        ("vo2MaxCycling",),
+        ("vo2Max",),
+        ("vo2MaxValue",),
+        ("vo2MaxPreciseValue",),
+        ("mostRecentVO2Max", "generic", "vo2MaxValue"),
+        ("mostRecentVO2Max", "generic", "vo2MaxPreciseValue"),
+        ("mostRecentVO2Max", "cycling", "vo2MaxValue"),
+        ("mostRecentVO2Max", "cycling", "vo2MaxPreciseValue"),
+        ("userData", "vo2MaxRunning"),
+        ("userData", "vo2MaxCycling"),
+    )
+
+    for path in candidate_paths:
+        current: Any = data
+        for key in path:
+            current = _as_dict(current).get(key)
+        if isinstance(current, (int, float)):
+            return float(current)
+    return None
+
+
 def _get_activity_type_mapping() -> Dict[int, str]:
     """Get or build a cached mapping of activity type IDs to names"""
     global _activity_type_cache
@@ -1018,28 +1049,61 @@ def register_tools(app):
         current = start
         while current <= end:
             date_str = current.isoformat()
-            try:
-                data = garmin_client.get_training_status(date_str)
-                if data:
-                    vo2_data = (data.get("mostRecentVO2Max") or {}).get("generic") or {}
-                    vo2 = vo2_data.get("vo2MaxValue")
-                    if vo2 is not None:
-                        vo2_rounded = round(vo2, 1)
-                        if vo2_rounded != last_vo2:  # deduplicate unchanged values
-                            trend.append({"date": date_str, "vo2_max": vo2_rounded})
-                            last_vo2 = vo2_rounded
-            except Exception:
-                pass
+            vo2 = None
+            source = None
+
+            for method_name in (
+                "get_max_metrics",
+                "get_fitnessage_data",
+                "get_training_status",
+            ):
+                method = getattr(garmin_client, method_name, None)
+                if not method:
+                    continue
+                try:
+                    vo2 = _extract_vo2_value(method(date_str))
+                except Exception:
+                    continue
+                if vo2 is not None:
+                    source = method_name
+                    break
+
+            if vo2 is not None:
+                vo2_rounded = round(vo2, 1)
+                if vo2_rounded != last_vo2:  # deduplicate unchanged values
+                    trend.append(
+                        {
+                            "date": date_str,
+                            "vo2_max": vo2_rounded,
+                            "source": source,
+                        }
+                    )
+                    last_vo2 = vo2_rounded
             current += datetime.timedelta(days=1)
 
         if not trend:
-            return f"No VO2 max data found between {start_date} and {end_date}."
+            try:
+                profile = garmin_client.get_user_profile()
+            except Exception:
+                profile = None
+
+            current_vo2 = _extract_vo2_value(profile)
+            if current_vo2 is None:
+                return f"No VO2 max data found between {start_date} and {end_date}."
+
+            trend.append(
+                {
+                    "date": end_date,
+                    "vo2_max": round(current_vo2, 1),
+                    "source": "get_user_profile",
+                }
+            )
 
         first_vo2 = trend[0]["vo2_max"] if trend else None
         latest_vo2 = trend[-1]["vo2_max"] if trend else None
         change = round(latest_vo2 - first_vo2, 1) if (first_vo2 and latest_vo2) else None
 
-        return json.dumps({
+        response = {
             "start_date": start_date,
             "end_date": end_date,
             "data_points": len(trend),
@@ -1047,7 +1111,14 @@ def register_tools(app):
             "latest_vo2_max": latest_vo2,
             "change": change,
             "trend": trend,
-        }, indent=2)
+        }
+        if trend and trend[-1].get("source") == "get_user_profile":
+            response["note"] = (
+                "Historical VO2 max values were not available from Garmin's "
+                "training status endpoint; returning the current profile estimate."
+            )
+
+        return json.dumps(response, indent=2)
 
     @app.tool()
     async def get_respiration_trend(start_date: str, end_date: str) -> str:

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -266,49 +266,128 @@ async def test_get_training_status_tool(app_with_training, mock_garmin_client):
 async def test_get_vo2max_trend_falls_back_to_profile(
     app_with_training, mock_garmin_client
 ):
-    """Test VO2 trend returns current profile estimate if history is unavailable"""
+    """Test current profile estimate is separate from unavailable history"""
+    mock_garmin_client.get_training_status.return_value = {}
     mock_garmin_client.get_max_metrics.return_value = {}
-    mock_garmin_client.get_fitnessage_data.return_value = {}
     mock_garmin_client.get_user_profile.return_value = {
         "userData": {"vo2MaxRunning": 28.0}
     }
 
     result = await app_with_training.call_tool(
-        "get_vo2max_trend",
-        {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+        "get_vo2max_trend", {"start_date": "2024-01-14", "end_date": "2024-01-15"}
     )
 
     data = json.loads(result[0][0].text)
-    assert data["latest_vo2_max"] == 28.0
-    assert data["trend"] == [
-        {
-            "date": "2024-01-15",
-            "vo2_max": 28.0,
-            "source": "get_user_profile",
-        }
-    ]
+    assert data["data_points"] == 0
+    assert data["first_vo2_max"] is None
+    assert data["latest_vo2_max"] is None
+    assert data["change"] is None
+    assert data["trend"] == []
+    assert data["current_vo2_max_estimate"] == {
+        "vo2_max": 28.0,
+        "sport": "running",
+        "source": "get_user_profile",
+    }
     assert "Historical VO2 max values were not available" in data["note"]
+    assert mock_garmin_client.get_training_status.call_count == 2
+    assert mock_garmin_client.get_max_metrics.call_count == 2
+    mock_garmin_client.get_fitnessage_data.assert_not_called()
+    mock_garmin_client.get_user_profile.assert_called_once_with()
 
 
 @pytest.mark.asyncio
 async def test_get_vo2max_trend_uses_daily_metrics(
     app_with_training, mock_garmin_client
 ):
-    """Test VO2 trend uses daily max metrics when Garmin returns them"""
+    """Test VO2 trend reads the real list-of-dicts max metrics shape"""
+    mock_garmin_client.get_training_status.return_value = {}
     mock_garmin_client.get_max_metrics.side_effect = [
-        {"vo2MaxValue": 27.5},
-        {"vo2MaxValue": 28.0},
+        [{"generic": {"vo2MaxValue": 27.5}}],
+        [{"generic": {"vo2MaxValue": 28.0}}],
     ]
 
     result = await app_with_training.call_tool(
-        "get_vo2max_trend",
-        {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+        "get_vo2max_trend", {"start_date": "2024-01-14", "end_date": "2024-01-15"}
     )
 
     data = json.loads(result[0][0].text)
     assert data["latest_vo2_max"] == 28.0
     assert data["change"] == 0.5
-    assert data["trend"][0]["source"] == "get_max_metrics"
+    assert data["sport"] == "running"
+    assert data["trend"] == [
+        {
+            "date": "2024-01-14",
+            "vo2_max": 27.5,
+            "source": "get_max_metrics",
+        },
+        {
+            "date": "2024-01-15",
+            "vo2_max": 28.0,
+            "source": "get_max_metrics",
+        },
+    ]
+    assert mock_garmin_client.get_training_status.call_count == 2
+    assert mock_garmin_client.get_max_metrics.call_count == 2
+    mock_garmin_client.get_fitnessage_data.assert_not_called()
+    mock_garmin_client.get_user_profile.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_prefers_training_status(
+    app_with_training, mock_garmin_client
+):
+    """Test common historical data avoids extra fallback requests"""
+    mock_garmin_client.get_training_status.side_effect = [
+        {"mostRecentVO2Max": {"generic": {"vo2MaxValue": 48.0}}},
+        {"mostRecentVO2Max": {"generic": {"vo2MaxValue": 48.5}}},
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["latest_vo2_max"] == 48.5
+    assert data["sport"] == "running"
+    assert all(point["source"] == "get_training_status" for point in data["trend"])
+    assert mock_garmin_client.get_training_status.call_count == 2
+    mock_garmin_client.get_max_metrics.assert_not_called()
+    mock_garmin_client.get_fitnessage_data.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_does_not_mix_sports(
+    app_with_training, mock_garmin_client
+):
+    """Test fallback sources keep the first selected sport consistent"""
+    mock_garmin_client.get_training_status.side_effect = [
+        {"mostRecentVO2Max": {"generic": {"vo2MaxValue": 50.0}}},
+        {"mostRecentVO2Max": {"cycling": {"vo2MaxValue": 55.0}}},
+    ]
+    mock_garmin_client.get_max_metrics.return_value = [
+        {"generic": {"vo2MaxValue": 51.0}}
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["sport"] == "running"
+    assert data["change"] == 1.0
+    assert data["trend"] == [
+        {
+            "date": "2024-01-14",
+            "vo2_max": 50.0,
+            "source": "get_training_status",
+        },
+        {
+            "date": "2024-01-15",
+            "vo2_max": 51.0,
+            "source": "get_max_metrics",
+        },
+    ]
+    mock_garmin_client.get_max_metrics.assert_called_once_with("2024-01-15")
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -305,10 +305,13 @@ async def test_get_vo2max_trend_falls_back_to_profile(
 async def test_get_vo2max_trend_uses_daily_metrics(
     app_with_training, mock_garmin_client
 ):
-    """Test VO2 trend reads the max metrics range response in one request"""
+    """Test range metrics take precedence without daily training-status calls"""
     mock_garmin_client.garmin_connect_metrics_url = (
         "/metrics-service/metrics/maxmet/daily"
     )
+    mock_garmin_client.get_training_status.return_value = {
+        "mostRecentVO2Max": {"generic": {"vo2MaxValue": 99.0}}
+    }
     mock_garmin_client.connectapi.return_value = [
         {
             "generic": {

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -267,8 +267,11 @@ async def test_get_vo2max_trend_falls_back_to_profile(
     app_with_training, mock_garmin_client
 ):
     """Test current profile estimate is separate from unavailable history"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = []
     mock_garmin_client.get_training_status.return_value = {}
-    mock_garmin_client.get_max_metrics.return_value = {}
     mock_garmin_client.get_user_profile.return_value = {
         "userData": {"vo2MaxRunning": 28.0}
     }
@@ -290,7 +293,10 @@ async def test_get_vo2max_trend_falls_back_to_profile(
     }
     assert "Historical VO2 max values were not available" in data["note"]
     assert mock_garmin_client.get_training_status.call_count == 2
-    assert mock_garmin_client.get_max_metrics.call_count == 2
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/metrics-service/metrics/maxmet/daily/2024-01-14/2024-01-15"
+    )
+    mock_garmin_client.get_max_metrics.assert_not_called()
     mock_garmin_client.get_fitnessage_data.assert_not_called()
     mock_garmin_client.get_user_profile.assert_called_once_with()
 
@@ -299,11 +305,23 @@ async def test_get_vo2max_trend_falls_back_to_profile(
 async def test_get_vo2max_trend_uses_daily_metrics(
     app_with_training, mock_garmin_client
 ):
-    """Test VO2 trend reads the real list-of-dicts max metrics shape"""
-    mock_garmin_client.get_training_status.return_value = {}
-    mock_garmin_client.get_max_metrics.side_effect = [
-        [{"generic": {"vo2MaxValue": 27.5}}],
-        [{"generic": {"vo2MaxValue": 28.0}}],
+    """Test VO2 trend reads the max metrics range response in one request"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = [
+        {
+            "generic": {
+                "calendarDate": "2024-01-14",
+                "vo2MaxValue": 27.5,
+            }
+        },
+        {
+            "generic": {
+                "calendarDate": "2024-01-15",
+                "vo2MaxValue": 28.0,
+            }
+        },
     ]
 
     result = await app_with_training.call_tool(
@@ -326,8 +344,11 @@ async def test_get_vo2max_trend_uses_daily_metrics(
             "source": "get_max_metrics",
         },
     ]
-    assert mock_garmin_client.get_training_status.call_count == 2
-    assert mock_garmin_client.get_max_metrics.call_count == 2
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/metrics-service/metrics/maxmet/daily/2024-01-14/2024-01-15"
+    )
+    mock_garmin_client.get_training_status.assert_not_called()
+    mock_garmin_client.get_max_metrics.assert_not_called()
     mock_garmin_client.get_fitnessage_data.assert_not_called()
     mock_garmin_client.get_user_profile.assert_not_called()
 
@@ -356,17 +377,128 @@ async def test_get_vo2max_trend_prefers_training_status(
 
 
 @pytest.mark.asyncio
-async def test_get_vo2max_trend_does_not_mix_sports(
+async def test_get_vo2max_trend_preserves_selected_cycling_from_mixed_payloads(
     app_with_training, mock_garmin_client
 ):
-    """Test fallback sources keep the first selected sport consistent"""
+    """Test mixed payloads do not hide cycling after it becomes available first"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = []
     mock_garmin_client.get_training_status.side_effect = [
-        {"mostRecentVO2Max": {"generic": {"vo2MaxValue": 50.0}}},
         {"mostRecentVO2Max": {"cycling": {"vo2MaxValue": 55.0}}},
+        {
+            "mostRecentVO2Max": {
+                "generic": {"vo2MaxValue": 48.0},
+                "cycling": {"vo2MaxValue": 56.0},
+            }
+        },
+        {
+            "mostRecentVO2Max": {
+                "generic": {"vo2MaxValue": 48.5},
+                "cycling": {"vo2MaxValue": 57.0},
+            }
+        },
     ]
-    mock_garmin_client.get_max_metrics.return_value = [
-        {"generic": {"vo2MaxValue": 51.0}}
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-13", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["sport"] == "cycling"
+    assert data["change"] == 2.0
+    assert data["trend"] == [
+        {
+            "date": "2024-01-13",
+            "vo2_max": 55.0,
+            "source": "get_training_status",
+        },
+        {
+            "date": "2024-01-14",
+            "vo2_max": 56.0,
+            "source": "get_training_status",
+        },
+        {
+            "date": "2024-01-15",
+            "vo2_max": 57.0,
+            "source": "get_training_status",
+        },
     ]
+    mock_garmin_client.get_max_metrics.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_selects_sport_with_most_history(
+    app_with_training, mock_garmin_client
+):
+    """Test an isolated oldest point does not decide the sport for the interval"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = []
+    mock_garmin_client.get_training_status.side_effect = [
+        {"mostRecentVO2Max": {"cycling": {"vo2MaxValue": 55.0}}},
+        {"mostRecentVO2Max": {"generic": {"vo2MaxValue": 48.0}}},
+        {"mostRecentVO2Max": {"generic": {"vo2MaxValue": 48.5}}},
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-13", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["sport"] == "running"
+    assert data["data_points"] == 2
+    assert [point["vo2_max"] for point in data["trend"]] == [48.0, 48.5]
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_uses_cycling_range_metrics(
+    app_with_training, mock_garmin_client
+):
+    """Test cycling-only max metrics retain their sport and date"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = [
+        {
+            "cycling": {
+                "calendarDate": "2024-01-15",
+                "vo2MaxValue": 55.1,
+            }
+        }
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-15", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["sport"] == "cycling"
+    assert data["trend"] == [
+        {
+            "date": "2024-01-15",
+            "vo2_max": 55.1,
+            "source": "get_max_metrics",
+        }
+    ]
+    mock_garmin_client.get_training_status.assert_not_called()
+    mock_garmin_client.get_max_metrics.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_range_failure_does_not_retry_max_metrics_daily(
+    app_with_training, mock_garmin_client
+):
+    """Test a failed range request falls back without amplifying that failure"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.side_effect = RuntimeError("API unavailable")
+    mock_garmin_client.get_training_status.return_value = {
+        "mostRecentVO2Max": {"generic": {"vo2MaxValue": 48.0}}
+    }
 
     result = await app_with_training.call_tool(
         "get_vo2max_trend", {"start_date": "2024-01-14", "end_date": "2024-01-15"}
@@ -374,20 +506,101 @@ async def test_get_vo2max_trend_does_not_mix_sports(
 
     data = json.loads(result[0][0].text)
     assert data["sport"] == "running"
-    assert data["change"] == 1.0
-    assert data["trend"] == [
-        {
-            "date": "2024-01-14",
-            "vo2_max": 50.0,
-            "source": "get_training_status",
-        },
-        {
-            "date": "2024-01-15",
-            "vo2_max": 51.0,
-            "source": "get_max_metrics",
-        },
+    assert mock_garmin_client.get_training_status.call_count == 2
+    mock_garmin_client.get_max_metrics.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_uses_daily_max_metrics_for_older_clients(
+    app_with_training, mock_garmin_client
+):
+    """Test clients without the range API keep the compatible daily fallback"""
+    mock_garmin_client.garmin_connect_metrics_url = None
+    mock_garmin_client.get_training_status.return_value = {}
+    mock_garmin_client.get_max_metrics.return_value = [
+        {"generic": {"vo2MaxValue": 48.0}}
     ]
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-15", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["latest_vo2_max"] == 48.0
+    mock_garmin_client.connectapi.assert_not_called()
     mock_garmin_client.get_max_metrics.assert_called_once_with("2024-01-15")
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_prefers_running_when_sport_coverage_is_tied(
+    app_with_training, mock_garmin_client
+):
+    """Test equal sport coverage has a stable running-first tie break"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = []
+    mock_garmin_client.get_training_status.return_value = {
+        "mostRecentVO2Max": {
+            "generic": {"vo2MaxValue": 48.0},
+            "cycling": {"vo2MaxValue": 55.0},
+        }
+    }
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-15", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["sport"] == "running"
+    assert data["latest_vo2_max"] == 48.0
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_no_history_avoids_daily_max_metrics_requests(
+    app_with_training, mock_garmin_client
+):
+    """Test the 90-day no-history case uses one range max-metrics request"""
+    mock_garmin_client.garmin_connect_metrics_url = (
+        "/metrics-service/metrics/maxmet/daily"
+    )
+    mock_garmin_client.connectapi.return_value = []
+    mock_garmin_client.get_training_status.return_value = {}
+    mock_garmin_client.get_user_profile.return_value = {
+        "userData": {"vo2MaxRunning": 48.0}
+    }
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-01", "end_date": "2024-03-30"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["data_points"] == 0
+    assert mock_garmin_client.get_training_status.call_count == 90
+    assert mock_garmin_client.connectapi.call_count == 1
+    mock_garmin_client.get_max_metrics.assert_not_called()
+    mock_garmin_client.get_user_profile.assert_called_once_with()
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_handles_endpoint_exception_and_missing_method(
+    app_with_training, mock_garmin_client
+):
+    """Test daily errors and an unavailable max-metrics method reach the profile"""
+    mock_garmin_client.garmin_connect_metrics_url = None
+    mock_garmin_client.get_training_status.side_effect = RuntimeError("API unavailable")
+    mock_garmin_client.get_max_metrics = None
+    mock_garmin_client.get_user_profile.return_value = {
+        "userData": {"vo2MaxCycling": 55.0}
+    }
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend", {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["current_vo2_max_estimate"]["sport"] == "cycling"
+    assert mock_garmin_client.get_training_status.call_count == 2
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -263,6 +263,55 @@ async def test_get_training_status_tool(app_with_training, mock_garmin_client):
 
 
 @pytest.mark.asyncio
+async def test_get_vo2max_trend_falls_back_to_profile(
+    app_with_training, mock_garmin_client
+):
+    """Test VO2 trend returns current profile estimate if history is unavailable"""
+    mock_garmin_client.get_max_metrics.return_value = {}
+    mock_garmin_client.get_fitnessage_data.return_value = {}
+    mock_garmin_client.get_user_profile.return_value = {
+        "userData": {"vo2MaxRunning": 28.0}
+    }
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["latest_vo2_max"] == 28.0
+    assert data["trend"] == [
+        {
+            "date": "2024-01-15",
+            "vo2_max": 28.0,
+            "source": "get_user_profile",
+        }
+    ]
+    assert "Historical VO2 max values were not available" in data["note"]
+
+
+@pytest.mark.asyncio
+async def test_get_vo2max_trend_uses_daily_metrics(
+    app_with_training, mock_garmin_client
+):
+    """Test VO2 trend uses daily max metrics when Garmin returns them"""
+    mock_garmin_client.get_max_metrics.side_effect = [
+        {"vo2MaxValue": 27.5},
+        {"vo2MaxValue": 28.0},
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_vo2max_trend",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"}
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["latest_vo2_max"] == 28.0
+    assert data["change"] == 0.5
+    assert data["trend"][0]["source"] == "get_max_metrics"
+
+
+@pytest.mark.asyncio
 async def test_get_lactate_threshold_tool_latest(app_with_training, mock_garmin_client):
     """Test get_lactate_threshold tool returns latest lactate threshold data"""
     # Setup mock with latest=True response format

--- a/tests/unit/test_training_vo2.py
+++ b/tests/unit/test_training_vo2.py
@@ -1,0 +1,104 @@
+import math
+from unittest.mock import Mock
+
+import pytest
+
+from garmin_mcp import training
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        None,
+        [],
+        [None],
+        {},
+        {"generic": None},
+        {"vo2MaxValue": True},
+        {"vo2MaxValue": "48.0"},
+        {"vo2MaxValue": math.nan},
+        {"vo2MaxValue": math.inf},
+    ],
+)
+def test_extract_vo2_measurements_ignores_missing_or_invalid_values(payload):
+    assert training._extract_vo2_measurements(payload) == {}
+
+
+def test_extract_vo2_measurements_returns_both_sports_from_mixed_payload():
+    payload = {
+        "mostRecentVO2Max": {
+            "generic": {"vo2MaxValue": 48.0},
+            "cycling": {"vo2MaxValue": 55.0},
+        }
+    }
+
+    assert training._extract_vo2_measurements(payload) == {
+        "running": 48.0,
+        "cycling": 55.0,
+    }
+
+
+def test_extract_vo2_measurements_merges_nested_list_payloads():
+    payload = [
+        [{"generic": {"vo2MaxValue": 48.0}}],
+        {"cycling": {"vo2MaxPreciseValue": 55.12}},
+    ]
+
+    assert training._extract_vo2_measurements(payload) == {
+        "running": 48.0,
+        "cycling": 55.12,
+    }
+
+
+def test_extract_dated_vo2_measurements_indexes_each_sport_date():
+    payload = [
+        {
+            "generic": {
+                "calendarDate": "2024-01-14",
+                "vo2MaxValue": 48.0,
+            },
+            "cycling": {
+                "calendarDate": "2024-01-14",
+                "vo2MaxValue": 55.0,
+            },
+        },
+        [
+            {
+                "cycling": {
+                    "calendarDate": "2024-01-15",
+                    "vo2MaxValue": 55.5,
+                }
+            }
+        ],
+    ]
+
+    assert training._extract_dated_vo2_measurements(payload) == {
+        "2024-01-14": {"running": 48.0, "cycling": 55.0},
+        "2024-01-15": {"cycling": 55.5},
+    }
+
+
+def test_get_max_metrics_range_uses_client_endpoint():
+    client = Mock()
+    client.garmin_connect_metrics_url = "/metrics-service/metrics/maxmet/daily"
+    client.connectapi.return_value = [{"generic": {"vo2MaxValue": 48.0}}]
+
+    supported, result = training._get_max_metrics_range(
+        client, "2024-01-14", "2024-01-15"
+    )
+
+    assert supported is True
+    assert result == [{"generic": {"vo2MaxValue": 48.0}}]
+    client.connectapi.assert_called_once_with(
+        "/metrics-service/metrics/maxmet/daily/2024-01-14/2024-01-15"
+    )
+
+
+def test_get_max_metrics_range_reports_unsupported_client():
+    client = Mock()
+    client.garmin_connect_metrics_url = None
+
+    assert training._get_max_metrics_range(
+        client, "2024-01-14", "2024-01-15"
+    ) == (False, None)
+    client.connectapi.assert_not_called()

--- a/tests/unit/test_training_vo2.py
+++ b/tests/unit/test_training_vo2.py
@@ -102,3 +102,12 @@ def test_get_max_metrics_range_reports_unsupported_client():
         client, "2024-01-14", "2024-01-15"
     ) == (False, None)
     client.connectapi.assert_not_called()
+
+
+def test_get_max_metrics_range_handles_missing_connectapi():
+    client = Mock(spec=["garmin_connect_metrics_url"])
+    client.garmin_connect_metrics_url = "/metrics-service/metrics/maxmet/daily"
+
+    assert training._get_max_metrics_range(
+        client, "2024-01-14", "2024-01-15"
+    ) == (False, None)


### PR DESCRIPTION
## Summary

`get_vo2max_trend` currently only reads `get_training_status(date)` per day and returns "No VO2 max data found" if that endpoint has no data across the whole range. In practice, some accounts/devices don't populate `mostRecentVO2Max` on `get_training_status` for a given day even though a current estimate is available elsewhere.

This PR makes the lookup more tolerant:

- Per day, tries `get_max_metrics`, `get_fitnessage_data`, then `get_training_status` in turn (first one with a usable value wins), via a small `_extract_vo2_value` helper that checks several known Garmin response shapes (`vo2MaxValue`, `vo2MaxPreciseValue`, nested `mostRecentVO2Max.generic`/`.cycling`, `userData.vo2Max*`, etc.).
- If no historical data point is found anywhere in the requested range, falls back to the current estimate from `get_user_profile()` and adds a `note` field explaining that it's a current snapshot rather than historical trend data, instead of just returning a "no data found" string.
- Each trend point now also records its `source` method, for debuggability.

## Test plan

- [x] `test_get_vo2max_trend_falls_back_to_profile` — verifies the profile fallback path and its `note`.
- [x] `test_get_vo2max_trend_uses_daily_metrics` — verifies `get_max_metrics` is used when it returns data, and `source` is recorded.
- [x] Ran the full existing test suite locally; no other tests affected.