### PR TITLE
feat(auth): securely bootstrap Garmin tokens in containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       run: uv python install ${{ matrix.python-version }}
 
     - name: Install dependencies
-      run: uv sync
+      run: uv sync --locked
 
     - name: Run integration tests
       run: uv run pytest tests/integration tests/unit -v --tb=short
@@ -58,10 +58,28 @@ jobs:
       run: |
         mkdir -p "$RUNNER_TEMP/garmin-token-secret"
         printf '%s\n' '{"di_token":"test-di-token","di_refresh_token":"test-refresh-token","di_client_id":"test-client-id"}' > "$RUNNER_TEMP/garmin-token-secret/garmin_tokens.json"
+        volume_name="garmin-mcp-token-bootstrap-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+        trap 'docker volume rm -f "$volume_name" >/dev/null 2>&1' EXIT
+        docker volume create "$volume_name"
+
         docker run --rm \
           --entrypoint python \
           --env GARMINTOKENS=/var/lib/garmin-tokens \
           --env GARMIN_TOKENS_FILE=/run/secrets/garmin_tokens.json \
           --mount "type=bind,source=$RUNNER_TEMP/garmin-token-secret/garmin_tokens.json,target=/run/secrets/garmin_tokens.json,readonly" \
+          --mount "type=volume,source=$volume_name,target=/var/lib/garmin-tokens" \
           garmin-mcp:test \
-          -c "import json, os, stat; from pathlib import Path; from garmin_mcp.token_utils import bootstrap_tokens; installed = bootstrap_tokens(); assert installed == Path('/var/lib/garmin-tokens/garmin_tokens.json'); assert json.loads(installed.read_text())['di_client_id'] == 'test-client-id'; assert stat.S_IMODE(installed.stat().st_mode) == 0o600; os.environ.pop('GARMIN_TOKENS_FILE'); os.environ['GARMIN_TOKENS_JSON'] = 'invalid'; assert bootstrap_tokens() is None"
+          /app/tests/docker/token_bootstrap_smoke.py installed
+
+        docker run --rm \
+          --entrypoint python \
+          --env GARMINTOKENS=/var/lib/garmin-tokens \
+          --env GARMIN_TOKENS_JSON=invalid \
+          --mount "type=volume,source=$volume_name,target=/var/lib/garmin-tokens" \
+          garmin-mcp:test \
+          /app/tests/docker/token_bootstrap_smoke.py preserved
+
+        if docker run --rm --env GARMIN_TOKENS_JSON=invalid garmin-mcp:test; then
+          echo "Expected the real entrypoint to reject invalid bootstrap JSON"
+          exit 1
+        fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,17 @@ jobs:
           garmin-mcp:test \
           /app/tests/docker/token_bootstrap_smoke.py preserved
 
-        if docker run --rm --env GARMIN_TOKENS_JSON=invalid garmin-mcp:test; then
+        bootstrap_status=0
+        bootstrap_output="$(docker run --rm \
+          --env GARMIN_TOKENS_JSON=invalid \
+          garmin-mcp:test 2>&1)" || bootstrap_status=$?
+        printf '%s\n' "$bootstrap_output" >&2
+
+        if [ "$bootstrap_status" -eq 0 ] || \
+          ! grep -Fq \
+            "bootstrap failed: the configured token value is not valid JSON" \
+            <<<"$bootstrap_output"; then
           echo "Expected the real entrypoint to reject invalid bootstrap JSON"
           exit 1
         fi
+        echo "Real entrypoint rejected invalid bootstrap JSON"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,3 +42,26 @@ jobs:
         else
           echo "❌ Some tests failed"
         fi
+
+  docker:
+    name: Docker image
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Build image
+      run: docker build --tag garmin-mcp:test .
+
+    - name: Smoke test token bootstrap
+      run: |
+        mkdir -p "$RUNNER_TEMP/garmin-token-secret"
+        printf '%s\n' '{"di_token":"test-di-token","di_refresh_token":"test-refresh-token","di_client_id":"test-client-id"}' > "$RUNNER_TEMP/garmin-token-secret/garmin_tokens.json"
+        docker run --rm \
+          --entrypoint python \
+          --env GARMINTOKENS=/var/lib/garmin-tokens \
+          --env GARMIN_TOKENS_FILE=/run/secrets/garmin_tokens.json \
+          --mount "type=bind,source=$RUNNER_TEMP/garmin-token-secret/garmin_tokens.json,target=/run/secrets/garmin_tokens.json,readonly" \
+          garmin-mcp:test \
+          -c "import json, os, stat; from pathlib import Path; from garmin_mcp.token_utils import bootstrap_tokens; installed = bootstrap_tokens(); assert installed == Path('/var/lib/garmin-tokens/garmin_tokens.json'); assert json.loads(installed.read_text())['di_client_id'] == 'test-client-id'; assert stat.S_IMODE(installed.stat().st_mode) == 0o600; os.environ.pop('GARMIN_TOKENS_FILE'); os.environ['GARMIN_TOKENS_JSON'] = 'invalid'; assert bootstrap_tokens() is None"

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ build/
 # Virtual environments
 .env
 .venv/
+secrets/
 *.log
 .DS_Store
 .claude.md

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ COPY src/ ./src/
 RUN uv sync --locked --no-dev
 
 # Copy the dependency-free Docker smoke test used by CI
-COPY tests/ ./tests/
+COPY tests/docker/ ./tests/docker/
 
 # Create directory for Garmin tokens
 RUN mkdir -p /root/.garminconnect && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,16 +16,16 @@ ENV PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:$PATH"
 
 # Install locked runtime dependencies before the source for better layer caching
-COPY pyproject.toml uv.lock README.md ./
+COPY pyproject.toml uv.lock ./
 RUN uv sync --locked --no-dev --no-install-project
 
 # Copy and install the application
+COPY README.md ./
 COPY src/ ./src/
 RUN uv sync --locked --no-dev
 
-# Copy test files (optional, for testing in container)
+# Copy the dependency-free Docker smoke test used by CI
 COPY tests/ ./tests/
-COPY pytest.ini ./
 
 # Create directory for Garmin tokens
 RUN mkdir -p /root/.garminconnect && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,16 +13,15 @@ COPY --from=ghcr.io/astral-sh/uv:latest /uv /usr/local/bin/uv
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_SYSTEM_PYTHON=1
+    PATH="/app/.venv/bin:$PATH"
 
-# Copy dependency files and README first for better layer caching
-COPY pyproject.toml README.md ./
+# Install locked runtime dependencies before the source for better layer caching
+COPY pyproject.toml uv.lock README.md ./
+RUN uv sync --locked --no-dev --no-install-project
 
-# Copy the application source code (needed for editable install)
+# Copy and install the application
 COPY src/ ./src/
-
-# Install dependencies using uv
-RUN uv pip install -e .
+RUN uv sync --locked --no-dev
 
 # Copy test files (optional, for testing in container)
 COPY tests/ ./tests/

--- a/README.md
+++ b/README.md
@@ -417,17 +417,20 @@ uv sync
 
 ### Configuration
 
-Your Garmin Connect credentials are read from environment variables:
+Authentication and token storage can be configured with environment variables:
 
 - `GARMIN_EMAIL`: Your Garmin Connect email address
 - `GARMIN_EMAIL_FILE`: Path to a file containing your Garmin Connect email address
 - `GARMIN_PASSWORD`: Your Garmin Connect password
 - `GARMIN_PASSWORD_FILE`: Path to a file containing your Garmin Connect password
+- `GARMINTOKENS`: Writable token directory or explicit `.json` path (default: `~/.garminconnect`)
+- `GARMIN_TOKENS_FILE`: Path to a raw `garmin_tokens.json` deployment secret used to initialize an empty writable token store
+- `GARMIN_TOKENS_JSON`: Inline raw token JSON for platforms that cannot mount secrets
 - `GARMIN_IS_CN`: Set to `true` to use Garmin Connect China (garmin.cn) instead of the international version (default: `false`)
 - `GARMIN_FIT_DOWNLOAD_DIR`: Default directory for downloaded activity files. When set, skips the first-run setup prompt in `download_activity_file`.
 - `GARMIN_FIT_CONFIG`: Path to the persisted download-directory config file (default: `~/.garminconnect_fit_config.json`).
 
-File-based secrets are useful in certain environments, such as inside a Docker container. Note that you cannot set both `GARMIN_EMAIL` and `GARMIN_EMAIL_FILE`, similarly you cannot set both `GARMIN_PASSWORD` and `GARMIN_PASSWORD_FILE`.
+File-based secrets are useful in container environments. Set only one of `GARMIN_TOKENS_FILE` and `GARMIN_TOKENS_JSON`; the file option is safer and recommended. An existing token file is never overwritten by bootstrap input, allowing refreshed tokens in the writable store to survive restarts. Similarly, do not set both the direct and `_FILE` forms of the email or password.
 
 ### Transport
 
@@ -685,9 +688,47 @@ docker run -it \
   garmin-mcp
 ```
 
-#### Using File-Based Secrets (More Secure)
+#### Bootstrapping from an OAuth Token Secret
 
-For enhanced security, especially in production environments, use file-based secrets instead of environment variables:
+For unattended containers, authenticate once on a trusted machine and inject the resulting OAuth token file instead of storing your Garmin email and password:
+
+1. Generate and verify tokens:
+
+```bash
+garmin-mcp-auth
+```
+
+The raw token document is saved at `~/.garminconnect/garmin_tokens.json` by default.
+
+2. Make that file available to Docker as a secret and retain a writable token volume:
+
+```yaml
+services:
+  garmin-mcp:
+    environment:
+      - GARMIN_TOKENS_FILE=/run/secrets/garmin_tokens
+    secrets:
+      - garmin_tokens
+    volumes:
+      - garmin-tokens:/root/.garminconnect
+
+secrets:
+  garmin_tokens:
+    file: ./secrets/garmin_tokens.json
+
+volumes:
+  garmin-tokens:
+```
+
+On the first start, the server validates the secret structure and atomically installs it as `/root/.garminconnect/garmin_tokens.json` with owner-only permissions. Later starts use the writable volume copy, so token refreshes are not replaced by an older bootstrap secret.
+
+To rotate the bootstrap secret, stop the service, update the secret source, and clear the token volume before starting it again. Clearing the volume removes the current persisted login.
+
+Platforms that cannot mount files may set `GARMIN_TOKENS_JSON` to the raw JSON document instead. Environment variables can be exposed through container metadata and process inspection, so do not put this value in a committed `.env` file and prefer `GARMIN_TOKENS_FILE` whenever possible.
+
+#### Using Credential Files
+
+Credential files can be used for first-time authentication when an OAuth token secret is not available:
 
 1. Create a secrets directory and add your credentials:
 

--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ Authentication and token storage can be configured with environment variables:
 - `GARMIN_FIT_DOWNLOAD_DIR`: Default directory for downloaded activity files. When set, skips the first-run setup prompt in `download_activity_file`.
 - `GARMIN_FIT_CONFIG`: Path to the persisted download-directory config file (default: `~/.garminconnect_fit_config.json`).
 
-File-based secrets are useful in container environments. Set only one of `GARMIN_TOKENS_FILE` and `GARMIN_TOKENS_JSON`; the file option is safer and recommended. An existing token file is never overwritten by bootstrap input, allowing refreshed tokens in the writable store to survive restarts. Similarly, do not set both the direct and `_FILE` forms of the email or password.
+File-based secrets are useful in container environments. Set only one of `GARMIN_TOKENS_FILE` and `GARMIN_TOKENS_JSON`; blank values are treated as unset, and the file option is safer and recommended. An existing token file is never overwritten by bootstrap input, allowing refreshed tokens in the writable store to survive restarts. When a configured source is skipped for this reason, the server reports the destination path without printing token contents. Similarly, do not set both the direct and `_FILE` forms of the email or password.
 
 ### Transport
 
@@ -720,7 +720,7 @@ volumes:
   garmin-tokens:
 ```
 
-On the first start, the server validates the secret structure and atomically installs it as `/root/.garminconnect/garmin_tokens.json` with owner-only permissions. Later starts use the writable volume copy, so token refreshes are not replaced by an older bootstrap secret.
+On the first start, the server validates the secret structure and safely installs it as `/root/.garminconnect/garmin_tokens.json` with owner-only permissions. It uses an atomic create-if-absent operation where the filesystem supports hard links and an exclusive-create fallback elsewhere. Later starts use the writable volume copy, so token refreshes are not replaced by an older bootstrap secret.
 
 To rotate the bootstrap secret, stop the service, update the secret source, and clear the token volume before starting it again. Clearing the volume removes the current persisted login.
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,24 +5,25 @@ services:
       dockerfile: Dockerfile
     container_name: garmin-mcp-server
 
-    # Option 1: Use environment variables directly
+    # Option 1: Use credentials from environment variables.
+    # Comment these two entries when using option 2 or 3.
     environment:
       - GARMIN_EMAIL=${GARMIN_EMAIL}
       - GARMIN_PASSWORD=${GARMIN_PASSWORD}
       # - GARMIN_IS_CN=true  # Uncomment to use Garmin Connect China (garmin.cn)
 
     # Option 2: Bootstrap from a pre-authenticated OAuth token secret.
-    # Remove GARMIN_EMAIL/GARMIN_PASSWORD above when using this option.
-    # environment:
+    # Add this entry to the environment list above:
     #   - GARMIN_TOKENS_FILE=/run/secrets/garmin_tokens
-    # secrets:
-    #   - garmin_tokens
 
     # Option 3: Use file-based credentials for first-time authentication
-    # environment:
+    # Add these entries to the environment list above:
     #   - GARMIN_EMAIL_FILE=/run/secrets/garmin_email
     #   - GARMIN_PASSWORD_FILE=/run/secrets/garmin_password
+
+    # Uncomment the corresponding secret names for option 2 or 3.
     # secrets:
+    #   - garmin_tokens
     #   - garmin_email
     #   - garmin_password
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,14 @@ services:
       - GARMIN_PASSWORD=${GARMIN_PASSWORD}
       # - GARMIN_IS_CN=true  # Uncomment to use Garmin Connect China (garmin.cn)
 
-    # Option 2: Use file-based secrets (uncomment to use)
+    # Option 2: Bootstrap from a pre-authenticated OAuth token secret.
+    # Remove GARMIN_EMAIL/GARMIN_PASSWORD above when using this option.
+    # environment:
+    #   - GARMIN_TOKENS_FILE=/run/secrets/garmin_tokens
+    # secrets:
+    #   - garmin_tokens
+
+    # Option 3: Use file-based credentials for first-time authentication
     # environment:
     #   - GARMIN_EMAIL_FILE=/run/secrets/garmin_email
     #   - GARMIN_PASSWORD_FILE=/run/secrets/garmin_password
@@ -36,6 +43,8 @@ volumes:
 
 # Uncomment if using file-based secrets
 # secrets:
+#   garmin_tokens:
+#     file: ./secrets/garmin_tokens.json
 #   garmin_email:
 #     file: ./secrets/garmin_email.txt
 #   garmin_password:

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -375,6 +375,17 @@ def main():
         import io
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, newline="\n")
 
+    try:
+        bootstrapped_path = token_utils.bootstrap_tokens(tokenstore)
+    except token_utils.TokenBootstrapError as exc:
+        print(f"ERROR: Garmin token bootstrap failed: {exc}", file=sys.stderr)
+        sys.exit(1)
+    if bootstrapped_path is not None:
+        print(
+            f"Garmin OAuth tokens bootstrapped into '{bootstrapped_path}'.",
+            file=sys.stderr,
+        )
+
     # --- Transport configuration --------------------------------------------
     # By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
     # Set GARMIN_MCP_TRANSPORT=streamable-http (or sse) to serve over HTTP.

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -306,7 +306,7 @@ def init_api(email, password):
                 file=sys.stderr,
             )
             # Encode Oauth1 and Oauth2 tokens to base64 string and save to file for next login (alternative way)
-            token_json_path = os.path.join(tokenstore, "garmin_tokens.json")
+            token_json_path = token_utils.get_token_json_path(tokenstore)
             with open(token_json_path, "r") as f:
                 token_data = f.read()
             token_base64 = base64.b64encode(token_data.encode()).decode()
@@ -376,15 +376,21 @@ def main():
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, newline="\n")
 
     try:
-        bootstrapped_path = token_utils.bootstrap_tokens(tokenstore)
+        bootstrap_result = token_utils.bootstrap_tokens(tokenstore)
     except token_utils.TokenBootstrapError as exc:
         print(f"ERROR: Garmin token bootstrap failed: {exc}", file=sys.stderr)
         sys.exit(1)
-    if bootstrapped_path is not None:
-        print(
-            f"Garmin OAuth tokens bootstrapped into '{bootstrapped_path}'.",
-            file=sys.stderr,
-        )
+    if bootstrap_result is not None:
+        if bootstrap_result.installed:
+            message = (
+                f"Garmin OAuth tokens bootstrapped into '{bootstrap_result.path}'."
+            )
+        else:
+            message = (
+                "Configured Garmin token bootstrap source skipped because "
+                f"'{bootstrap_result.path}' already exists."
+            )
+        print(message, file=sys.stderr)
 
     # --- Transport configuration --------------------------------------------
     # By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
@@ -402,7 +408,7 @@ def main():
     garmin_client = init_api(email, password)
     if not garmin_client:
         print("Failed to initialize Garmin Connect client. Exiting.", file=sys.stderr)
-        return
+        sys.exit(1)
 
     print("Garmin Connect client initialized successfully.", file=sys.stderr)
 

--- a/src/garmin_mcp/auth_cli.py
+++ b/src/garmin_mcp/auth_cli.py
@@ -16,6 +16,7 @@ from garminconnect import Garmin, GarminConnectAuthenticationError, GarminConnec
 from garmin_mcp.token_utils import (
     get_token_path,
     get_token_base64_path,
+    get_token_json_path,
     token_exists,
     validate_tokens,
     get_token_info,
@@ -172,7 +173,7 @@ def authenticate(token_path: str, token_base64_path: str, force_reauth: bool = F
         print(f"\n✓ OAuth tokens saved to: {token_path}")
 
         # Save tokens as base64
-        token_json_path = os.path.join(token_path, "garmin_tokens.json")
+        token_json_path = get_token_json_path(token_path)
         with open(token_json_path, "r") as f:
             token_data = f.read()
         token_base64 = base64.b64encode(token_data.encode()).decode()

--- a/src/garmin_mcp/token_utils.py
+++ b/src/garmin_mcp/token_utils.py
@@ -1,8 +1,10 @@
 """Token management utilities for Garmin MCP authentication."""
 
+import errno
 import json
 import os
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Tuple
 
@@ -13,7 +15,24 @@ class TokenBootstrapError(ValueError):
     """Raised when configured bootstrap tokens cannot be installed safely."""
 
 
-_REQUIRED_TOKEN_FIELDS = ("di_token", "di_refresh_token", "di_client_id")
+@dataclass(frozen=True)
+class TokenBootstrapResult:
+    """Outcome of a configured token bootstrap."""
+
+    path: Path
+    installed: bool
+
+
+_REQUIRED_TOKEN_FIELDS = ("di_token",)
+_LINK_FALLBACK_ERRNOS = {
+    errno.EACCES,
+    errno.EPERM,
+    errno.EXDEV,
+    errno.EINVAL,
+    getattr(errno, "ENOSYS", errno.EPERM),
+    getattr(errno, "ENOTSUP", errno.EPERM),
+    getattr(errno, "EOPNOTSUPP", errno.EPERM),
+}
 
 
 def resolve_token_path(path: str) -> str:
@@ -104,14 +123,12 @@ def _parse_bootstrap_tokens(raw_tokens: str) -> dict:
     return tokens
 
 
-def _write_tokens_atomically(
-    target: Path, tokens: dict, directory_store: bool
-) -> bool:
-    """Install validated tokens atomically without replacing another writer."""
+def _write_tokens_atomically(target: Path, tokens: dict) -> bool:
+    """Install validated tokens safely without replacing another writer."""
     parent_existed = target.parent.exists()
     try:
         target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
-        if directory_store or not parent_existed:
+        if not parent_existed:
             os.chmod(target.parent, 0o700)
     except OSError as exc:
         raise TokenBootstrapError(
@@ -126,7 +143,8 @@ def _write_tokens_atomically(
             prefix=f".{target.name}.",
         )
         temp_path = Path(temp_name)
-        os.fchmod(fd, 0o600)
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
         with os.fdopen(fd, "w", encoding="utf-8") as token_file:
             fd = None
             json.dump(tokens, token_file, separators=(",", ":"))
@@ -139,9 +157,13 @@ def _write_tokens_atomically(
             # bootstrap the same shared volume without overwriting each other.
             os.link(temp_path, target)
         except FileExistsError:
-            if target.is_file():
+            if target.is_file() and not target.is_symlink():
                 return False
             raise
+        except OSError as exc:
+            if exc.errno not in _LINK_FALLBACK_ERRNOS:
+                raise
+            return _write_tokens_exclusively(target, temp_path)
         return True
     except OSError as exc:
         raise TokenBootstrapError(
@@ -160,7 +182,51 @@ def _write_tokens_atomically(
                 pass
 
 
-def bootstrap_tokens(token_path: str = None) -> Path | None:
+def _write_tokens_exclusively(target: Path, source: Path) -> bool:
+    """Fallback for filesystems that cannot hard-link the prepared token file."""
+    fd = None
+    created = False
+    try:
+        flags = os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_BINARY", 0)
+        fd = os.open(target, flags, 0o600)
+        created = True
+        if hasattr(os, "fchmod"):
+            os.fchmod(fd, 0o600)
+        payload = source.read_bytes()
+        remaining = memoryview(payload)
+        while remaining:
+            written = os.write(fd, remaining)
+            if written == 0:
+                raise OSError("zero-byte write while installing token file")
+            remaining = remaining[written:]
+        os.fsync(fd)
+        return True
+    except FileExistsError:
+        if target.is_file() and not target.is_symlink():
+            return False
+        raise
+    except Exception:
+        if created:
+            try:
+                target.unlink(missing_ok=True)
+            except OSError:
+                pass
+        raise
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+
+
+def _non_blank_env(name: str) -> str | None:
+    """Return a configured value, treating empty/whitespace values as unset."""
+    value = os.getenv(name)
+    return value if value is not None and value.strip() else None
+
+
+def bootstrap_tokens(token_path: str = None) -> TokenBootstrapResult | None:
     """Initialize an empty writable token store from a deployment secret.
 
     ``GARMIN_TOKENS_FILE`` points to a JSON secret file and is the recommended
@@ -172,10 +238,10 @@ def bootstrap_tokens(token_path: str = None) -> Path | None:
     than replacing them with stale bootstrap credentials on every restart.
 
     Returns:
-        The installed token file path, or ``None`` when no bootstrap was needed.
+        The configured bootstrap outcome, or ``None`` when no source was set.
     """
-    source_file = os.getenv("GARMIN_TOKENS_FILE")
-    inline_tokens = os.getenv("GARMIN_TOKENS_JSON")
+    source_file = _non_blank_env("GARMIN_TOKENS_FILE")
+    inline_tokens = _non_blank_env("GARMIN_TOKENS_JSON")
 
     if source_file is None and inline_tokens is None:
         return None
@@ -186,25 +252,29 @@ def bootstrap_tokens(token_path: str = None) -> Path | None:
 
     if token_path is None:
         token_path = get_token_path()
-    store = Path(resolve_token_path(token_path))
-    directory_store = store.is_dir() or not store.name.endswith(".json")
     target = get_token_json_path(token_path)
 
     # A writable store may contain tokens refreshed after the bootstrap secret
     # was created. It is therefore the source of truth once initialized.
+    if target.is_symlink():
+        raise TokenBootstrapError(
+            f"token destination '{target}' must not be a symbolic link"
+        )
     if target.is_file():
-        return None
+        return TokenBootstrapResult(target, installed=False)
     if target.exists():
         raise TokenBootstrapError(
             f"token destination '{target}' exists but is not a regular file"
         )
 
     if source_file is not None:
-        if not source_file.strip():
-            raise TokenBootstrapError("GARMIN_TOKENS_FILE is empty")
         source = Path(resolve_token_path(source_file))
         try:
             raw_tokens = source.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            raise TokenBootstrapError(
+                f"token secret '{source}' is not valid UTF-8"
+            ) from None
         except OSError as exc:
             raise TokenBootstrapError(
                 f"cannot read token secret '{source}': {exc.strerror or exc}"
@@ -213,8 +283,8 @@ def bootstrap_tokens(token_path: str = None) -> Path | None:
         raw_tokens = inline_tokens
 
     tokens = _parse_bootstrap_tokens(raw_tokens)
-    installed = _write_tokens_atomically(target, tokens, directory_store)
-    return target if installed else None
+    installed = _write_tokens_atomically(target, tokens)
+    return TokenBootstrapResult(target, installed=installed)
 
 
 def token_exists(token_path: str = None) -> bool:

--- a/src/garmin_mcp/token_utils.py
+++ b/src/garmin_mcp/token_utils.py
@@ -89,6 +89,11 @@ def get_token_base64_path() -> str:
 def get_token_json_path(token_path: str) -> Path:
     """Return the JSON file used by garminconnect for a token-store path."""
     store = Path(resolve_token_path(token_path))
+    # Mirrors garminconnect 0.3.2's Client.dump()/load() resolution
+    # (case-sensitive ".json" suffix). garminconnect 0.3.7 extracts this as
+    # garminconnect.client.token_file_path() and makes the suffix test
+    # case-insensitive. Align this predicate when the pin moves; importing that
+    # helper directly would couple this package to an internal module.
     if store.is_dir() or not store.name.endswith(".json"):
         return store / "garmin_tokens.json"
     return store

--- a/src/garmin_mcp/token_utils.py
+++ b/src/garmin_mcp/token_utils.py
@@ -1,10 +1,19 @@
 """Token management utilities for Garmin MCP authentication."""
 
+import json
 import os
+import tempfile
 from pathlib import Path
 from typing import Tuple
 
 from garminconnect import Garmin, GarminConnectConnectionError
+
+
+class TokenBootstrapError(ValueError):
+    """Raised when configured bootstrap tokens cannot be installed safely."""
+
+
+_REQUIRED_TOKEN_FIELDS = ("di_token", "di_refresh_token", "di_client_id")
 
 
 def resolve_token_path(path: str) -> str:
@@ -56,6 +65,156 @@ def get_token_base64_path() -> str:
     return resolve_token_path(
         os.getenv("GARMINTOKENS_BASE64") or "~/.garminconnect_base64"
     )
+
+
+def get_token_json_path(token_path: str) -> Path:
+    """Return the JSON file used by garminconnect for a token-store path."""
+    store = Path(resolve_token_path(token_path))
+    if store.is_dir() or not store.name.endswith(".json"):
+        return store / "garmin_tokens.json"
+    return store
+
+
+def _parse_bootstrap_tokens(raw_tokens: str) -> dict:
+    """Validate bootstrap JSON without making a Garmin network request."""
+    if not raw_tokens.strip():
+        raise TokenBootstrapError("the configured token value is empty")
+
+    try:
+        tokens = json.loads(raw_tokens)
+    except json.JSONDecodeError as exc:
+        raise TokenBootstrapError(
+            f"the configured token value is not valid JSON ({exc.msg})"
+        ) from None
+
+    if not isinstance(tokens, dict):
+        raise TokenBootstrapError("the configured token value must be a JSON object")
+
+    missing = [
+        field
+        for field in _REQUIRED_TOKEN_FIELDS
+        if not isinstance(tokens.get(field), str) or not tokens[field].strip()
+    ]
+    if missing:
+        raise TokenBootstrapError(
+            "the configured token value is missing non-empty field(s): "
+            + ", ".join(missing)
+        )
+
+    return tokens
+
+
+def _write_tokens_atomically(
+    target: Path, tokens: dict, directory_store: bool
+) -> bool:
+    """Install validated tokens atomically without replacing another writer."""
+    parent_existed = target.parent.exists()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
+        if directory_store or not parent_existed:
+            os.chmod(target.parent, 0o700)
+    except OSError as exc:
+        raise TokenBootstrapError(
+            f"cannot prepare token directory '{target.parent}': {exc.strerror or exc}"
+        ) from None
+
+    fd = None
+    temp_path = None
+    try:
+        fd, temp_name = tempfile.mkstemp(
+            dir=target.parent,
+            prefix=f".{target.name}.",
+        )
+        temp_path = Path(temp_name)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as token_file:
+            fd = None
+            json.dump(tokens, token_file, separators=(",", ":"))
+            token_file.write("\n")
+            token_file.flush()
+            os.fsync(token_file.fileno())
+        try:
+            # The hard link is an atomic create-if-absent because the temporary
+            # file lives in the destination directory. Concurrent replicas can
+            # bootstrap the same shared volume without overwriting each other.
+            os.link(temp_path, target)
+        except FileExistsError:
+            if target.is_file():
+                return False
+            raise
+        return True
+    except OSError as exc:
+        raise TokenBootstrapError(
+            f"cannot write token file '{target}': {exc.strerror or exc}"
+        ) from None
+    finally:
+        if fd is not None:
+            try:
+                os.close(fd)
+            except OSError:
+                pass
+        if temp_path is not None:
+            try:
+                temp_path.unlink(missing_ok=True)
+            except OSError:
+                pass
+
+
+def bootstrap_tokens(token_path: str = None) -> Path | None:
+    """Initialize an empty writable token store from a deployment secret.
+
+    ``GARMIN_TOKENS_FILE`` points to a JSON secret file and is the recommended
+    input. ``GARMIN_TOKENS_JSON`` accepts the same document inline for platforms
+    that cannot mount secrets. Exactly one may be configured.
+
+    Existing ``garmin_tokens.json`` files are never overwritten. This lets
+    garminconnect persist refreshed tokens in the writable token store rather
+    than replacing them with stale bootstrap credentials on every restart.
+
+    Returns:
+        The installed token file path, or ``None`` when no bootstrap was needed.
+    """
+    source_file = os.getenv("GARMIN_TOKENS_FILE")
+    inline_tokens = os.getenv("GARMIN_TOKENS_JSON")
+
+    if source_file is None and inline_tokens is None:
+        return None
+    if source_file is not None and inline_tokens is not None:
+        raise TokenBootstrapError(
+            "set only one of GARMIN_TOKENS_FILE and GARMIN_TOKENS_JSON"
+        )
+
+    if token_path is None:
+        token_path = get_token_path()
+    store = Path(resolve_token_path(token_path))
+    directory_store = store.is_dir() or not store.name.endswith(".json")
+    target = get_token_json_path(token_path)
+
+    # A writable store may contain tokens refreshed after the bootstrap secret
+    # was created. It is therefore the source of truth once initialized.
+    if target.is_file():
+        return None
+    if target.exists():
+        raise TokenBootstrapError(
+            f"token destination '{target}' exists but is not a regular file"
+        )
+
+    if source_file is not None:
+        if not source_file.strip():
+            raise TokenBootstrapError("GARMIN_TOKENS_FILE is empty")
+        source = Path(resolve_token_path(source_file))
+        try:
+            raw_tokens = source.read_text(encoding="utf-8")
+        except OSError as exc:
+            raise TokenBootstrapError(
+                f"cannot read token secret '{source}': {exc.strerror or exc}"
+            ) from None
+    else:
+        raw_tokens = inline_tokens
+
+    tokens = _parse_bootstrap_tokens(raw_tokens)
+    installed = _write_tokens_atomically(target, tokens, directory_store)
+    return target if installed else None
 
 
 def token_exists(token_path: str = None) -> bool:

--- a/tests/docker/token_bootstrap_smoke.py
+++ b/tests/docker/token_bootstrap_smoke.py
@@ -1,0 +1,32 @@
+"""In-image smoke checks for the deployment token bootstrap lifecycle."""
+
+import json
+import stat
+import sys
+
+from garminconnect import Garmin
+
+from garmin_mcp.token_utils import bootstrap_tokens
+
+
+expected_state = sys.argv[1]
+if expected_state not in {"installed", "preserved"}:
+    raise SystemExit("expected state must be 'installed' or 'preserved'")
+
+result = bootstrap_tokens()
+assert result is not None
+assert result.installed is (expected_state == "installed")
+assert result.path.name == "garmin_tokens.json"
+assert stat.S_IMODE(result.path.stat().st_mode) == 0o600
+
+tokens = json.loads(result.path.read_text(encoding="utf-8"))
+assert tokens["di_token"] == "test-di-token"
+assert tokens["di_client_id"] == "test-client-id"
+
+# Use the pinned dependency's public file loader without making a network call.
+client = Garmin().client
+client.load(str(result.path.parent))
+assert client.di_token == "test-di-token"
+assert client.di_refresh_token == "test-refresh-token"
+
+print(f"token bootstrap smoke test: {expected_state}")

--- a/tests/unit/test_token_bootstrap_startup.py
+++ b/tests/unit/test_token_bootstrap_startup.py
@@ -23,14 +23,53 @@ def test_main_exits_nonzero_when_token_bootstrap_fails(monkeypatch, capsys):
 
 def test_main_reports_installed_bootstrap_tokens(monkeypatch, capsys, tmp_path):
     installed = tmp_path / "garmin_tokens.json"
-    bootstrap = Mock(return_value=installed)
+    bootstrap = Mock(
+        return_value=garmin_mcp.token_utils.TokenBootstrapResult(
+            installed, installed=True
+        )
+    )
     monkeypatch.setattr(garmin_mcp.token_utils, "bootstrap_tokens", bootstrap)
     monkeypatch.setattr(garmin_mcp, "init_api", Mock(return_value=None))
     monkeypatch.setenv("GARMIN_MCP_TRANSPORT", "stdio")
 
-    garmin_mcp.main()
+    with pytest.raises(SystemExit) as exc_info:
+        garmin_mcp.main()
 
+    assert exc_info.value.code == 1
     assert f"Garmin OAuth tokens bootstrapped into '{installed}'." in (
         capsys.readouterr().err
     )
     bootstrap.assert_called_once_with(garmin_mcp.tokenstore)
+
+
+def test_main_reports_skipped_bootstrap_source(monkeypatch, capsys, tmp_path):
+    existing = tmp_path / "garmin_tokens.json"
+    bootstrap = Mock(
+        return_value=garmin_mcp.token_utils.TokenBootstrapResult(
+            existing, installed=False
+        )
+    )
+    monkeypatch.setattr(garmin_mcp.token_utils, "bootstrap_tokens", bootstrap)
+    monkeypatch.setattr(garmin_mcp, "init_api", Mock(return_value=None))
+    monkeypatch.setenv("GARMIN_MCP_TRANSPORT", "stdio")
+
+    with pytest.raises(SystemExit):
+        garmin_mcp.main()
+
+    assert (
+        "Configured Garmin token bootstrap source skipped because "
+        f"'{existing}' already exists."
+    ) in capsys.readouterr().err
+
+
+def test_main_exits_nonzero_when_garmin_initialization_fails(monkeypatch):
+    monkeypatch.setattr(
+        garmin_mcp.token_utils, "bootstrap_tokens", Mock(return_value=None)
+    )
+    monkeypatch.setattr(garmin_mcp, "init_api", Mock(return_value=None))
+    monkeypatch.setenv("GARMIN_MCP_TRANSPORT", "stdio")
+
+    with pytest.raises(SystemExit) as exc_info:
+        garmin_mcp.main()
+
+    assert exc_info.value.code == 1

--- a/tests/unit/test_token_bootstrap_startup.py
+++ b/tests/unit/test_token_bootstrap_startup.py
@@ -1,0 +1,36 @@
+"""Tests for token bootstrap integration at server startup."""
+
+from unittest.mock import Mock
+
+import pytest
+
+import garmin_mcp
+
+
+def test_main_exits_nonzero_when_token_bootstrap_fails(monkeypatch, capsys):
+    bootstrap = Mock(
+        side_effect=garmin_mcp.token_utils.TokenBootstrapError("invalid secret")
+    )
+    monkeypatch.setattr(garmin_mcp.token_utils, "bootstrap_tokens", bootstrap)
+
+    with pytest.raises(SystemExit) as exc_info:
+        garmin_mcp.main()
+
+    assert exc_info.value.code == 1
+    assert "Garmin token bootstrap failed: invalid secret" in capsys.readouterr().err
+    bootstrap.assert_called_once_with(garmin_mcp.tokenstore)
+
+
+def test_main_reports_installed_bootstrap_tokens(monkeypatch, capsys, tmp_path):
+    installed = tmp_path / "garmin_tokens.json"
+    bootstrap = Mock(return_value=installed)
+    monkeypatch.setattr(garmin_mcp.token_utils, "bootstrap_tokens", bootstrap)
+    monkeypatch.setattr(garmin_mcp, "init_api", Mock(return_value=None))
+    monkeypatch.setenv("GARMIN_MCP_TRANSPORT", "stdio")
+
+    garmin_mcp.main()
+
+    assert f"Garmin OAuth tokens bootstrapped into '{installed}'." in (
+        capsys.readouterr().err
+    )
+    bootstrap.assert_called_once_with(garmin_mcp.tokenstore)

--- a/tests/unit/test_token_utils.py
+++ b/tests/unit/test_token_utils.py
@@ -1,5 +1,6 @@
 """Unit tests for token_utils module."""
 
+import errno
 import json
 import os
 import stat
@@ -8,9 +9,11 @@ from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 
 import pytest
+from garminconnect import Garmin
 
 from garmin_mcp.token_utils import (
     TokenBootstrapError,
+    TokenBootstrapResult,
     bootstrap_tokens,
     get_token_path,
     get_token_base64_path,
@@ -150,6 +153,26 @@ class TestBootstrapTokens:
         assert bootstrap_tokens(str(tmp_path / "tokens")) is None
         assert not (tmp_path / "tokens").exists()
 
+    @pytest.mark.parametrize("blank", ["", "   \t"])
+    def test_blank_sources_are_treated_as_unset(self, monkeypatch, tmp_path, blank):
+        monkeypatch.setenv("GARMIN_TOKENS_FILE", blank)
+        monkeypatch.setenv("GARMIN_TOKENS_JSON", blank)
+
+        assert bootstrap_tokens(str(tmp_path / "tokens")) is None
+        assert not (tmp_path / "tokens").exists()
+
+    def test_blank_file_source_does_not_conflict_with_inline_json(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("GARMIN_TOKENS_FILE", " ")
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+
+        result = bootstrap_tokens(str(tmp_path / "tokens"))
+
+        assert result.installed is True
+
     def test_inline_json_initializes_directory_store(self, monkeypatch, tmp_path):
         token_dir = tmp_path / "tokens"
         monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
@@ -157,12 +180,36 @@ class TestBootstrapTokens:
             "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
         )
 
-        installed = bootstrap_tokens(str(token_dir))
+        result = bootstrap_tokens(str(token_dir))
 
-        assert installed == token_dir / "garmin_tokens.json"
-        assert json.loads(installed.read_text()) == VALID_BOOTSTRAP_TOKENS
+        assert result == TokenBootstrapResult(
+            token_dir / "garmin_tokens.json", installed=True
+        )
+        assert json.loads(result.path.read_text()) == VALID_BOOTSTRAP_TOKENS
         assert stat.S_IMODE(token_dir.stat().st_mode) == 0o700
-        assert stat.S_IMODE(installed.stat().st_mode) == 0o600
+        assert stat.S_IMODE(result.path.stat().st_mode) == 0o600
+
+        client = Garmin().client
+        client.load(str(token_dir))
+        assert client.di_token == VALID_BOOTSTRAP_TOKENS["di_token"]
+        assert client.di_refresh_token == VALID_BOOTSTRAP_TOKENS["di_refresh_token"]
+        assert client.di_client_id == VALID_BOOTSTRAP_TOKENS["di_client_id"]
+
+    def test_existing_token_directory_permissions_are_preserved(
+        self, monkeypatch, tmp_path
+    ):
+        token_dir = tmp_path / "tokens"
+        token_dir.mkdir(mode=0o755)
+        os.chmod(token_dir, 0o755)
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+
+        result = bootstrap_tokens(str(token_dir))
+
+        assert result.installed is True
+        assert stat.S_IMODE(token_dir.stat().st_mode) == 0o755
 
     def test_secret_file_initializes_explicit_json_path(
         self, monkeypatch, tmp_path
@@ -173,9 +220,9 @@ class TestBootstrapTokens:
         monkeypatch.setenv("GARMIN_TOKENS_FILE", str(source))
         monkeypatch.delenv("GARMIN_TOKENS_JSON", raising=False)
 
-        installed = bootstrap_tokens(str(target))
+        result = bootstrap_tokens(str(target))
 
-        assert installed == target
+        assert result == TokenBootstrapResult(target, installed=True)
         assert json.loads(target.read_text()) == VALID_BOOTSTRAP_TOKENS
         assert stat.S_IMODE(target.stat().st_mode) == 0o600
         assert source.read_text() == json.dumps(VALID_BOOTSTRAP_TOKENS)
@@ -188,8 +235,26 @@ class TestBootstrapTokens:
         monkeypatch.setenv("GARMIN_TOKENS_JSON", "not valid JSON")
         monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
 
-        assert bootstrap_tokens(str(token_dir)) is None
+        assert bootstrap_tokens(str(token_dir)) == TokenBootstrapResult(
+            target, installed=False
+        )
         assert target.read_text() == '{"existing":"refreshed"}'
+
+    def test_symlink_destination_is_rejected(self, monkeypatch, tmp_path):
+        token_dir = tmp_path / "tokens"
+        token_dir.mkdir()
+        real_target = tmp_path / "real-tokens.json"
+        real_target.write_text('{"existing":"tokens"}')
+        (token_dir / "garmin_tokens.json").symlink_to(real_target)
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+
+        with pytest.raises(TokenBootstrapError, match="symbolic link"):
+            bootstrap_tokens(str(token_dir))
+
+        assert real_target.read_text() == '{"existing":"tokens"}'
 
     def test_file_and_inline_sources_are_mutually_exclusive(
         self, monkeypatch, tmp_path
@@ -205,10 +270,9 @@ class TestBootstrapTokens:
     @pytest.mark.parametrize(
         ("raw_tokens", "message"),
         [
-            ("", "empty"),
             ("not-json", "not valid JSON"),
             ("[]", "JSON object"),
-            ('{"di_token":"only-one-field"}', "di_refresh_token, di_client_id"),
+            ('{"di_refresh_token":"only-refresh"}', "di_token"),
         ],
     )
     def test_invalid_inline_tokens_fail_without_writing(
@@ -223,6 +287,21 @@ class TestBootstrapTokens:
 
         assert not token_dir.exists()
 
+    def test_di_token_without_refresh_fields_is_accepted(
+        self, monkeypatch, tmp_path
+    ):
+        token_dir = tmp_path / "tokens"
+        monkeypatch.setenv("GARMIN_TOKENS_JSON", '{"di_token":"short-lived-token"}')
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+
+        result = bootstrap_tokens(str(token_dir))
+
+        assert result.installed is True
+        client = Garmin().client
+        client.load(str(token_dir))
+        assert client.di_token == "short-lived-token"
+        assert client.di_refresh_token is None
+
     def test_missing_secret_file_fails_without_writing(self, monkeypatch, tmp_path):
         token_dir = tmp_path / "tokens"
         monkeypatch.setenv(
@@ -234,6 +313,51 @@ class TestBootstrapTokens:
             bootstrap_tokens(str(token_dir))
 
         assert not token_dir.exists()
+
+    def test_non_utf8_secret_fails_without_writing(self, monkeypatch, tmp_path):
+        source = tmp_path / "secret.json"
+        source.write_bytes(b"\xff\xfe")
+        token_dir = tmp_path / "tokens"
+        monkeypatch.setenv("GARMIN_TOKENS_FILE", str(source))
+        monkeypatch.delenv("GARMIN_TOKENS_JSON", raising=False)
+
+        with pytest.raises(TokenBootstrapError, match="not valid UTF-8"):
+            bootstrap_tokens(str(token_dir))
+
+        assert not token_dir.exists()
+
+    def test_install_works_without_os_fchmod(self, monkeypatch, tmp_path):
+        token_dir = tmp_path / "tokens"
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+        monkeypatch.delattr(os, "fchmod")
+
+        result = bootstrap_tokens(str(token_dir))
+
+        assert result.installed is True
+        assert json.loads(result.path.read_text()) == VALID_BOOTSTRAP_TOKENS
+
+    def test_exclusive_create_fallback_when_hard_links_are_unsupported(
+        self, monkeypatch, tmp_path
+    ):
+        token_dir = tmp_path / "tokens"
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+        monkeypatch.setattr(
+            os,
+            "link",
+            Mock(side_effect=OSError(errno.EOPNOTSUPP, "not supported")),
+        )
+
+        result = bootstrap_tokens(str(token_dir))
+
+        assert result.installed is True
+        assert json.loads(result.path.read_text()) == VALID_BOOTSTRAP_TOKENS
+        assert stat.S_IMODE(result.path.stat().st_mode) == 0o600
 
 
 class TestTokenExists:

--- a/tests/unit/test_token_utils.py
+++ b/tests/unit/test_token_utils.py
@@ -1,6 +1,8 @@
 """Unit tests for token_utils module."""
 
+import json
 import os
+import stat
 import tempfile
 from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
@@ -8,14 +10,24 @@ from unittest.mock import Mock, patch, MagicMock
 import pytest
 
 from garmin_mcp.token_utils import (
+    TokenBootstrapError,
+    bootstrap_tokens,
     get_token_path,
     get_token_base64_path,
+    get_token_json_path,
     resolve_token_path,
     token_exists,
     validate_tokens,
     remove_tokens,
     get_token_info,
 )
+
+
+VALID_BOOTSTRAP_TOKENS = {
+    "di_token": "test-di-token",
+    "di_refresh_token": "test-refresh-token",
+    "di_client_id": "test-client-id",
+}
 
 
 class TestGetTokenPath:
@@ -102,6 +114,126 @@ class TestGetTokenBase64Path:
         assert Path(get_token_base64_path()) == (
             tmp_path / ".garminconnect_base64"
         )
+
+
+class TestGetTokenJsonPath:
+    """Tests for matching garminconnect's directory/file path semantics."""
+
+    def test_directory_style_path_appends_default_filename(self, tmp_path):
+        token_dir = tmp_path / "tokens"
+
+        assert get_token_json_path(str(token_dir)) == (
+            token_dir / "garmin_tokens.json"
+        )
+
+    def test_explicit_json_path_is_preserved(self, tmp_path):
+        token_file = tmp_path / "custom.json"
+
+        assert get_token_json_path(str(token_file)) == token_file
+
+    def test_existing_directory_named_json_appends_default_filename(self, tmp_path):
+        token_dir = tmp_path / "tokens.json"
+        token_dir.mkdir()
+
+        assert get_token_json_path(str(token_dir)) == (
+            token_dir / "garmin_tokens.json"
+        )
+
+
+class TestBootstrapTokens:
+    """Tests for bootstrapping a writable token store from deployment secrets."""
+
+    def test_no_configured_source_is_a_noop(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+        monkeypatch.delenv("GARMIN_TOKENS_JSON", raising=False)
+
+        assert bootstrap_tokens(str(tmp_path / "tokens")) is None
+        assert not (tmp_path / "tokens").exists()
+
+    def test_inline_json_initializes_directory_store(self, monkeypatch, tmp_path):
+        token_dir = tmp_path / "tokens"
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+
+        installed = bootstrap_tokens(str(token_dir))
+
+        assert installed == token_dir / "garmin_tokens.json"
+        assert json.loads(installed.read_text()) == VALID_BOOTSTRAP_TOKENS
+        assert stat.S_IMODE(token_dir.stat().st_mode) == 0o700
+        assert stat.S_IMODE(installed.stat().st_mode) == 0o600
+
+    def test_secret_file_initializes_explicit_json_path(
+        self, monkeypatch, tmp_path
+    ):
+        source = tmp_path / "secret.json"
+        source.write_text(json.dumps(VALID_BOOTSTRAP_TOKENS))
+        target = tmp_path / "store" / "custom.json"
+        monkeypatch.setenv("GARMIN_TOKENS_FILE", str(source))
+        monkeypatch.delenv("GARMIN_TOKENS_JSON", raising=False)
+
+        installed = bootstrap_tokens(str(target))
+
+        assert installed == target
+        assert json.loads(target.read_text()) == VALID_BOOTSTRAP_TOKENS
+        assert stat.S_IMODE(target.stat().st_mode) == 0o600
+        assert source.read_text() == json.dumps(VALID_BOOTSTRAP_TOKENS)
+
+    def test_existing_tokens_are_never_overwritten(self, monkeypatch, tmp_path):
+        token_dir = tmp_path / "tokens"
+        token_dir.mkdir()
+        target = token_dir / "garmin_tokens.json"
+        target.write_text('{"existing":"refreshed"}')
+        monkeypatch.setenv("GARMIN_TOKENS_JSON", "not valid JSON")
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+
+        assert bootstrap_tokens(str(token_dir)) is None
+        assert target.read_text() == '{"existing":"refreshed"}'
+
+    def test_file_and_inline_sources_are_mutually_exclusive(
+        self, monkeypatch, tmp_path
+    ):
+        monkeypatch.setenv("GARMIN_TOKENS_FILE", str(tmp_path / "secret.json"))
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_JSON", json.dumps(VALID_BOOTSTRAP_TOKENS)
+        )
+
+        with pytest.raises(TokenBootstrapError, match="set only one"):
+            bootstrap_tokens(str(tmp_path / "tokens"))
+
+    @pytest.mark.parametrize(
+        ("raw_tokens", "message"),
+        [
+            ("", "empty"),
+            ("not-json", "not valid JSON"),
+            ("[]", "JSON object"),
+            ('{"di_token":"only-one-field"}', "di_refresh_token, di_client_id"),
+        ],
+    )
+    def test_invalid_inline_tokens_fail_without_writing(
+        self, monkeypatch, tmp_path, raw_tokens, message
+    ):
+        token_dir = tmp_path / "tokens"
+        monkeypatch.setenv("GARMIN_TOKENS_JSON", raw_tokens)
+        monkeypatch.delenv("GARMIN_TOKENS_FILE", raising=False)
+
+        with pytest.raises(TokenBootstrapError, match=message):
+            bootstrap_tokens(str(token_dir))
+
+        assert not token_dir.exists()
+
+    def test_missing_secret_file_fails_without_writing(self, monkeypatch, tmp_path):
+        token_dir = tmp_path / "tokens"
+        monkeypatch.setenv(
+            "GARMIN_TOKENS_FILE", str(tmp_path / "missing-secret.json")
+        )
+        monkeypatch.delenv("GARMIN_TOKENS_JSON", raising=False)
+
+        with pytest.raises(TokenBootstrapError, match="cannot read token secret"):
+            bootstrap_tokens(str(token_dir))
+
+        assert not token_dir.exists()
 
 
 class TestTokenExists:


### PR DESCRIPTION
## Summary

Add secure, first-start Garmin OAuth token bootstrap for unattended container deployments.

A deployment can provide an existing `garmin_tokens.json` through a mounted secret using `GARMIN_TOKENS_FILE`, or inline through `GARMIN_TOKENS_JSON` where file mounts are unavailable. The server validates and installs the tokens into its writable token store before initializing Garmin Connect.

This supersedes #192, which has the same general goal but references an `entrypoint.sh` that is absent from that PR and therefore cannot build.

## Motivation

Container secret mounts are commonly read-only, while `garminconnect` needs a writable token store so refreshed credentials can survive restarts.

Using the mounted secret directly as the active token store would either prevent refreshes or restore stale bootstrap credentials on every restart. This change instead uses the secret only to initialize an empty writable store:

1. Authenticate once on a trusted machine.
2. Mount the resulting token JSON as a deployment secret.
3. Install it into a writable token volume on first start.
4. Preserve that writable copy across subsequent starts and token refreshes.

This supports Docker Compose and other orchestrators that can mount a file or set an environment variable, without storing the Garmin email and password in the container.

## Configuration

Two mutually exclusive bootstrap sources are supported:

- `GARMIN_TOKENS_FILE`: path to a raw token JSON secret; recommended.
- `GARMIN_TOKENS_JSON`: inline raw token JSON for platforms that cannot mount files.

Blank values are treated as unset. When neither source is configured, bootstrap behavior is unchanged.

`GARMINTOKENS` continues to select the writable token directory or an explicit `.json` destination.

## Behavior and security

- Validates that bootstrap input is a JSON object containing a non-empty `di_token`.
- Accepts the native `di_token`, `di_refresh_token`, and `di_client_id` document produced by the pinned `garminconnect` version.
- Never prints token contents.
- Rejects ambiguous configuration when both bootstrap sources are set.
- Rejects a symbolic-link destination.
- Never overwrites an existing token file, because it may contain credentials refreshed after the bootstrap secret was created.
- Reports when a configured bootstrap source is skipped because writable tokens already exist.
- Creates a new bootstrap token directory with mode `0700` and the token file with mode `0600`.
- Bootstrap itself does not change the permissions of a token directory that already existed.
- Uses atomic hard-link create-if-absent where supported, with an exclusive-create fallback for filesystems that do not support hard links.
- Handles concurrent initializers without allowing one replica to overwrite another.
- Treats empty, malformed, non-object, and non-UTF-8 bootstrap documents as configuration errors.
- Exits non-zero with a clear error when an empty store must be initialized but the configured source cannot be read, validated, or installed.
- Uses the existing writable token file as the source of truth on later starts, without reparsing or replacing it from the bootstrap source.

The file-based option is recommended because inline environment values can be exposed through container metadata and process inspection.

## Docker and dependency reproducibility

The Docker image now installs from `uv.lock` using `uv sync --locked --no-dev`. This ensures the image uses the exact dependency set tested by CI instead of independently resolving compatible versions during every build.

This complements #227:

- #227 caps the supported MCP range below MCP 2.x at the package metadata level, protecting `uvx`, DXT, and other fresh installations.
- This PR locks the container to the repository's tested dependency graph so its dependencies cannot drift independently.

After this change, dependency updates that modify `pyproject.toml` without updating `uv.lock` will fail the Docker build rather than silently producing a differently resolved image. That failure is intentional.

The image copies only the small pytest-free Docker smoke fixture rather than the complete test suite and development configuration.

## Container lifecycle verification

CI builds the real image and verifies:

1. A mounted, read-only secret initializes an empty named token volume.
2. The installed file has owner-only permissions.
3. The pinned `garminconnect` loader can read the installed token document.
4. A second container start preserves the writable volume copy rather than replacing it with new bootstrap input.
5. The real image entrypoint exits non-zero and emits the specific bootstrap-validation error when given invalid bootstrap JSON.

The final assertion checks the error message as well as the exit status, so an unrelated authentication failure cannot make the test pass.

This lifecycle coverage is distinct from #170 and #195, which build or publish images but do not start them. If preferred, the smoke step could later be folded into #195's container workflow to avoid two image builds.

## Related fixes

- `main()` now exits non-zero when the Garmin client cannot be initialized, instead of exiting successfully with no server running. This applies to all deployments, not only those using bootstrap.
- The base64 token export in `init_api` and `garmin-mcp-auth` now resolves the token filename through the shared helper, fixing an explicit `.json` `GARMINTOKENS` path.

## Documentation

The README and Compose example now document:

- mounted OAuth token bootstrap;
- the required writable token volume;
- file versus inline secret tradeoffs;
- non-overwrite behavior across restarts;
- token rotation by replacing the secret and intentionally clearing the persisted token volume;
- the existing credential-file login option as a separate workflow.

## Test plan

- `uv sync --locked`
- `uv run pytest tests/integration tests/unit -q` — **480 passed**
- Docker image build from the repository Dockerfile — **passed**
- Two-start named-volume bootstrap smoke test — **passed**
- Pinned `garminconnect` token-loader round trip — **passed**
- Real-entrypoint invalid-bootstrap assertion — **passed**
- Negative control confirming an unrelated missing-token exit does not satisfy the bootstrap assertion — **passed**
