### PR TITLE
fix: pin mcp SDK below 2.0 to keep FastMCP import working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "python-dotenv==1.2.2",
     "garminconnect==0.3.2",
     "requests==2.33.0",
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2.0",
     "fitparse>=1.2.0",
 ]
 


### PR DESCRIPTION
## Problem

mcp 2.0.0 (released on PyPI 2026-07-28) removed `mcp.server.fastmcp` entirely, replacing `FastMCP` with a new `MCPServer` API. Since the dependency constraint is `mcp>=1.28.1`, any fresh install or uvx environment rebuild now resolves to 2.0.0 and the server crashes on startup:

```
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

Users with a uvx/uv cache built before July 28 are unaffected until their environment rebuilds (e.g. when a new commit lands on this repo), so this breaks installs progressively.

## Fix

Pin `mcp>=1.28.1,<2.0` until the codebase is migrated to the new `MCPServer` API. The 2.0 migration is a substantial rewrite (all tool/resource registration modules use the `FastMCP` decorator pattern), so pinning keeps installs working in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)