### PR TITLE
fix: cap mcp dependency below 2.0 to keep FastMCP import working

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ dependencies = [
     "python-dotenv==1.2.2",
     "garminconnect==0.3.2",
     "requests==2.33.0",
-    "mcp>=1.28.1",
+    "mcp>=1.28.1,<2",
     "fitparse>=1.2.0",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -321,7 +321,7 @@ name = "exceptiongroup"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+    { name = "typing-extensions" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/0b/9f/a65090624ecf468cdca03533906e7c69ed7588582240cfe7cc9e770b50eb/exceptiongroup-1.3.0.tar.gz", hash = "sha256:b241f5885f560bc56a59ee63ca4c6a8bfa46ae4ad651af316d4e81817bb9fd88", size = 29749, upload-time = "2025-05-10T17:42:51.123Z" }
 wheels = [
@@ -358,7 +358,7 @@ dev = [
 requires-dist = [
     { name = "fitparse", specifier = ">=1.2.0" },
     { name = "garminconnect", specifier = "==0.3.2" },
-    { name = "mcp", specifier = ">=1.28.1" },
+    { name = "mcp", specifier = ">=1.28.1,<2" },
     { name = "python-dotenv", specifier = "==1.2.2" },
     { name = "requests", specifier = "==2.33.0" },
 ]


### PR DESCRIPTION
## Summary

`garmin_mcp` fails to start at import time on a fresh install. `pyproject.toml` declares `mcp>=1.28.1` with no upper bound, so a fresh resolve now pulls `mcp==2.0.0`. That release removed the bundled FastMCP module (`mcp.server.fastmcp`), which this project imports in `garmin_mcp/__init__.py`. Result: the server process crashes immediately after the client sends `initialize`.

```
Traceback (most recent call last):
  File ".../bin/garmin-mcp", line 6, in <module>
    from garmin_mcp import main
  File ".../site-packages/garmin_mcp/__init__.py", line 10, in <module>
    from mcp.server.fastmcp import FastMCP
ModuleNotFoundError: No module named 'mcp.server.fastmcp'
```

This is not a cache issue — `uvx --refresh` / `uv cache clean` don't help because the resolver still picks 2.0.0.

## Fix

Cap the `mcp` dependency at `<2` in `pyproject.toml` (and regenerate `uv.lock`), keeping the current FastMCP import working with no code changes. This unblocks users immediately; migrating to the standalone `fastmcp` package for `mcp` 2.x support is a separate, larger follow-up if maintainers want it.

## Test plan

- [x] `uv run python -c "from mcp.server.fastmcp import FastMCP"` succeeds with the capped dependency (previously failed against `mcp==2.0.0`)
- [x] `uv run python -c "import garmin_mcp"` succeeds
- [x] `uv run pytest -q` — 467 passed; the only failures are pre-existing live-API e2e tests requiring real Garmin credentials, unrelated to this change
- [x] `uvx --python 3.12 --from git+https://github.com/guysherman/garmin_mcp@fix/cap-mcp-dependency-below-2 garmin-mcp` installs and initializes successfully end-to-end (matches how the `.dxt` extension launches the server)
- [x] Built and installed the extension and it is working fine.