### PR TITLE
feat(workouts): expose Garmin Coach workouts (closes #231)

### DIFF
--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -554,6 +554,9 @@ def _curate_scheduled_workout(scheduled: dict) -> dict:
         "scheduled_workout_id": scheduled.get('scheduledWorkoutId'),
         "workout_uuid": scheduled.get('workoutUuid'),
         "workout_id": scheduled.get('workoutId'),
+        "training_plan_id": scheduled.get('trainingPlanId'),
+        "fbt_adaptive_plan_id": scheduled.get('fbtAdaptivePlanId'),
+        "tp_type": scheduled.get('tpType'),
         "name": scheduled.get('workoutName'),
         "sport": scheduled.get('workoutType'),
         "completed": is_completed,
@@ -645,6 +648,7 @@ def _get_garmin_coach_workouts(calendar_date: str) -> str:
 
     all_workouts = []
     plan_names = []
+    plans = []
     valid_plan_count = 0
     for plan in training_plans:
         if not isinstance(plan, dict):
@@ -654,6 +658,22 @@ def _get_garmin_coach_workouts(calendar_date: str) -> str:
         plan_name = plan.get("planName")
         if plan_name and plan_name not in plan_names:
             plan_names.append(plan_name)
+
+        plan_details = plan.get("trainingPlanDetailsDTO")
+        if not isinstance(plan_details, dict):
+            plan_details = {}
+        plan_summary = {
+            "name": plan_name,
+            "training_plan_id": plan.get("trainingPlanId"),
+            "classification": plan.get("trainingPlanClassification"),
+            "training_type": plan_details.get("trainingType"),
+        }
+        plan_summary = {
+            key: value for key, value in plan_summary.items()
+            if value is not None
+        }
+        if plan_summary:
+            plans.append(plan_summary)
 
         workout_summaries = plan.get("workoutScheduleSummaries") or []
         if not isinstance(workout_summaries, list):
@@ -670,6 +690,7 @@ def _get_garmin_coach_workouts(calendar_date: str) -> str:
     curated = {
         "date": calendar_date,
         "training_plans": plan_names if plan_names else None,
+        "plans": plans if plans else None,
         "count": len(all_workouts),
         "workouts": all_workouts,
     }
@@ -711,9 +732,12 @@ def register_tools(app):
         Returns workout details including segments and step structure.
 
         Accepts either:
-        - Numeric workout ID (from get_workouts or get_scheduled_workouts)
-        - Workout UUID (from get_garmin_coach_workouts or
-          get_training_plan_workouts for Garmin Coach workouts)
+        - Numeric workout ID (from get_workouts, get_scheduled_workouts, or
+          training-plan families that expose workout_id)
+        - Workout UUID (from adaptive Garmin Coach/training-plan workouts)
+
+        Rest-day UUIDs can resolve to a minimal record without a workout name
+        or segments.
 
         Args:
             workout_id: Workout ID (numeric) or UUID (for training plan workouts)
@@ -1074,10 +1098,12 @@ def register_tools(app):
     async def get_garmin_coach_workouts(calendar_date: str) -> str:
         """Get Garmin Coach workouts around the given date
 
-        Returns workouts from the active adaptive Garmin Coach plan, including
-        workout UUIDs, dates, sport, duration, completion status, rest days,
-        race days, and workout intent when Garmin provides them. The API
-        typically returns approximately seven days anchored around the date.
+        Returns workouts from the active Garmin Coach/training plan, including
+        plan metadata, workout identifiers, dates, sport, duration, completion
+        status, rest days, race days, and workout intent when Garmin provides
+        them. Adaptive plans expose only Garmin's currently generated window,
+        typically the current week; future dates may return no workouts even
+        while a plan is active. The count includes rest-day entries.
 
         Garmin's device-generated Daily Suggested Workouts are computed on a
         compatible watch and are not available through the Garmin Connect API
@@ -1087,8 +1113,10 @@ def register_tools(app):
         This is the preferred tool for Garmin Coach requests. The legacy
         get_training_plan_workouts tool returns the same data; do not call both.
 
-        Coach workouts have workout_uuid (not workout_id). Use the workout_uuid
-        with get_workout_by_id to retrieve detailed steps and targets.
+        Adaptive Coach plans typically expose workout_uuid; other plan families
+        may expose numeric workout_id. Pass whichever identifier is present to
+        get_workout_by_id. Rest-day UUIDs may return minimal detail without
+        workout segments.
 
         Args:
             calendar_date: Reference date in YYYY-MM-DD format (returns week's workouts)
@@ -1104,11 +1132,13 @@ def register_tools(app):
 
         Prefer get_garmin_coach_workouts for new requests. This legacy tool
         returns the same Garmin Coach/training-plan data; do not call both for
-        one request. The API typically returns approximately seven days of
-        workouts anchored around the specified date.
+        one request. Adaptive plans expose only Garmin's currently generated
+        window, typically the current week; future dates may return no workouts
+        even while a plan is active.
 
-        Training plan workouts have workout_uuid (not workout_id). Use the
-        workout_uuid with get_workout_by_id to get detailed step information.
+        Adaptive training plans typically expose workout_uuid; other plan
+        families may expose numeric workout_id. Pass whichever identifier is
+        present to get_workout_by_id. The returned count includes rest days.
 
         Args:
             calendar_date: Reference date in YYYY-MM-DD format (returns week's workouts)

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -1105,10 +1105,12 @@ def register_tools(app):
         typically the current week; future dates may return no workouts even
         while a plan is active. The count includes rest-day entries.
 
-        Garmin's device-generated Daily Suggested Workouts are computed on a
-        compatible watch and are not available through the Garmin Connect API
-        this server uses; they exist only on the watch. This tool returns Garmin
-        Coach/training-plan workouts and does not guess watch-only suggestions.
+        Garmin's standalone Daily Suggested Workouts are generated on compatible
+        devices. As of July 31, 2026, no supported or known Garmin Connect
+        web/API endpoint, including those exposed by this project's
+        python-garminconnect dependency, returns the device's upcoming DSW
+        schedule. This tool returns Garmin Coach/training-plan workouts and does
+        not synthesize device-generated suggestions.
 
         This is the preferred tool for Garmin Coach requests. The legacy
         get_training_plan_workouts tool returns the same data; do not call both.

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -621,6 +621,64 @@ def _is_already_scheduled(workout_id: int, calendar_date: str) -> bool:
     return False
 
 
+def _get_garmin_coach_workouts(calendar_date: str) -> str:
+    """Return curated workouts from the active Garmin Coach/training plan."""
+    _validate_date(calendar_date, "calendar_date")
+    query = {
+        "query": (
+            f'query{{trainingPlanScalar(calendarDate:"{calendar_date}", '
+            f'lang:"en-US", firstDayOfWeek:"monday")}}'
+        )
+    }
+    result = garmin_client.query_garmin_graphql(query)
+
+    if not isinstance(result, dict) or not isinstance(result.get("data"), dict):
+        return "No training plan data found or error querying data."
+
+    plan_data = result["data"].get("trainingPlanScalar") or {}
+    if not isinstance(plan_data, dict):
+        return "No training plan data found or error querying data."
+
+    training_plans = plan_data.get("trainingPlanWorkoutScheduleDTOS") or []
+    if not isinstance(training_plans, list) or not training_plans:
+        return f"No training plan workouts scheduled for {calendar_date}."
+
+    all_workouts = []
+    plan_names = []
+    valid_plan_count = 0
+    for plan in training_plans:
+        if not isinstance(plan, dict):
+            continue
+        valid_plan_count += 1
+
+        plan_name = plan.get("planName")
+        if plan_name and plan_name not in plan_names:
+            plan_names.append(plan_name)
+
+        workout_summaries = plan.get("workoutScheduleSummaries") or []
+        if not isinstance(workout_summaries, list):
+            continue
+        all_workouts.extend(
+            _curate_scheduled_workout(workout)
+            for workout in workout_summaries
+            if isinstance(workout, dict)
+        )
+
+    if valid_plan_count == 0:
+        return f"No training plan workouts scheduled for {calendar_date}."
+
+    curated = {
+        "date": calendar_date,
+        "training_plans": plan_names if plan_names else None,
+        "count": len(all_workouts),
+        "workouts": all_workouts,
+    }
+    return json.dumps(
+        {key: value for key, value in curated.items() if value is not None},
+        indent=2,
+    )
+
+
 def register_tools(app):
     """Register all workout-related tools with the MCP server app"""
 
@@ -654,7 +712,8 @@ def register_tools(app):
 
         Accepts either:
         - Numeric workout ID (from get_workouts or get_scheduled_workouts)
-        - Workout UUID (from get_training_plan_workouts for Garmin Coach workouts)
+        - Workout UUID (from get_garmin_coach_workouts or
+          get_training_plan_workouts for Garmin Coach workouts)
 
         Args:
             workout_id: Workout ID (numeric) or UUID (for training plan workouts)
@@ -1012,12 +1071,41 @@ def register_tools(app):
             return f"Error retrieving scheduled workouts: {str(e)}"
 
     @app.tool()
-    async def get_training_plan_workouts(calendar_date: str) -> str:
-        """Get training plan workouts for the week containing the given date
+    async def get_garmin_coach_workouts(calendar_date: str) -> str:
+        """Get Garmin Coach workouts around the given date
 
-        Returns workouts from your active training plan for the week containing
-        the specified date. The API returns approximately 7 days of scheduled
-        workouts anchored around the given date.
+        Returns workouts from the active adaptive Garmin Coach plan, including
+        workout UUIDs, dates, sport, duration, completion status, rest days,
+        race days, and workout intent when Garmin provides them. The API
+        typically returns approximately seven days anchored around the date.
+
+        Garmin's device-generated Daily Suggested Workouts are computed on a
+        compatible watch and are not available through the Garmin Connect API
+        this server uses; they exist only on the watch. This tool returns Garmin
+        Coach/training-plan workouts and does not guess watch-only suggestions.
+
+        This is the preferred tool for Garmin Coach requests. The legacy
+        get_training_plan_workouts tool returns the same data; do not call both.
+
+        Coach workouts have workout_uuid (not workout_id). Use the workout_uuid
+        with get_workout_by_id to retrieve detailed steps and targets.
+
+        Args:
+            calendar_date: Reference date in YYYY-MM-DD format (returns week's workouts)
+        """
+        try:
+            return _get_garmin_coach_workouts(calendar_date)
+        except Exception as e:
+            return f"Error retrieving Garmin Coach workouts: {str(e)}"
+
+    @app.tool()
+    async def get_training_plan_workouts(calendar_date: str) -> str:
+        """Compatibility alias for get_garmin_coach_workouts
+
+        Prefer get_garmin_coach_workouts for new requests. This legacy tool
+        returns the same Garmin Coach/training-plan data; do not call both for
+        one request. The API typically returns approximately seven days of
+        workouts anchored around the specified date.
 
         Training plan workouts have workout_uuid (not workout_id). Use the
         workout_uuid with get_workout_by_id to get detailed step information.
@@ -1026,49 +1114,7 @@ def register_tools(app):
             calendar_date: Reference date in YYYY-MM-DD format (returns week's workouts)
         """
         try:
-            _validate_date(calendar_date, "calendar_date")
-            # Query for training plan workouts using GraphQL
-            query = {
-                "query": f'query{{trainingPlanScalar(calendarDate:"{calendar_date}", lang:"en-US", firstDayOfWeek:"monday")}}'
-            }
-            result = garmin_client.query_garmin_graphql(query)
-
-            if not result or "data" not in result:
-                return "No training plan data found or error querying data."
-
-            plan_data = result.get("data", {}).get("trainingPlanScalar", {})
-            training_plans = plan_data.get("trainingPlanWorkoutScheduleDTOS", [])
-
-            if not training_plans:
-                return f"No training plan workouts scheduled for {calendar_date}."
-
-            # Collect all workouts from all training plans
-            all_workouts = []
-            plan_names = []
-
-            for plan in training_plans:
-                plan_name = plan.get('planName')
-                if plan_name and plan_name not in plan_names:
-                    plan_names.append(plan_name)
-
-                # workoutScheduleSummaries has same structure as scheduled workouts
-                workout_summaries = plan.get('workoutScheduleSummaries', [])
-                for workout in workout_summaries:
-                    # Reuse the scheduled workout curation since structure is identical
-                    all_workouts.append(_curate_scheduled_workout(workout))
-
-            # Curate training plan data
-            curated = {
-                "date": calendar_date,
-                "training_plans": plan_names if plan_names else None,
-                "count": len(all_workouts),
-                "workouts": all_workouts
-            }
-
-            # Remove None values from top level
-            curated = {k: v for k, v in curated.items() if v is not None}
-
-            return json.dumps(curated, indent=2)
+            return _get_garmin_coach_workouts(calendar_date)
         except Exception as e:
             return f"Error retrieving training plan workouts: {str(e)}"
 

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -1208,8 +1208,16 @@ async def test_get_scheduled_workouts_tool(app_with_workouts, mock_garmin_client
 
 
 @pytest.mark.asyncio
-async def test_get_training_plan_workouts_tool(app_with_workouts, mock_garmin_client):
-    """Test get_training_plan_workouts tool - uses GraphQL query"""
+@pytest.mark.parametrize(
+    "tool_name",
+    ["get_garmin_coach_workouts", "get_training_plan_workouts"],
+)
+async def test_get_garmin_coach_workout_tools(
+    app_with_workouts,
+    mock_garmin_client,
+    tool_name,
+):
+    """Both the explicit Coach tool and legacy training-plan tool use GraphQL."""
     import json as json_module
 
     # Setup mock for GraphQL query - matches actual API response structure
@@ -1254,7 +1262,7 @@ async def test_get_training_plan_workouts_tool(app_with_workouts, mock_garmin_cl
 
     # Call tool
     result = await app_with_workouts.call_tool(
-        "get_training_plan_workouts",
+        tool_name,
         {"calendar_date": "2024-01-15"}
     )
 
@@ -1278,6 +1286,118 @@ async def test_get_training_plan_workouts_tool(app_with_workouts, mock_garmin_cl
     assert workouts[1]["name"] == "Strength"
     assert workouts[1]["completed"] is True
     assert workouts[1]["activity_id"] == 987654
+
+
+@pytest.mark.asyncio
+async def test_get_garmin_coach_workouts_handles_malformed_plan_entries(
+    app_with_workouts,
+    mock_garmin_client,
+):
+    """Unexpected nullable/scalar plan entries do not break the whole result."""
+    import json as json_module
+
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {
+            "trainingPlanScalar": {
+                "trainingPlanWorkoutScheduleDTOS": [
+                    None,
+                    {
+                        "planName": "Adaptive Plan",
+                        "workoutScheduleSummaries": [
+                            None,
+                            {
+                                "workoutUuid": "abc-123",
+                                "workoutName": "Base Run",
+                                "workoutType": "running",
+                                "scheduleDate": "2024-01-15",
+                                "associatedActivityId": None,
+                            },
+                        ],
+                    },
+                ]
+            }
+        }
+    }
+
+    result = await app_with_workouts.call_tool(
+        "get_garmin_coach_workouts",
+        {"calendar_date": "2024-01-15"},
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["training_plans"] == ["Adaptive Plan"]
+    assert result_data["count"] == 1
+    assert result_data["workouts"][0]["workout_uuid"] == "abc-123"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("response", "expected"),
+    [
+        (None, "No training plan data found or error querying data."),
+        (
+            {"data": None},
+            "No training plan data found or error querying data.",
+        ),
+        (
+            {"data": {"trainingPlanScalar": None}},
+            "No training plan workouts scheduled for 2024-01-15.",
+        ),
+        (
+            {
+                "data": {
+                    "trainingPlanScalar": {
+                        "trainingPlanWorkoutScheduleDTOS": [],
+                    }
+                }
+            },
+            "No training plan workouts scheduled for 2024-01-15.",
+        ),
+        (
+            {
+                "data": {
+                    "trainingPlanScalar": {
+                        "trainingPlanWorkoutScheduleDTOS": [None],
+                    }
+                }
+            },
+            "No training plan workouts scheduled for 2024-01-15.",
+        ),
+    ],
+)
+async def test_get_garmin_coach_workouts_handles_missing_plan_data(
+    app_with_workouts,
+    mock_garmin_client,
+    response,
+    expected,
+):
+    """Missing, null, empty, or wholly malformed plan data is handled."""
+    mock_garmin_client.query_garmin_graphql.return_value = response
+
+    result = await app_with_workouts.call_tool(
+        "get_garmin_coach_workouts",
+        {"calendar_date": "2024-01-15"},
+    )
+
+    assert result[0][0].text == expected
+
+
+@pytest.mark.asyncio
+async def test_get_garmin_coach_workouts_rejects_invalid_date(
+    app_with_workouts,
+    mock_garmin_client,
+):
+    """Invalid dates are rejected before a GraphQL request is made."""
+    result = await app_with_workouts.call_tool(
+        "get_garmin_coach_workouts",
+        {"calendar_date": "2024-01-15-invalid"},
+    )
+
+    assert result[0][0].text == (
+        "Error retrieving Garmin Coach workouts: Invalid calendar_date "
+        "'2024-01-15-invalid': expected YYYY-MM-DD"
+    )
+    mock_garmin_client.query_garmin_graphql.assert_not_called()
 
 
 # Delete workout tests

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -109,6 +109,7 @@ async def test_get_workout_by_id_tool(app_with_workouts, mock_garmin_client):
     # Verify - tool converts to int for numeric IDs
     assert result is not None
     mock_garmin_client.get_workout_by_id.assert_called_once_with(123456)
+    mock_garmin_client.connectapi.assert_not_called()
 
     # Parse the result and verify curation includes steps
     result_data = json_module.loads(result[0][0].text)
@@ -266,6 +267,7 @@ async def test_get_workout_by_uuid_tool(app_with_workouts, mock_garmin_client):
     mock_garmin_client.connectapi.assert_called_once_with(
         f"workout-service/fbt-adaptive/{workout_uuid}"
     )
+    mock_garmin_client.get_workout_by_id.assert_not_called()
 
     # Parse the result and verify training plan workout fields
     result_data = json_module.loads(result[0][0].text)
@@ -1208,6 +1210,64 @@ async def test_get_scheduled_workouts_tool(app_with_workouts, mock_garmin_client
 
 
 @pytest.mark.asyncio
+async def test_get_scheduled_workouts_preserves_manual_shape_and_adds_plan_ids(
+    app_with_workouts,
+    mock_garmin_client,
+):
+    """Shared curation enriches plan entries without changing manual entries."""
+    import json as json_module
+
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {
+            "workoutScheduleSummariesScalar": [
+                {
+                    "scheduledWorkoutId": 1001,
+                    "workoutUuid": None,
+                    "workoutId": 2001,
+                    "workoutName": "Manual Ride",
+                    "workoutType": "cycling",
+                    "scheduleDate": "2024-01-15",
+                    "associatedActivityId": None,
+                    "trainingPlanId": None,
+                    "fbtAdaptivePlanId": None,
+                    "tpType": None,
+                },
+                {
+                    "scheduledWorkoutId": None,
+                    "workoutUuid": "abc-123-def",
+                    "workoutId": None,
+                    "workoutName": "Coach Ride",
+                    "workoutType": "cycling",
+                    "scheduleDate": "2024-01-16",
+                    "associatedActivityId": None,
+                    "trainingPlanId": 3001,
+                    "fbtAdaptivePlanId": 3001,
+                    "tpType": None,
+                },
+            ]
+        }
+    }
+
+    result = await app_with_workouts.call_tool(
+        "get_scheduled_workouts",
+        {"start_date": "2024-01-15", "end_date": "2024-01-16"},
+    )
+
+    scheduled = json_module.loads(result[0][0].text)["scheduled_workouts"]
+    assert scheduled[0] == {
+        "date": "2024-01-15",
+        "scheduled_workout_id": 1001,
+        "workout_id": 2001,
+        "name": "Manual Ride",
+        "sport": "cycling",
+        "completed": False,
+    }
+    assert scheduled[1]["training_plan_id"] == 3001
+    assert scheduled[1]["fbt_adaptive_plan_id"] == 3001
+    assert "tp_type" not in scheduled[1]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     "tool_name",
     ["get_garmin_coach_workouts", "get_training_plan_workouts"],
@@ -1226,10 +1286,13 @@ async def test_get_garmin_coach_workout_tools(
             "trainingPlanScalar": {
                 "trainingPlanWorkoutScheduleDTOS": [
                     {
+                        "trainingPlanId": 12345,
                         "planName": "5K Training Plan",
+                        "trainingPlanClassification": "FBT_ADAPTIVE",
                         "trainingPlanDetailsDTO": {
                             "athletePlanId": 12345,
-                            "workoutsPerWeek": 4
+                            "workoutsPerWeek": 4,
+                            "trainingType": "RUNNING",
                         },
                         "workoutScheduleSummaries": [
                             {
@@ -1240,7 +1303,10 @@ async def test_get_garmin_coach_workout_tools(
                                 "scheduleDate": "2024-01-15",
                                 "tpPlanName": "5K Training Plan",
                                 "associatedActivityId": None,
-                                "estimatedDurationInSecs": 1800
+                                "estimatedDurationInSecs": 1800,
+                                "trainingPlanId": 12345,
+                                "fbtAdaptivePlanId": 12345,
+                                "tpType": None,
                             },
                             {
                                 "workoutUuid": "xyz-456-ghi",
@@ -1250,7 +1316,10 @@ async def test_get_garmin_coach_workout_tools(
                                 "scheduleDate": "2024-01-15",
                                 "tpPlanName": "5K Training Plan",
                                 "associatedActivityId": 987654,
-                                "estimatedDurationInSecs": 1200
+                                "estimatedDurationInSecs": 1200,
+                                "trainingPlanId": 12345,
+                                "fbtAdaptivePlanId": 12345,
+                                "tpType": None,
                             }
                         ]
                     }
@@ -1274,6 +1343,14 @@ async def test_get_garmin_coach_workout_tools(
     result_data = json_module.loads(result[0][0].text)
     assert result_data["date"] == "2024-01-15"
     assert result_data["training_plans"] == ["5K Training Plan"]
+    assert result_data["plans"] == [
+        {
+            "name": "5K Training Plan",
+            "training_plan_id": 12345,
+            "classification": "FBT_ADAPTIVE",
+            "training_type": "RUNNING",
+        }
+    ]
     assert result_data["count"] == 2
 
     # Verify workouts are curated correctly
@@ -1281,11 +1358,134 @@ async def test_get_garmin_coach_workout_tools(
     assert workouts[0]["name"] == "Base Run"
     assert workouts[0]["sport"] == "running"
     assert workouts[0]["completed"] is False
+    assert workouts[0]["training_plan_id"] == 12345
+    assert workouts[0]["fbt_adaptive_plan_id"] == 12345
+    assert "tp_type" not in workouts[0]
 
-    # Verify completed workout has activity_id
+    # Supplemental strength remains owned by the adaptive running plan.
     assert workouts[1]["name"] == "Strength"
+    assert workouts[1]["sport"] == "strength_training"
+    assert workouts[1]["training_plan_id"] == 12345
+    assert workouts[1]["fbt_adaptive_plan_id"] == 12345
     assert workouts[1]["completed"] is True
     assert workouts[1]["activity_id"] == 987654
+
+
+@pytest.mark.asyncio
+async def test_get_garmin_coach_workouts_stp_numeric_ids(
+    app_with_workouts,
+    mock_garmin_client,
+):
+    """Strength-plan entries preserve numeric IDs and their STP type."""
+    import json as json_module
+
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {
+            "trainingPlanScalar": {
+                "trainingPlanWorkoutScheduleDTOS": [
+                    {
+                        "trainingPlanId": 67890,
+                        "planName": "Push, Pull, Legs",
+                        "trainingPlanClassification": "STP",
+                        "trainingPlanDetailsDTO": {
+                            "athletePlanId": 67890,
+                            "trainingType": "STRENGTH",
+                        },
+                        "workoutScheduleSummaries": [
+                            {
+                                "scheduledWorkoutId": 111,
+                                "workoutUuid": None,
+                                "workoutId": 222,
+                                "workoutName": "Leg Day",
+                                "workoutType": "strength_training",
+                                "scheduleDate": "2024-01-15",
+                                "tpPlanName": "Push, Pull, Legs",
+                                "associatedActivityId": None,
+                                "trainingPlanId": 67890,
+                                "fbtAdaptivePlanId": None,
+                                "tpType": "STP",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+
+    result = await app_with_workouts.call_tool(
+        "get_garmin_coach_workouts",
+        {"calendar_date": "2024-01-15"},
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["training_plans"] == ["Push, Pull, Legs"]
+    assert result_data["plans"] == [
+        {
+            "name": "Push, Pull, Legs",
+            "training_plan_id": 67890,
+            "classification": "STP",
+            "training_type": "STRENGTH",
+        }
+    ]
+    workout = result_data["workouts"][0]
+    assert workout["workout_id"] == 222
+    assert "workout_uuid" not in workout
+    assert workout["training_plan_id"] == 67890
+    assert workout["tp_type"] == "STP"
+    assert "fbt_adaptive_plan_id" not in workout
+
+
+@pytest.mark.asyncio
+async def test_get_garmin_coach_workouts_includes_rest_days(
+    app_with_workouts,
+    mock_garmin_client,
+):
+    """Rest days remain counted even when Garmin omits name and sport."""
+    import json as json_module
+
+    mock_garmin_client.query_garmin_graphql.return_value = {
+        "data": {
+            "trainingPlanScalar": {
+                "trainingPlanWorkoutScheduleDTOS": [
+                    {
+                        "trainingPlanId": 12345,
+                        "planName": "Adaptive Plan",
+                        "trainingPlanClassification": "FBT_ADAPTIVE",
+                        "trainingPlanDetailsDTO": {"trainingType": "CYCLING"},
+                        "workoutScheduleSummaries": [
+                            {
+                                "workoutUuid": "rest-123",
+                                "workoutId": None,
+                                "workoutName": None,
+                                "workoutType": None,
+                                "scheduleDate": "2024-01-15",
+                                "associatedActivityId": None,
+                                "trainingPlanId": 12345,
+                                "fbtAdaptivePlanId": 12345,
+                                "tpType": None,
+                                "isRestDay": True,
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    }
+
+    result = await app_with_workouts.call_tool(
+        "get_garmin_coach_workouts",
+        {"calendar_date": "2024-01-15"},
+    )
+
+    result_data = json_module.loads(result[0][0].text)
+    assert result_data["count"] == 1
+    rest_day = result_data["workouts"][0]
+    assert rest_day["workout_uuid"] == "rest-123"
+    assert rest_day["is_rest_day"] is True
+    assert rest_day["training_plan_id"] == 12345
+    assert rest_day["fbt_adaptive_plan_id"] == 12345
+    assert "name" not in rest_day
+    assert "sport" not in rest_day
 
 
 @pytest.mark.asyncio
@@ -1303,6 +1503,7 @@ async def test_get_garmin_coach_workouts_handles_malformed_plan_entries(
                     None,
                     {
                         "planName": "Adaptive Plan",
+                        "trainingPlanDetailsDTO": [],
                         "workoutScheduleSummaries": [
                             None,
                             {


### PR DESCRIPTION
Fixes #231.

Applies the changes from contributor PR #232 (by @pn). Adds two new tools to expose workouts from Garmin Coach / daily suggested training plans.

## New tools
- `get_garmin_coach_workouts(date)` — returns curated workouts from the user's active Garmin Coach/training plan for a given date via the GraphQL `trainingPlanScalar` endpoint
- `get_training_plan_workouts(date)` — alias pointing to the same implementation

Both tools:
- Validate the date format up front
- Return plan metadata (name, classification, training type) alongside scheduled workouts
- Handle malformed/missing plan entries gracefully
- Use the existing `_curate_scheduled_workout` helper for workout formatting
- Also expose `training_plan_id`, `fbt_adaptive_plan_id`, and `tp_type` from scheduled workout entries

## Tests
- 11 new integration tests covering plan data, aliases, malformed entries, missing data shapes, and date validation
- All 93 workouts integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)