### PR TITLE
fix(training): get_endurance_score crashes on a null enduranceScoreDTO

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -287,7 +287,11 @@ def register_tools(app):
             activity_type_mapping = _get_activity_type_mapping()
 
             # Extract the current endurance score DTO
-            score_dto = endurance_data.get("enduranceScoreDTO", {})
+            # `or {}` rather than a .get default: Garmin sends an explicit
+            # null for sections the user has no data in, and a default only
+            # applies when the key is absent. Same pattern already used for
+            # mostRecentTrainingLoadBalance in get_training_load_balance.
+            score_dto = endurance_data.get("enduranceScoreDTO") or {}
 
             # Map classification number to label
             classification_labels = {

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -742,3 +742,26 @@ async def test_get_training_status_no_cycling_vo2_when_absent(app_with_training,
         assert "cycling_vo2_max_precise" not in data
     except (json.JSONDecodeError, AttributeError):
         assert "cycling_vo2_max" not in text
+
+
+@pytest.mark.asyncio
+async def test_get_endurance_score_handles_null_dto(app_with_training, mock_garmin_client):
+    """A null enduranceScoreDTO must not crash the tool.
+
+    Garmin returns an explicit null for sections the user has no data in.
+    `.get("enduranceScoreDTO", {})` returns None in that case — the default
+    only applies when the key is absent — so the following .get raised
+    "'NoneType' object has no attribute 'get'".
+    """
+    mock_garmin_client.get_endurance_score.return_value = {
+        "enduranceScoreDTO": None,
+        "avg": None,
+    }
+
+    result = await app_with_training.call_tool(
+        "get_endurance_score",
+        {"start_date": "2024-01-08", "end_date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "Error" not in text


### PR DESCRIPTION
Found while exercising every read tool against a live account.

## Problem

`get_endurance_score` returns an error string for accounts where Garmin has no endurance score:

```
Error retrieving endurance score data: 'NoneType' object has no attribute 'get'
```

Garmin sends an **explicit null** for sections the user has no data in:

```json
{"enduranceScoreDTO": null, "avg": null}
```

`.get("enduranceScoreDTO", {})` returns `None` there — the default only applies when the key is *absent*, not when it is present-and-null. The next `.get` on `score_dto` then raises.

## Fix

`endurance_data.get("enduranceScoreDTO") or {}` — the same guard `get_training_load_balance` already applies to `mostRecentTrainingLoadBalance`, with the existing comment there describing exactly this behaviour:

> Garmin returns explicit None for sections the user has no data in, which breaks chained .get with a default arg.

## Test

Added `test_get_endurance_score_handles_null_dto`. Verified it fails without the change:

```
E   assert 'NoneType' not in "Error retri...ribute 'get'"
```

and passes with it. Full training suite: 27 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)