### PR TITLE
fix(devices): get_device_solar_data reads fields that do not exist

### DIFF
--- a/src/garmin_mcp/devices.py
+++ b/src/garmin_mcp/devices.py
@@ -226,14 +226,14 @@ def register_tools(app):
             return f"Error retrieving primary training device: {str(e)}"
 
     @app.tool()
-    async def get_device_solar_data(device_id: str, date: str) -> str:
+    async def get_device_solar_data(device_id: Union[int, str], date: str) -> str:
         """Get solar data for a specific device
 
         Returns solar charging data for devices with solar panels (e.g., Instinct Solar,
         Fenix Solar). Only applicable to solar-capable devices.
 
         Args:
-            device_id: Device ID (can be obtained from get_devices)
+            device_id: Device ID (can be obtained from get_devices; numeric or string)
             date: Date in YYYY-MM-DD format
         """
         try:
@@ -246,16 +246,41 @@ def register_tools(app):
             if not daily_data:
                 return f"No solar data available for device ID {device_id} on {date}. This device may not have solar capabilities."
 
-            # Curate solar data from the daily DTOs
+            # Curate solar data from the daily DTOs.
+            #
+            # The daily DTO carries localConnectDate, totalActivityTimeGainedMs
+            # and solarInputReadings — a minute-by-minute series (~1250-1440
+            # entries per day) of solarUtilization percentages. Summarise it
+            # rather than returning the series, which would be tens of KB per
+            # day.
             curated_days = []
             for day_data in daily_data:
+                readings = day_data.get("solarInputReadings") or []
+                utilization = [
+                    r.get("solarUtilization")
+                    for r in readings
+                    if isinstance(r, dict) and r.get("solarUtilization") is not None
+                ]
+                charging_readings = sum(
+                    1 for r in readings if isinstance(r, dict) and r.get("charging")
+                )
+                gained_ms = day_data.get("totalActivityTimeGainedMs")
+
                 curated_day = {
-                    "date": day_data.get("calendarDate"),
-                    "solar_intensity_avg": day_data.get("solarIntensityAvg"),
-                    "solar_intensity_max": day_data.get("solarIntensityMax"),
-                    "battery_charged_percent": day_data.get("batteryCharged"),
-                    "battery_used_percent": day_data.get("batteryUsed"),
-                    "battery_net_percent": day_data.get("batteryNet"),
+                    "date": day_data.get("localConnectDate"),
+                    "solar_utilization_avg_pct": (
+                        round(sum(utilization) / len(utilization), 2)
+                        if utilization else None
+                    ),
+                    "solar_utilization_max_pct": (
+                        round(max(utilization), 2) if utilization else None
+                    ),
+                    "readings_count": len(readings) or None,
+                    "minutes_charging": charging_readings or None,
+                    "activity_time_gained_minutes": (
+                        round(gained_ms / 60000.0, 1)
+                        if isinstance(gained_ms, (int, float)) else None
+                    ),
                 }
                 # Remove None values
                 curated_day = {k: v for k, v in curated_day.items() if v is not None}

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -467,3 +467,57 @@ async def test_get_menstrual_calendar_data_chunking(app_with_womens_health, mock
 
     data = json.loads(result[0][0].text)
     assert data == [MOCK_MENSTRUAL_DATA, second_chunk]
+
+
+@pytest.mark.asyncio
+async def test_get_device_solar_data_reads_real_payload(app_with_devices, mock_garmin_client):
+    """Solar data must be summarised from the fields Garmin actually returns.
+
+    The daily DTO carries localConnectDate, totalActivityTimeGainedMs and a
+    solarInputReadings series. Reading calendarDate / solarIntensityAvg /
+    solarIntensityMax / batteryCharged / batteryUsed / batteryNet found
+    nothing, and after the None-stripping every day collapsed to {} — so a
+    solar watch with a full day of readings reported no data.
+    """
+    mock_garmin_client.get_device_solar_data.return_value = {
+        "solarDailyDataDTOs": [
+            {
+                "localConnectDate": "2026-08-04",
+                "deviceId": 3493127157,
+                "totalActivityTimeGainedMs": 5250000,
+                "solarInputReadings": [
+                    {"solarUtilization": 0.0, "charging": False},
+                    {"solarUtilization": 50.0, "charging": True},
+                    {"solarUtilization": 100.0, "charging": True},
+                ],
+            }
+        ]
+    }
+
+    result = await app_with_devices.call_tool(
+        "get_device_solar_data", {"device_id": 3493127157, "date": "2026-08-04"}
+    )
+    payload = json.loads(result[0][0].text)
+    day = payload["solar_data"][0]
+
+    assert day != {}, "day collapsed to empty — fields read do not exist in the payload"
+    assert day["date"] == "2026-08-04"
+    assert day["solar_utilization_avg_pct"] == 50.0
+    assert day["solar_utilization_max_pct"] == 100.0
+    assert day["readings_count"] == 3
+    assert day["minutes_charging"] == 2
+    assert day["activity_time_gained_minutes"] == 87.5
+
+
+@pytest.mark.asyncio
+async def test_get_device_solar_data_accepts_numeric_device_id(app_with_devices, mock_garmin_client):
+    """get_devices() returns deviceId as an int, so the schema must accept one."""
+    mock_garmin_client.get_device_solar_data.return_value = {
+        "solarDailyDataDTOs": [
+            {"localConnectDate": "2026-08-04", "solarInputReadings": []}
+        ]
+    }
+    result = await app_with_devices.call_tool(
+        "get_device_solar_data", {"device_id": 3493127157, "date": "2026-08-04"}
+    )
+    assert "Error" not in result[0][0].text


### PR DESCRIPTION
Found while exercising every read tool against a live account with an Instinct 2X Solar.

## Problem

`get_device_solar_data` returns an empty result for solar watches that do have data:

```json
{ "device_id": 3493127157, "solar_data": [ {} ] }
```

It extracts `calendarDate`, `solarIntensityAvg`, `solarIntensityMax`, `batteryCharged`, `batteryUsed` and `batteryNet`. **None of these appear in the response.** Every lookup returns `None`, the existing None-stripping then removes all of them, and each day collapses to `{}`.

The day I probed had **1254 readings**.

## Actual payload

```json
{
  "solarDailyDataDTOs": [{
    "localConnectDate": "2026-08-04",
    "userProfilePk": ...,
    "deviceId": 3493127157,
    "totalActivityTimeGainedMs": 5250000,
    "solarInputReadings": [
      {"readingTimestampLocal": "2026-08-04T00:01:00.0",
       "solarUtilization": 0.0, "charging": false, ...}
    ]
  }]
}
```

`solarInputReadings` is a minute-by-minute series, roughly 1250-1440 entries per day.

## Fix

Read the fields that exist and **summarise** the series rather than returning it — the raw series would be tens of KB per day, which is a lot of context for an MCP response:

```json
{"date": "2026-08-04", "solar_utilization_avg_pct": 2.23,
 "solar_utilization_max_pct": 100.0, "readings_count": 1439,
 "minutes_charging": 950, "activity_time_gained_minutes": 87.5}
```

Happy to return the full series behind a flag instead if you would prefer that.

Also widened `device_id` to `Union[int, str]`. `get_devices()` returns `deviceId` as an int, so the `str`-only annotation made FastMCP reject the exact value a caller reads from the previous call:

```
ValidationError: 1 validation error for get_device_solar_dataArguments
```

## Tests

Two regression tests added, both failing on the current implementation — one asserting the day does not collapse to `{}`, one that a numeric `device_id` is accepted. Full module suite: 30 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)