### PR TITLE
Add Garmin gear notes to get_gear output

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 - View body composition data
 - Track training status and readiness
 - Access cycling FTP and lactate threshold metrics
-- Manage gear and equipment
+- Manage gear and equipment, including free-text notes returned by `get_gear`
 - Access workouts and training plans
 - Inspect detailed workout step structures, including repeat groups and swim pace targets
 - Weekly health aggregates (steps, stress, intensity minutes)
@@ -44,6 +44,12 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
 > **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
+
+### Gear Notes
+
+Each item in the `gear` array returned by `get_gear` includes a `notes` field
+containing the free-text Notes value shown in Garmin Connect. Gear without a
+Notes value returns `null`; all existing gear fields remain unchanged.
 
 ### Activity File Downloads
 

--- a/src/garmin_mcp/gear_management.py
+++ b/src/garmin_mcp/gear_management.py
@@ -21,12 +21,21 @@ ACTIVITY_TYPE_MAPPING = {
     8: "Other",
 }
 
+GEAR_V2_LIST_ENDPOINT = "/gear-service/gear/v2/list"
+
 
 def _parse_iso_date(iso_string: str) -> str:
     """Extract date from ISO datetime string"""
     if not iso_string:
         return None
     return iso_string.split("T")[0] if "T" in iso_string else iso_string
+
+
+def _normalize_gear_uuid(uuid: Optional[str]) -> Optional[str]:
+    """Normalize UUIDs returned in hyphenated and unhyphenated forms."""
+    if not isinstance(uuid, str):
+        return None
+    return uuid.replace("-", "").lower()
 
 
 def configure(client):
@@ -42,8 +51,9 @@ def register_tools(app):
     async def get_gear(include_stats: bool = True) -> str:
         """Get all gear registered with the user account
 
-        Returns complete gear inventory including usage statistics and default
-        activity associations. No parameters required - user profile is fetched automatically.
+        Returns complete gear inventory including free-text notes, usage statistics,
+        and default activity associations. The notes field is null when unavailable.
+        No parameters required - user profile is fetched automatically.
 
         Args:
             include_stats: Include usage statistics for each gear item (default True).
@@ -60,6 +70,18 @@ def register_tools(app):
             gear_list = garmin_client.get_gear(user_profile_id)
             if not gear_list:
                 return "No gear found."
+
+            # Notes are only exposed by Garmin's v2 gear endpoint. Its UUIDs are
+            # hyphenated, unlike the legacy endpoint used for the existing fields.
+            notes_by_uuid = {}
+            try:
+                gear_v2_list = garmin_client.connectapi(GEAR_V2_LIST_ENDPOINT) or []
+                for gear_v2 in gear_v2_list:
+                    normalized_uuid = _normalize_gear_uuid(gear_v2.get("uuid"))
+                    if normalized_uuid:
+                        notes_by_uuid[normalized_uuid] = gear_v2.get("notes")
+            except Exception:
+                pass  # Keep the legacy gear inventory available if v2 is unavailable
 
             # 3. Get defaults to map gear -> activity types
             defaults_list = garmin_client.get_gear_defaults(user_profile_id) or []
@@ -96,6 +118,9 @@ def register_tools(app):
                     "status": status,
                     "date_begin": _parse_iso_date(g.get("dateBegin")),
                     "date_end": _parse_iso_date(g.get("dateEnd")),
+                    "notes": notes_by_uuid.get(
+                        _normalize_gear_uuid(uuid), g.get("notes")
+                    ),
                 }
 
                 # Add max distance in km if set

--- a/src/garmin_mcp/gear_management.py
+++ b/src/garmin_mcp/gear_management.py
@@ -3,10 +3,12 @@ Gear management functions for Garmin Connect MCP Server
 """
 
 import json
+import logging
 from typing import Any, Dict, List, Optional, Union
 
 # The garmin_client will be set by the main file
 garmin_client = None
+logger = logging.getLogger(__name__)
 
 # Activity type mappings for gear defaults
 # This is extrapolated from data and might not be complete or 100% accurate
@@ -77,6 +79,10 @@ def register_tools(app):
             try:
                 gear_v2_list = garmin_client.connectapi(GEAR_V2_LIST_ENDPOINT) or []
                 if not isinstance(gear_v2_list, list):
+                    logger.debug(
+                        "Unexpected Garmin v2 gear response type: %s",
+                        type(gear_v2_list).__name__,
+                    )
                     gear_v2_list = []
                 for gear_v2 in gear_v2_list:
                     if not isinstance(gear_v2, dict):
@@ -84,8 +90,10 @@ def register_tools(app):
                     normalized_v2_uuid = _normalize_gear_uuid(gear_v2.get("uuid"))
                     if normalized_v2_uuid:
                         notes_by_uuid[normalized_v2_uuid] = gear_v2.get("notes")
-            except Exception:
-                pass  # Keep the legacy gear inventory available if v2 is unavailable
+            except Exception as exc:
+                logger.debug(
+                    "Garmin v2 gear list unavailable: %s", exc, exc_info=True
+                )
 
             # 3. Get defaults to map gear -> activity types
             defaults_list = garmin_client.get_gear_defaults(user_profile_id) or []

--- a/src/garmin_mcp/gear_management.py
+++ b/src/garmin_mcp/gear_management.py
@@ -24,8 +24,8 @@ ACTIVITY_TYPE_MAPPING = {
 GEAR_V2_LIST_ENDPOINT = "/gear-service/gear/v2/list"
 
 
-def _parse_iso_date(iso_string: str) -> str:
-    """Extract date from ISO datetime string"""
+def _parse_iso_date(iso_string: Optional[str]) -> Optional[str]:
+    """Extract a date from an optional ISO datetime string."""
     if not iso_string:
         return None
     return iso_string.split("T")[0] if "T" in iso_string else iso_string
@@ -73,13 +73,17 @@ def register_tools(app):
 
             # Notes are only exposed by Garmin's v2 gear endpoint. Its UUIDs are
             # hyphenated, unlike the legacy endpoint used for the existing fields.
-            notes_by_uuid = {}
+            notes_by_uuid: Dict[str, Optional[str]] = {}
             try:
                 gear_v2_list = garmin_client.connectapi(GEAR_V2_LIST_ENDPOINT) or []
+                if not isinstance(gear_v2_list, list):
+                    gear_v2_list = []
                 for gear_v2 in gear_v2_list:
-                    normalized_uuid = _normalize_gear_uuid(gear_v2.get("uuid"))
-                    if normalized_uuid:
-                        notes_by_uuid[normalized_uuid] = gear_v2.get("notes")
+                    if not isinstance(gear_v2, dict):
+                        continue
+                    normalized_v2_uuid = _normalize_gear_uuid(gear_v2.get("uuid"))
+                    if normalized_v2_uuid:
+                        notes_by_uuid[normalized_v2_uuid] = gear_v2.get("notes")
             except Exception:
                 pass  # Keep the legacy gear inventory available if v2 is unavailable
 

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -598,7 +598,7 @@ MOCK_GEAR = [
 # Gear notes are exposed by Garmin's v2 endpoint, whose UUIDs are hyphenated.
 MOCK_GEAR_V2 = [
     {
-        "uuid": "8abfc40d-71fb-4860-bce1-9072b6c79644",
+        "uuid": "8ABFC40D-71FB-4860-BCE1-9072B6C79644",
         "name": "Nimbus 25",
         "notes": "Rotation shoe; blue laces.",
     },

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -595,6 +595,19 @@ MOCK_GEAR = [
     },
 ]
 
+# Gear notes are exposed by Garmin's v2 endpoint, whose UUIDs are hyphenated.
+MOCK_GEAR_V2 = [
+    {
+        "uuid": "8abfc40d-71fb-4860-bce1-9072b6c79644",
+        "name": "Nimbus 25",
+        "notes": "Rotation shoe; blue laces.",
+    },
+    {
+        "uuid": "6f27ed27-3977-49ac-9f6f-450e039c2424",
+        "name": "Nimbus 24",
+    },
+]
+
 MOCK_GEAR_DEFAULTS = [
     {
         "uuid": "8abfc40d71fb4860bce19072b6c79644",

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -12,6 +12,7 @@ Tests tools from:
 Total: 25 tools
 """
 import json
+import logging
 
 import pytest
 from unittest.mock import Mock
@@ -389,7 +390,9 @@ async def test_get_gear_tool_preserves_empty_and_null_notes(
 
 
 @pytest.mark.asyncio
-async def test_get_gear_tool_without_stats(app_with_gear, mock_garmin_client):
+async def test_get_gear_tool_without_stats(
+    app_with_gear, mock_garmin_client, caplog
+):
     """Test get_gear tool with include_stats=False"""
     mock_garmin_client.get_device_last_used.return_value = MOCK_DEVICE_LAST_USED
     mock_garmin_client.get_gear.return_value = MOCK_GEAR
@@ -397,12 +400,14 @@ async def test_get_gear_tool_without_stats(app_with_gear, mock_garmin_client):
     mock_garmin_client.get_gear_defaults.return_value = MOCK_GEAR_DEFAULTS
 
     # Call with include_stats=False
-    result = await app_with_gear.call_tool("get_gear", {"include_stats": False})
+    with caplog.at_level(logging.DEBUG, logger=gear_management.__name__):
+        result = await app_with_gear.call_tool("get_gear", {"include_stats": False})
 
     assert result is not None
     payload = json.loads(result[0][0].text)
     assert payload["gear_count"] == len(MOCK_GEAR)
     assert all(item["notes"] is None for item in payload["gear"])
+    assert "Garmin v2 gear list unavailable: v2 unavailable" in caplog.text
     # Stats should not be fetched
     mock_garmin_client.get_gear_stats.assert_not_called()
 

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -369,6 +369,25 @@ async def test_get_gear_tool(app_with_gear, mock_garmin_client):
     mock_garmin_client.get_gear_defaults.assert_called_once_with(80653452)
 
 
+@pytest.mark.parametrize("notes_value", ["", None], ids=["empty", "null"])
+@pytest.mark.asyncio
+async def test_get_gear_tool_preserves_empty_and_null_notes(
+    app_with_gear, mock_garmin_client, notes_value
+):
+    """Explicit empty and null notes retain their distinct JSON values."""
+    mock_garmin_client.get_device_last_used.return_value = MOCK_DEVICE_LAST_USED
+    mock_garmin_client.get_gear.return_value = [MOCK_GEAR[0]]
+    mock_garmin_client.connectapi.return_value = [
+        {**MOCK_GEAR_V2[0], "notes": notes_value}
+    ]
+    mock_garmin_client.get_gear_defaults.return_value = []
+
+    result = await app_with_gear.call_tool("get_gear", {"include_stats": False})
+
+    payload = json.loads(result[0][0].text)
+    assert payload["gear"][0]["notes"] == notes_value
+
+
 @pytest.mark.asyncio
 async def test_get_gear_tool_without_stats(app_with_gear, mock_garmin_client):
     """Test get_gear tool with include_stats=False"""
@@ -382,6 +401,7 @@ async def test_get_gear_tool_without_stats(app_with_gear, mock_garmin_client):
 
     assert result is not None
     payload = json.loads(result[0][0].text)
+    assert payload["gear_count"] == len(MOCK_GEAR)
     assert all(item["notes"] is None for item in payload["gear"])
     # Stats should not be fetched
     mock_garmin_client.get_gear_stats.assert_not_called()

--- a/tests/integration/test_other_modules_tools.py
+++ b/tests/integration/test_other_modules_tools.py
@@ -34,6 +34,7 @@ from tests.fixtures.garmin_responses import (
     MOCK_USER_PROFILE,
     MOCK_UNIT_SYSTEM,
     MOCK_GEAR,
+    MOCK_GEAR_V2,
     MOCK_GEAR_DEFAULTS,
     MOCK_GEAR_STATS,
     MOCK_MENSTRUAL_DATA,
@@ -344,6 +345,7 @@ async def test_get_gear_tool(app_with_gear, mock_garmin_client):
     # Setup mocks for all internal API calls
     mock_garmin_client.get_device_last_used.return_value = MOCK_DEVICE_LAST_USED
     mock_garmin_client.get_gear.return_value = MOCK_GEAR
+    mock_garmin_client.connectapi.return_value = MOCK_GEAR_V2
     mock_garmin_client.get_gear_defaults.return_value = MOCK_GEAR_DEFAULTS
     mock_garmin_client.get_gear_stats.return_value = MOCK_GEAR_STATS
 
@@ -351,9 +353,19 @@ async def test_get_gear_tool(app_with_gear, mock_garmin_client):
     result = await app_with_gear.call_tool("get_gear", {})
 
     assert result is not None
+    payload = json.loads(result[0][0].text)
+    gear_by_uuid = {item["uuid"]: item for item in payload["gear"]}
+    assert (
+        gear_by_uuid["8abfc40d71fb4860bce19072b6c79644"]["notes"]
+        == "Rotation shoe; blue laces."
+    )
+    assert gear_by_uuid["6f27ed27397749ac9f6f450e039c2424"]["notes"] is None
     # Verify the chain of API calls
     mock_garmin_client.get_device_last_used.assert_called_once()
     mock_garmin_client.get_gear.assert_called_once_with(80653452)  # from MOCK_DEVICE_LAST_USED
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/gear-service/gear/v2/list"
+    )
     mock_garmin_client.get_gear_defaults.assert_called_once_with(80653452)
 
 
@@ -362,12 +374,15 @@ async def test_get_gear_tool_without_stats(app_with_gear, mock_garmin_client):
     """Test get_gear tool with include_stats=False"""
     mock_garmin_client.get_device_last_used.return_value = MOCK_DEVICE_LAST_USED
     mock_garmin_client.get_gear.return_value = MOCK_GEAR
+    mock_garmin_client.connectapi.side_effect = RuntimeError("v2 unavailable")
     mock_garmin_client.get_gear_defaults.return_value = MOCK_GEAR_DEFAULTS
 
     # Call with include_stats=False
     result = await app_with_gear.call_tool("get_gear", {"include_stats": False})
 
     assert result is not None
+    payload = json.loads(result[0][0].text)
+    assert all(item["notes"] is None for item in payload["gear"])
     # Stats should not be fetched
     mock_garmin_client.get_gear_stats.assert_not_called()
 


### PR DESCRIPTION
## Summary

- Add an always-present `notes` field to every gear item returned by `get_gear`.
- Preserve all existing gear fields, statistics, sorting, and default-activity associations.
- Emit debug-only diagnostics when the optional v2 enrichment is unavailable or malformed.
- Document the new output field in both the tool docstring and README.
- Add regression coverage for populated, empty, and null/missing notes, UUID normalization, and v2 endpoint failure.

## Upstream behavior and implementation

The project's pinned `python-garminconnect==0.3.2` implementation of
[`get_gear(userProfileNumber)`](https://github.com/cyberjunky/python-garminconnect/blob/0.3.2/garminconnect/__init__.py#L2240-L2245)
uses Garmin's legacy `/gear-service/gear/filterGear` response. That response does
not contain the free-text Notes value displayed by Garmin Connect.

The Notes value is exposed as the optional lowercase `notes` field by
`/gear-service/gear/v2/list`. The v2 response uses hyphenated UUIDs while the
legacy response uses the same UUIDs without hyphens. `get_gear` now performs one
v2 request, normalizes UUIDs for the join, and adds the corresponding Notes value
to the existing curated legacy item.

The legacy response remains the canonical inventory because the v2 list can omit
retired gear. If the v2 endpoint is unavailable, an item is not present, or its
Notes value is absent/null, the item is still returned with `"notes": null`.
An explicit empty string is preserved.

## Backward compatibility

- No tool arguments or existing output keys are changed.
- The v2 call is additive and failure-tolerant.
- Existing gear inventory and optional statistics remain available if the Notes
  endpoint fails.

## Documentation

- Updated the `get_gear` tool docstring with the field and null behavior.
- Added a README section describing the `notes` field and compatibility semantics.

## Testing

- `uv run pytest tests/integration -q` — **378 passed**
- `uv run pytest tests/unit -q` — **118 passed**
