### PR TITLE
feat(activity): add generic paginated FIT message endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ User Profile (3 tools)
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
-- ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
+- ✅ Activity Analysis (3 tools) - general FIT parsing, cycling analysis, and Power Duration Curve
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
-> **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
+> **Note:** The cycling-specific analysis requires a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. General FIT parsing works for any activity type. The `fitparse` dependency is installed automatically.
+
+### General FIT Data
+
+Use **`get_activity_fit_messages(activity_id, message_types=None, include_records=false, message_offset=0, message_limit=1000)`** as the source-of-truth endpoint for original device activity data. It downloads Garmin's original FIT file and returns every message and field decoded by `fitparse`, including unknown fields, raw values, units, field definition numbers, profile labels, and global message numbers when available. Garmin Connect edits made after upload may be stored only in Garmin's service and are not necessarily written back into the original FIT file; this tool intentionally does not merge them.
+
+The high-frequency `record` stream is inventoried but omitted by default. Any other type occurring more than 100 times is also inventoried but omitted from an unfiltered default response. Request those types explicitly with `message_types`; all selected results are paged with `message_offset`, `message_limit`, and `pagination.next_offset` (maximum 5,000 messages per call). Use `message_types` to retrieve a focused subset such as `set` and `exercise_title` for a strength workout while `message_counts` still reports the complete FIT contents.
 
 ### Activity File Downloads
 

--- a/README.md
+++ b/README.md
@@ -40,10 +40,13 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ User Profile (3 tools)
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
-- ✅ Activity Analysis (3 tools) - general FIT parsing, cycling analysis, and Power Duration Curve
+- ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
+- ✅ General FIT Data (1 tool) - lossless, paginated parsing for every activity type
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
-> **Note:** The cycling-specific analysis requires a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. General FIT parsing works for any activity type. The `fitparse` dependency is installed automatically.
+> **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
+
+> **General FIT Data** works for any activity type and has no power-meter or electronic-shifting requirement.
 
 ### General FIT Data
 

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -20,8 +20,10 @@ from typing import Any, Dict, List, Optional, Union
 
 try:
     import fitparse
+    from fitparse.profile import FIELD_TYPES as FIT_FIELD_TYPES
     FITPARSE_AVAILABLE = True
 except ImportError:
+    FIT_FIELD_TYPES = {}
     FITPARSE_AVAILABLE = False
 
 # The garmin_client will be set by the main file
@@ -111,6 +113,311 @@ def _extract_fit_bytes(raw: bytes) -> bytes:
         return gzip.decompress(raw)
 
     return raw
+
+
+def _json_safe_fit_value(value: Any) -> Any:
+    """Convert a decoded FIT value to a lossless, JSON-safe representation."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return {
+            "encoding": "hex",
+            "value": bytes(value).hex(),
+        }
+    if isinstance(value, (list, tuple)):
+        return [_json_safe_fit_value(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            str(key): _json_safe_fit_value(item)
+            for key, item in value.items()
+        }
+
+    # fitparse commonly returns datetime/date values. isoformat retains more
+    # information than str() for values with timezone or sub-second precision.
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        try:
+            return isoformat()
+        except (TypeError, ValueError):
+            pass
+
+    # Enum-like values and Decimal both expose useful string forms. FIT values
+    # outside the normal scalar/container types are rare, but must not make an
+    # otherwise valid activity impossible to inspect.
+    return str(value)
+
+
+def _fit_field_definition_number(field: Any) -> Optional[int]:
+    """Return a FIT field definition number across fitparse object versions."""
+    field_def = getattr(field, "field_def", None)
+    for candidate in (field, field_def):
+        if candidate is None:
+            continue
+        for attr in ("def_num", "field_def_num", "field_definition_number"):
+            value = getattr(candidate, attr, None)
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def _map_fit_profile_values(value: Any, values: Any) -> tuple[bool, Any]:
+    """Map scalar/array enum values through FIT profile labels when possible."""
+    if not isinstance(values, dict):
+        return False, None
+    if isinstance(value, (list, tuple)):
+        mapped = [values.get(item) if item is not None else None for item in value]
+        return any(item is not None for item in mapped), mapped
+    try:
+        if value in values:
+            return True, values[value]
+    except TypeError:
+        pass
+    return False, None
+
+
+def _exercise_subtype_names(field: Any, message: Any) -> tuple[bool, Any]:
+    """Resolve FIT set category_subtype values using sibling categories."""
+    if getattr(field, "name", None) != "category_subtype" or message is None:
+        return False, None
+
+    category_field = next(
+        (
+            candidate
+            for candidate in getattr(message, "fields", [])
+            if getattr(candidate, "name", None) == "category"
+        ),
+        None,
+    )
+    if category_field is None:
+        return False, None
+
+    categories = getattr(category_field, "value", None)
+    subtypes = getattr(field, "value", None)
+    if not isinstance(categories, (list, tuple)):
+        categories = [categories]
+    if not isinstance(subtypes, (list, tuple)):
+        subtypes = [subtypes]
+
+    category_type = FIT_FIELD_TYPES.get("exercise_category")
+    category_values = getattr(category_type, "values", {})
+    subtype_names: List[Optional[str]] = []
+    for index, subtype in enumerate(subtypes):
+        category = categories[index] if index < len(categories) else None
+        category_name = category_values.get(category)
+        subtype_type = FIT_FIELD_TYPES.get(f"{category_name}_exercise_name")
+        subtype_values = getattr(subtype_type, "values", {})
+        subtype_names.append(
+            subtype_values.get(subtype) if subtype is not None else None
+        )
+
+    return any(name is not None for name in subtype_names), subtype_names
+
+
+def _serialize_fit_field(field: Any, message: Any = None) -> Dict[str, Any]:
+    """Serialize one fitparse FieldData without curating fields by sport."""
+    definition_number = _fit_field_definition_number(field)
+    name = getattr(field, "name", None)
+    if not name:
+        name = (
+            f"unknown_{definition_number}"
+            if definition_number is not None
+            else "unknown"
+        )
+
+    serialized: Dict[str, Any] = {
+        "name": str(name),
+        "value": _json_safe_fit_value(getattr(field, "value", None)),
+    }
+
+    units = getattr(field, "units", None)
+    if units is not None:
+        serialized["units"] = str(units)
+    if definition_number is not None:
+        serialized["definition_number"] = definition_number
+
+    for source_attr, output_key in (
+        ("base_type", "base_type"),
+        ("type", "profile_type"),
+    ):
+        metadata = getattr(field, source_attr, None)
+        metadata_name = getattr(metadata, "name", None)
+        if isinstance(metadata_name, str):
+            serialized[output_key] = metadata_name
+
+    field_type = getattr(field, "field_type", None)
+    if isinstance(field_type, str):
+        serialized["field_type"] = field_type
+
+    value = getattr(field, "value", None)
+    profile_values = getattr(getattr(field, "type", None), "values", None)
+    has_value_names, value_names = _map_fit_profile_values(value, profile_values)
+    if not has_value_names:
+        has_value_names, value_names = _exercise_subtype_names(field, message)
+    if has_value_names:
+        serialized[
+            "value_names" if isinstance(value_names, list) else "value_name"
+        ] = value_names
+
+    # Retain the pre-scaled profile value as well as the decoded/scaled value.
+    # This matters when profiles change or a consumer needs to audit decoding.
+    if hasattr(field, "raw_value"):
+        serialized["raw_value"] = _json_safe_fit_value(field.raw_value)
+
+    return serialized
+
+
+def _fit_global_message_number(message: Any) -> Optional[int]:
+    """Return a message's global FIT profile number when the decoder exposes it."""
+    candidates = [
+        message,
+        getattr(message, "definition", None),
+        getattr(message, "_definition", None),
+    ]
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        for attr in ("mesg_num", "global_mesg_num", "global_message_number"):
+            value = getattr(candidate, attr, None)
+            if isinstance(value, int):
+                return value
+    return None
+
+
+def _parse_fit_messages(
+    raw: bytes,
+    *,
+    message_types: Optional[List[str]] = None,
+    include_records: bool = False,
+    message_offset: int = 0,
+    message_limit: int = 1000,
+) -> Dict[str, Any]:
+    """Parse all FIT messages/fields with safe high-frequency pagination.
+
+    Non-record messages are never curated: every message and every field
+    emitted by fitparse is returned. The high-frequency ``record`` stream is
+    counted but omitted by default. Other message types with more than 100
+    instances are also inventoried but omitted from unfiltered default results.
+    Explicitly filtered results use general pagination so a long activity
+    cannot accidentally exceed MCP result limits.
+    """
+    if message_offset < 0:
+        raise ValueError("message_offset must be at least 0")
+    if not 1 <= message_limit <= 5000:
+        raise ValueError("message_limit must be between 1 and 5000")
+
+    selected_types = None
+    if message_types is not None:
+        selected_types = {
+            str(message_type).strip().lower()
+            for message_type in message_types
+            if str(message_type).strip()
+        }
+    records_selected = selected_types is None or "record" in selected_types
+
+    fit_bytes = _extract_fit_bytes(raw)
+    fitfile = fitparse.FitFile(io.BytesIO(fit_bytes))
+    eligible_messages: List[Dict[str, Any]] = []
+    message_counts: Dict[str, int] = {}
+    record_count = 0
+
+    for message_index, message in enumerate(fitfile.get_messages()):
+        message_type = str(getattr(message, "name", None) or "unknown")
+        normalized_type = message_type.lower()
+        type_index = message_counts.get(message_type, 0)
+        message_counts[message_type] = type_index + 1
+
+        if normalized_type == "record":
+            record_count += 1
+            if not include_records or not records_selected:
+                continue
+
+        if selected_types is not None and normalized_type not in selected_types:
+            continue
+
+        serialized_message: Dict[str, Any] = {
+            "message_index": message_index,
+            "type_index": type_index,
+            "type": message_type,
+            # A list rather than an object preserves duplicate/unknown field
+            # definitions instead of overwriting fields that share a name.
+            "fields": [
+                _serialize_fit_field(field, message)
+                for field in getattr(message, "fields", [])
+            ],
+        }
+        global_message_number = _fit_global_message_number(message)
+        if global_message_number is not None:
+            serialized_message["global_message_number"] = global_message_number
+
+        eligible_messages.append(serialized_message)
+
+    # An unfiltered request should be useful as an inventory without returning
+    # thousands of vendor-specific samples whose semantics are not yet known.
+    # Explicit message_types opts a caller into those types, still behind the
+    # general message_limit pagination below.
+    omitted_high_frequency_types: Dict[str, int] = {}
+    if selected_types is None:
+        omitted_high_frequency_types = {
+            message_type: count
+            for message_type, count in message_counts.items()
+            if message_type.lower() != "record" and count > 100
+        }
+        if omitted_high_frequency_types:
+            eligible_messages = [
+                message
+                for message in eligible_messages
+                if message["type"] not in omitted_high_frequency_types
+            ]
+
+    total_eligible_count = len(eligible_messages)
+    messages = eligible_messages[
+        message_offset:message_offset + message_limit
+    ]
+    returned_counts: Dict[str, int] = {}
+    for message in messages:
+        message_type = message["type"]
+        returned_counts[message_type] = returned_counts.get(message_type, 0) + 1
+
+    records_included = include_records and records_selected
+    returned_record_count = returned_counts.get("record", 0)
+    record_stream: Dict[str, Any] = {
+        "included": records_included,
+        "total_count": record_count,
+        "returned_count": returned_record_count,
+    }
+    if not include_records and records_selected and record_count:
+        record_stream["hint"] = (
+            "Set include_records=true and use message pagination to retrieve records."
+        )
+
+    pagination: Dict[str, Any] = {
+        "total_eligible_count": total_eligible_count,
+        "returned_count": len(messages),
+        "offset": message_offset,
+        "limit": message_limit,
+    }
+    if message_offset + len(messages) < total_eligible_count:
+        pagination["next_offset"] = message_offset + len(messages)
+
+    result = {
+        "fit_size_bytes": len(fit_bytes),
+        "message_counts": message_counts,
+        "returned_message_counts": returned_counts,
+        "record_stream": record_stream,
+        "pagination": pagination,
+        "messages": messages,
+    }
+    if omitted_high_frequency_types:
+        result["omitted_high_frequency_message_types"] = {
+            message_type: {
+                "count": count,
+                "hint": (
+                    f"Request message_types=['{message_type}'] and follow pagination."
+                ),
+            }
+            for message_type, count in omitted_high_frequency_types.items()
+        }
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -1048,6 +1355,96 @@ def _parse_fit(fit_bytes: bytes, include_records: bool) -> dict:
 
 def register_tools(app):
     """Register all activity analysis tools with the MCP server app"""
+
+    @app.tool()
+    async def get_activity_fit_messages(
+        activity_id: Union[int, str],
+        message_types: Optional[List[str]] = None,
+        include_records: bool = False,
+        message_offset: int = 0,
+        message_limit: int = 1000,
+    ) -> str:
+        """Retrieve and generically parse an activity's original FIT file.
+
+        This is the source-of-truth endpoint for original device activity data.
+        It returns every message and every field emitted by the FIT decoder
+        without applying sport-specific curation. Messages remain in file order,
+        and each field includes its decoded value plus units and definition
+        number when available. Unknown and duplicate fields are retained.
+
+        Garmin Connect edits made after upload may be stored only in Garmin's
+        service and are not necessarily written back into the original FIT file.
+        This tool intentionally does not merge those service-side edits.
+
+        High-frequency ``record`` messages are counted but omitted by default.
+        Other message types occurring more than 100 times are also inventoried
+        but omitted from an unfiltered default response. Request those types
+        explicitly with message_types. All returned messages are bounded by
+        message_offset/message_limit (maximum 5000 per call); follow
+        pagination.next_offset until absent to retrieve the full selected stream.
+
+        Use message_types to return only particular FIT message types while
+        message_counts still inventories the complete file. For example, a
+        strength workout can usually be inspected efficiently with
+        ["session", "lap", "set", "exercise_title"]. Message type names are
+        case-insensitive and should use FIT/fitparse snake_case names.
+
+        Args:
+            activity_id: Garmin activity ID.
+            message_types: Optional list of FIT message types to return. Omit to
+                           return low-frequency non-record message types.
+            include_records: Include the high-frequency record stream (default false).
+            message_offset: Zero-based offset within the selected message stream.
+            message_limit: Maximum messages returned per call, 1-5000 (default 1000).
+        """
+        if not FITPARSE_AVAILABLE:
+            return (
+                "fitparse library is not installed. "
+                "Install it with: pip install fitparse"
+            )
+
+        try:
+            activity_id = int(activity_id)
+            from garminconnect import Garmin
+
+            downloaded = garmin_client.download_activity(
+                activity_id,
+                dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL,
+            )
+            if not downloaded:
+                return f"No FIT data returned for activity {activity_id}"
+
+            raw = bytes(downloaded)
+            try:
+                parsed = _parse_fit_messages(
+                    raw,
+                    message_types=message_types,
+                    include_records=include_records,
+                    message_offset=message_offset,
+                    message_limit=message_limit,
+                )
+            except Exception as parse_err:
+                return json.dumps({
+                    "error": str(parse_err),
+                    "activity_id": activity_id,
+                    "debug": {
+                        "download_size_bytes": len(raw),
+                        "first_16_bytes_hex": raw[:16].hex(),
+                        "hint": (
+                            "1f8b = gzip, 504b = ZIP, 0e10/0c10 = raw FIT, "
+                            "3c or 7b = HTML/JSON error from Garmin"
+                        ),
+                    },
+                }, indent=2)
+
+            result = {
+                "activity_id": activity_id,
+                "source": "garmin_original_fit",
+                **parsed,
+            }
+            return json.dumps(result, indent=2, ensure_ascii=False)
+        except Exception as e:
+            return f"Error downloading FIT data for activity {activity_id}: {str(e)}"
 
     @app.tool()
     async def get_activity_fit_data(

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -166,11 +166,13 @@ def _fit_profile_label(value: Any, raw_value: Any, values: Any) -> Any:
         return None
 
     for candidate in (raw_value, value):
-        try:
-            if candidate in values:
-                return values[candidate]
-        except TypeError:
+        # FIT profile enum keys are numeric codes. fitparse may also expose the
+        # already-decoded string label; container values are handled by the
+        # caller and must not be used as dictionary keys.
+        if not isinstance(candidate, (int, str)):
             continue
+        if candidate in values:
+            return values[candidate]
 
     # fitparse renders known enum values before exposing FieldData.value. Keep
     # that decoded label rather than requiring consumers to reverse-map it.
@@ -400,12 +402,12 @@ def _parse_fit_messages(
 
     fit_bytes = _extract_fit_bytes(raw)
     fitfile = fitparse.FitFile(io.BytesIO(fit_bytes))
+    fit_messages = list(fitfile.get_messages())
     message_counts: Dict[str, int] = {}
 
-    # Inventory without constructing JSON-shaped copies. FitFile caches parsed
-    # messages, so the second pass below does not decode the file again and only
-    # the requested page is serialized.
-    for message in fitfile.get_messages():
+    # Inventory without constructing JSON-shaped copies. Only the requested
+    # page is serialized below.
+    for message in fit_messages:
         message_type = str(getattr(message, "name", None) or "unknown")
         message_counts[message_type] = message_counts.get(message_type, 0) + 1
 
@@ -439,7 +441,7 @@ def _parse_fit_messages(
     messages: List[Dict[str, Any]] = []
     eligible_index = 0
     seen_type_counts: Dict[str, int] = {}
-    for message_index, message in enumerate(fitfile.get_messages()):
+    for message_index, message in enumerate(fit_messages):
         message_type = str(getattr(message, "name", None) or "unknown")
         type_index = seen_type_counts.get(message_type, 0)
         seen_type_counts[message_type] = type_index + 1

--- a/src/garmin_mcp/activity_analysis.py
+++ b/src/garmin_mcp/activity_analysis.py
@@ -160,57 +160,136 @@ def _fit_field_definition_number(field: Any) -> Optional[int]:
     return None
 
 
-def _map_fit_profile_values(value: Any, values: Any) -> tuple[bool, Any]:
-    """Map scalar/array enum values through FIT profile labels when possible."""
+def _fit_profile_label(value: Any, raw_value: Any, values: Any) -> Any:
+    """Resolve one FIT enum label from either decoded or raw profile values."""
     if not isinstance(values, dict):
+        return None
+
+    for candidate in (raw_value, value):
+        try:
+            if candidate in values:
+                return values[candidate]
+        except TypeError:
+            continue
+
+    # fitparse renders known enum values before exposing FieldData.value. Keep
+    # that decoded label rather than requiring consumers to reverse-map it.
+    if isinstance(value, str) and value in values.values():
+        return value
+    return None
+
+
+def _map_fit_profile_values(
+    value: Any,
+    raw_value: Any,
+    values: Any,
+) -> tuple[bool, Any]:
+    """Map scalar/array FIT values through profile labels when possible."""
+    value_is_sequence = isinstance(value, (list, tuple))
+    raw_is_sequence = isinstance(raw_value, (list, tuple))
+    if not value_is_sequence and not raw_is_sequence:
+        mapped = _fit_profile_label(value, raw_value, values)
+        return mapped is not None, mapped
+
+    decoded_values = list(value) if value_is_sequence else [value]
+    raw_values = list(raw_value) if raw_is_sequence else [raw_value]
+    value_count = max(len(decoded_values), len(raw_values))
+    mapped_values = []
+    for index in range(value_count):
+        decoded_item = decoded_values[index] if index < len(decoded_values) else None
+        raw_item = raw_values[index] if index < len(raw_values) else None
+        mapped_values.append(_fit_profile_label(decoded_item, raw_item, values))
+    return any(item is not None for item in mapped_values), mapped_values
+
+
+_FIT_CONTEXTUAL_ENUM_FIELDS = {
+    # FIT stores exercise-name values as uint16 because their enum type depends
+    # on a sibling exercise category. These are standard FIT profile messages,
+    # not Garmin Connect API fields.
+    ("set", "category_subtype"): (
+        "category",
+        "exercise_category",
+        "{selector}_exercise_name",
+    ),
+    ("exercise_title", "exercise_name"): (
+        "exercise_category",
+        "exercise_category",
+        "{selector}_exercise_name",
+    ),
+}
+
+
+def _contextual_fit_value_names(field: Any, message: Any) -> tuple[bool, Any]:
+    """Resolve standard FIT enums whose type depends on a sibling field."""
+    if message is None:
         return False, None
-    if isinstance(value, (list, tuple)):
-        mapped = [values.get(item) if item is not None else None for item in value]
-        return any(item is not None for item in mapped), mapped
-    try:
-        if value in values:
-            return True, values[value]
-    except TypeError:
-        pass
-    return False, None
 
-
-def _exercise_subtype_names(field: Any, message: Any) -> tuple[bool, Any]:
-    """Resolve FIT set category_subtype values using sibling categories."""
-    if getattr(field, "name", None) != "category_subtype" or message is None:
+    message_name = str(getattr(message, "name", None) or "").lower()
+    field_name = str(getattr(field, "name", None) or "").lower()
+    context = _FIT_CONTEXTUAL_ENUM_FIELDS.get(
+        (message_name, field_name)
+    )
+    if context is None:
         return False, None
+    selector_field_name, selector_type_name, value_type_template = context
 
-    category_field = next(
+    selector_field = next(
         (
             candidate
             for candidate in getattr(message, "fields", [])
-            if getattr(candidate, "name", None) == "category"
+            if str(getattr(candidate, "name", None) or "").lower()
+            == selector_field_name
         ),
         None,
     )
-    if category_field is None:
+    if selector_field is None:
         return False, None
 
-    categories = getattr(category_field, "value", None)
+    selector_type = FIT_FIELD_TYPES.get(selector_type_name)
+    selector_values = getattr(selector_type, "values", {})
+    selectors = getattr(selector_field, "value", None)
+    raw_selectors = getattr(selector_field, "raw_value", None)
+    has_selector_names, selector_names = _map_fit_profile_values(
+        selectors,
+        raw_selectors,
+        selector_values,
+    )
+    if not has_selector_names:
+        return False, None
+
     subtypes = getattr(field, "value", None)
-    if not isinstance(categories, (list, tuple)):
-        categories = [categories]
-    if not isinstance(subtypes, (list, tuple)):
+    raw_subtypes = getattr(field, "raw_value", None)
+    subtype_is_sequence = isinstance(subtypes, (list, tuple))
+    raw_subtype_is_sequence = isinstance(raw_subtypes, (list, tuple))
+    if not isinstance(selector_names, list):
+        selector_names = [selector_names]
+    if not subtype_is_sequence:
         subtypes = [subtypes]
+    else:
+        subtypes = list(subtypes)
+    if not raw_subtype_is_sequence:
+        raw_subtypes = [raw_subtypes]
+    else:
+        raw_subtypes = list(raw_subtypes)
 
-    category_type = FIT_FIELD_TYPES.get("exercise_category")
-    category_values = getattr(category_type, "values", {})
     subtype_names: List[Optional[str]] = []
-    for index, subtype in enumerate(subtypes):
-        category = categories[index] if index < len(categories) else None
-        category_name = category_values.get(category)
-        subtype_type = FIT_FIELD_TYPES.get(f"{category_name}_exercise_name")
-        subtype_values = getattr(subtype_type, "values", {})
-        subtype_names.append(
-            subtype_values.get(subtype) if subtype is not None else None
+    value_count = max(len(subtypes), len(raw_subtypes))
+    for index in range(value_count):
+        subtype = subtypes[index] if index < len(subtypes) else None
+        raw_subtype = raw_subtypes[index] if index < len(raw_subtypes) else None
+        selector_name = (
+            selector_names[index] if index < len(selector_names) else None
         )
+        subtype_type = FIT_FIELD_TYPES.get(
+            value_type_template.format(selector=selector_name)
+        )
+        subtype_values = getattr(subtype_type, "values", {})
+        subtype_names.append(_fit_profile_label(subtype, raw_subtype, subtype_values))
 
-    return any(name is not None for name in subtype_names), subtype_names
+    has_names = any(name is not None for name in subtype_names)
+    if not subtype_is_sequence and not raw_subtype_is_sequence:
+        return has_names, subtype_names[0] if subtype_names else None
+    return has_names, subtype_names
 
 
 def _serialize_fit_field(field: Any, message: Any = None) -> Dict[str, Any]:
@@ -249,10 +328,15 @@ def _serialize_fit_field(field: Any, message: Any = None) -> Dict[str, Any]:
         serialized["field_type"] = field_type
 
     value = getattr(field, "value", None)
+    raw_value = getattr(field, "raw_value", None)
     profile_values = getattr(getattr(field, "type", None), "values", None)
-    has_value_names, value_names = _map_fit_profile_values(value, profile_values)
+    has_value_names, value_names = _map_fit_profile_values(
+        value,
+        raw_value,
+        profile_values,
+    )
     if not has_value_names:
-        has_value_names, value_names = _exercise_subtype_names(field, message)
+        has_value_names, value_names = _contextual_fit_value_names(field, message)
     if has_value_names:
         serialized[
             "value_names" if isinstance(value_names, list) else "value_name"
@@ -316,40 +400,14 @@ def _parse_fit_messages(
 
     fit_bytes = _extract_fit_bytes(raw)
     fitfile = fitparse.FitFile(io.BytesIO(fit_bytes))
-    eligible_messages: List[Dict[str, Any]] = []
     message_counts: Dict[str, int] = {}
-    record_count = 0
 
-    for message_index, message in enumerate(fitfile.get_messages()):
+    # Inventory without constructing JSON-shaped copies. FitFile caches parsed
+    # messages, so the second pass below does not decode the file again and only
+    # the requested page is serialized.
+    for message in fitfile.get_messages():
         message_type = str(getattr(message, "name", None) or "unknown")
-        normalized_type = message_type.lower()
-        type_index = message_counts.get(message_type, 0)
-        message_counts[message_type] = type_index + 1
-
-        if normalized_type == "record":
-            record_count += 1
-            if not include_records or not records_selected:
-                continue
-
-        if selected_types is not None and normalized_type not in selected_types:
-            continue
-
-        serialized_message: Dict[str, Any] = {
-            "message_index": message_index,
-            "type_index": type_index,
-            "type": message_type,
-            # A list rather than an object preserves duplicate/unknown field
-            # definitions instead of overwriting fields that share a name.
-            "fields": [
-                _serialize_fit_field(field, message)
-                for field in getattr(message, "fields", [])
-            ],
-        }
-        global_message_number = _fit_global_message_number(message)
-        if global_message_number is not None:
-            serialized_message["global_message_number"] = global_message_number
-
-        eligible_messages.append(serialized_message)
+        message_counts[message_type] = message_counts.get(message_type, 0) + 1
 
     # An unfiltered request should be useful as an inventory without returning
     # thousands of vendor-specific samples whose semantics are not yet known.
@@ -362,24 +420,70 @@ def _parse_fit_messages(
             for message_type, count in message_counts.items()
             if message_type.lower() != "record" and count > 100
         }
-        if omitted_high_frequency_types:
-            eligible_messages = [
-                message
-                for message in eligible_messages
-                if message["type"] not in omitted_high_frequency_types
-            ]
+    def message_type_is_eligible(message_type: str) -> bool:
+        normalized_type = message_type.lower()
+        if normalized_type == "record" and (
+            not include_records or not records_selected
+        ):
+            return False
+        if selected_types is not None and normalized_type not in selected_types:
+            return False
+        return message_type not in omitted_high_frequency_types
 
-    total_eligible_count = len(eligible_messages)
-    messages = eligible_messages[
-        message_offset:message_offset + message_limit
-    ]
+    total_eligible_count = sum(
+        count
+        for message_type, count in message_counts.items()
+        if message_type_is_eligible(message_type)
+    )
+    page_end = message_offset + message_limit
+    messages: List[Dict[str, Any]] = []
+    eligible_index = 0
+    seen_type_counts: Dict[str, int] = {}
+    for message_index, message in enumerate(fitfile.get_messages()):
+        message_type = str(getattr(message, "name", None) or "unknown")
+        type_index = seen_type_counts.get(message_type, 0)
+        seen_type_counts[message_type] = type_index + 1
+        if not message_type_is_eligible(message_type):
+            continue
+
+        if message_offset <= eligible_index < page_end:
+            serialized_message: Dict[str, Any] = {
+                "message_index": message_index,
+                "type_index": type_index,
+                "type": message_type,
+                # A list rather than an object preserves duplicate/unknown field
+                # definitions instead of overwriting fields that share a name.
+                "fields": [
+                    _serialize_fit_field(field, message)
+                    for field in getattr(message, "fields", [])
+                ],
+            }
+            global_message_number = _fit_global_message_number(message)
+            if global_message_number is not None:
+                serialized_message["global_message_number"] = (
+                    global_message_number
+                )
+            messages.append(serialized_message)
+        eligible_index += 1
+        if eligible_index >= page_end:
+            break
+
     returned_counts: Dict[str, int] = {}
     for message in messages:
         message_type = message["type"]
         returned_counts[message_type] = returned_counts.get(message_type, 0) + 1
 
+    record_count = sum(
+        count
+        for message_type, count in message_counts.items()
+        if message_type.lower() == "record"
+    )
     records_included = include_records and records_selected
-    returned_record_count = returned_counts.get("record", 0)
+    returned_record_count = sum(
+        count
+        for message_type, count in returned_counts.items()
+        if message_type.lower() == "record"
+    )
     record_stream: Dict[str, Any] = {
         "included": records_included,
         "total_count": record_count,

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -9,6 +9,8 @@ import os
 import zipfile
 import pytest
 from unittest.mock import Mock, patch, MagicMock
+from fitparse.profile import MESSAGE_TYPES
+from fitparse.records import DataMessage, FieldData
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import activity_analysis
@@ -46,7 +48,7 @@ def _make_mock_fit_message(name, fields: dict):
 def _mock_fitfile(messages):
     """Create a mock FitFile that yields the given messages."""
     mock_ff = MagicMock()
-    mock_ff.get_messages.return_value = iter(messages)
+    mock_ff.get_messages.side_effect = lambda: iter(messages)
     return mock_ff
 
 
@@ -73,6 +75,22 @@ def _make_generic_fit_message(name, fields, global_message_number=None):
         del field.raw_value
         message.fields.append(field)
     return message
+
+
+def _make_profile_fit_message(message_number, fields):
+    """Create a DataMessage with the actual fitparse profile field objects."""
+    message_type = MESSAGE_TYPES[message_number]
+    field_data = [
+        FieldData(
+            field_def=None,
+            field=message_type.fields[definition_number],
+            parent_field=None,
+            value=value,
+            raw_value=raw_value,
+        )
+        for definition_number, value, raw_value in fields
+    ]
+    return DataMessage(header=None, def_mesg=message_type, fields=field_data)
 
 
 # ---------------------------------------------------------------------------
@@ -162,6 +180,52 @@ async def test_get_activity_fit_messages_preserves_all_message_types_and_fields(
 
 
 @pytest.mark.asyncio
+async def test_get_activity_fit_messages_resolves_standard_contextual_enums(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """Real fitparse fields retain labels for context-dependent FIT enums."""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+    messages = [
+        _make_profile_fit_message(
+            225,
+            [
+                (7, "squat", 28),
+                (8, 6, 6),
+            ],
+        ),
+        _make_profile_fit_message(
+            264,
+            [
+                (0, "squat", 28),
+                (1, 6, 6),
+            ],
+        ),
+    ]
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile(messages)
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages", {"activity_id": ACTIVITY_ID}
+        )
+
+    data = json.loads(result[0][0].text)
+    fields_by_message = [
+        {field["name"]: field for field in message["fields"]}
+        for message in data["messages"]
+    ]
+    assert fields_by_message[0]["category"]["value_name"] == "squat"
+    assert (
+        fields_by_message[0]["category_subtype"]["value_name"]
+        == "barbell_back_squat"
+    )
+    assert (
+        fields_by_message[1]["exercise_name"]["value_name"]
+        == "barbell_back_squat"
+    )
+    assert fields_by_message[1]["exercise_name"]["raw_value"] == 6
+
+
+@pytest.mark.asyncio
 async def test_get_activity_fit_messages_omits_records_by_default(
     app_with_activity_analysis, mock_garmin_client
 ):
@@ -199,7 +263,10 @@ async def test_get_activity_fit_messages_paginates_records(
         for bpm in (140, 141, 142)
     ]
 
-    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp, patch(
+        "garmin_mcp.activity_analysis._serialize_fit_field",
+        wraps=activity_analysis._serialize_fit_field,
+    ) as serialize_field:
         mock_fp.FitFile.return_value = _mock_fitfile(messages)
         result = await app_with_activity_analysis.call_tool(
             "get_activity_fit_messages",
@@ -226,6 +293,7 @@ async def test_get_activity_fit_messages_paginates_records(
     }
     assert data["messages"][0]["type_index"] == 1
     assert data["messages"][0]["fields"][0]["value"] == 141
+    assert serialize_field.call_count == 1
 
 
 @pytest.mark.asyncio
@@ -287,7 +355,10 @@ async def test_get_activity_fit_messages_omits_other_high_frequency_types_by_def
         for index in range(101)
     ]
 
-    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp, patch(
+        "garmin_mcp.activity_analysis._serialize_fit_field",
+        wraps=activity_analysis._serialize_fit_field,
+    ) as serialize_field:
         mock_fp.FitFile.return_value = _mock_fitfile(messages)
         result = await app_with_activity_analysis.call_tool(
             "get_activity_fit_messages", {"activity_id": ACTIVITY_ID}
@@ -297,6 +368,7 @@ async def test_get_activity_fit_messages_omits_other_high_frequency_types_by_def
     assert [message["type"] for message in data["messages"]] == ["session"]
     assert data["message_counts"]["unknown_233"] == 101
     assert data["omitted_high_frequency_message_types"]["unknown_233"]["count"] == 101
+    assert serialize_field.call_count == 1
 
 @pytest.mark.asyncio
 async def test_get_activity_fit_data_calls_download(app_with_activity_analysis, mock_garmin_client):

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -50,9 +50,253 @@ def _mock_fitfile(messages):
     return mock_ff
 
 
+def _make_generic_fit_message(name, fields, global_message_number=None):
+    """Create a message with real FieldData-like objects for generic parsing."""
+    message = Mock()
+    message.name = name
+    message.fields = []
+    if global_message_number is not None:
+        message.mesg_num = global_message_number
+    else:
+        del message.mesg_num
+
+    for definition_number, field_name, value, units in fields:
+        field = Mock()
+        field.name = field_name
+        field.value = value
+        field.units = units
+        field.field_def = Mock(def_num=definition_number)
+        if field_name == "category":
+            field.type = activity_analysis.FIT_FIELD_TYPES["exercise_category"]
+        else:
+            del field.type
+        del field.raw_value
+        message.fields.append(field)
+    return message
+
+
 # ---------------------------------------------------------------------------
 # Basic tool behaviour
 # ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_messages_preserves_all_message_types_and_fields(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """Generic FIT tool does not discard strength or unknown FIT fields."""
+    from garminconnect import Garmin
+
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+    exercise_title = _make_generic_fit_message(
+        "exercise_title",
+        [
+            (254, "message_index", 0, None),
+            (0, "exercise_category", "bench_press", None),
+            (1, "exercise_name", "barbell_bench_press", None),
+        ],
+        global_message_number=264,
+    )
+    set_message = _make_generic_fit_message(
+        "set",
+        [
+            (3, "repetitions", 8, "repetitions"),
+            (4, "weight", 61.2349, "kg"),
+            (7, "category", [8, 21], None),
+            (8, "category_subtype", [0, None], None),
+            (5, "set_type", "active", None),
+            (99, "unknown_99", b"\x01\x02", None),
+        ],
+        global_message_number=225,
+    )
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([exercise_title, set_message])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages", {"activity_id": ACTIVITY_ID}
+        )
+
+    mock_garmin_client.download_activity.assert_called_once_with(
+        ACTIVITY_ID,
+        dl_fmt=Garmin.ActivityDownloadFormat.ORIGINAL,
+    )
+    data = json.loads(result[0][0].text)
+    assert data["source"] == "garmin_original_fit"
+    assert data["message_counts"] == {"exercise_title": 1, "set": 1}
+    assert [message["type"] for message in data["messages"]] == [
+        "exercise_title", "set"
+    ]
+    assert data["messages"][0]["global_message_number"] == 264
+    assert data["messages"][1]["fields"] == [
+        {
+            "name": "repetitions",
+            "value": 8,
+            "units": "repetitions",
+            "definition_number": 3,
+        },
+        {
+            "name": "weight",
+            "value": 61.2349,
+            "units": "kg",
+            "definition_number": 4,
+        },
+        {
+            "name": "category",
+            "value": [8, 21],
+            "definition_number": 7,
+            "profile_type": "exercise_category",
+            "value_names": ["deadlift", "pull_up"],
+        },
+        {
+            "name": "category_subtype",
+            "value": [0, None],
+            "definition_number": 8,
+            "value_names": ["barbell_deadlift", None],
+        },
+        {"name": "set_type", "value": "active", "definition_number": 5},
+        {
+            "name": "unknown_99",
+            "value": {"encoding": "hex", "value": "0102"},
+            "definition_number": 99,
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_messages_omits_records_by_default(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """Record messages are inventoried but do not inflate the default result."""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+    messages = [
+        _make_generic_fit_message("record", [(3, "heart_rate", 140, "bpm")]),
+        _make_generic_fit_message("set", [(3, "repetitions", 10, "repetitions")]),
+        _make_generic_fit_message("record", [(3, "heart_rate", 141, "bpm")]),
+    ]
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile(messages)
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages", {"activity_id": ACTIVITY_ID}
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data["message_counts"] == {"record": 2, "set": 1}
+    assert data["returned_message_counts"] == {"set": 1}
+    assert [message["type"] for message in data["messages"]] == ["set"]
+    assert data["record_stream"]["included"] is False
+    assert data["record_stream"]["total_count"] == 2
+    assert data["record_stream"]["returned_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_messages_paginates_records(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """Callers can walk a large record stream in bounded pages."""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+    messages = [
+        _make_generic_fit_message("record", [(3, "heart_rate", bpm, "bpm")])
+        for bpm in (140, 141, 142)
+    ]
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile(messages)
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages",
+            {
+                "activity_id": ACTIVITY_ID,
+                "include_records": True,
+                "message_offset": 1,
+                "message_limit": 1,
+            },
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data["record_stream"] == {
+        "included": True,
+        "total_count": 3,
+        "returned_count": 1,
+    }
+    assert data["pagination"] == {
+        "total_eligible_count": 3,
+        "returned_count": 1,
+        "offset": 1,
+        "limit": 1,
+        "next_offset": 2,
+    }
+    assert data["messages"][0]["type_index"] == 1
+    assert data["messages"][0]["fields"][0]["value"] == 141
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_messages_filters_returned_types_but_keeps_inventory(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """message_types narrows output without hiding what the FIT file contains."""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+    messages = [
+        _make_generic_fit_message("session", [(5, "sport", "training", None)]),
+        _make_generic_fit_message("set", [(3, "repetitions", 5, "repetitions")]),
+    ]
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile(messages)
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages",
+            {"activity_id": ACTIVITY_ID, "message_types": ["SET"]},
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data["message_counts"] == {"session": 1, "set": 1}
+    assert data["returned_message_counts"] == {"set": 1}
+    assert [message["type"] for message in data["messages"]] == ["set"]
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_messages_rejects_unbounded_message_limit(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """Message pages have a hard maximum to protect MCP response size."""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile([])
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages",
+            {
+                "activity_id": ACTIVITY_ID,
+                "include_records": True,
+                "message_limit": 5001,
+            },
+        )
+
+    data = json.loads(result[0][0].text)
+    assert data["error"] == "message_limit must be between 1 and 5000"
+
+
+@pytest.mark.asyncio
+async def test_get_activity_fit_messages_omits_other_high_frequency_types_by_default(
+    app_with_activity_analysis, mock_garmin_client
+):
+    """Unknown vendor sample streams cannot inflate an unfiltered response."""
+    mock_garmin_client.download_activity.return_value = b"\x00" * 20
+    messages = [
+        _make_generic_fit_message("session", [(5, "sport", "training", None)])
+    ] + [
+        _make_generic_fit_message("unknown_233", [(0, "unknown_0", index, None)])
+        for index in range(101)
+    ]
+
+    with patch("garmin_mcp.activity_analysis.fitparse") as mock_fp:
+        mock_fp.FitFile.return_value = _mock_fitfile(messages)
+        result = await app_with_activity_analysis.call_tool(
+            "get_activity_fit_messages", {"activity_id": ACTIVITY_ID}
+        )
+
+    data = json.loads(result[0][0].text)
+    assert [message["type"] for message in data["messages"]] == ["session"]
+    assert data["message_counts"]["unknown_233"] == 101
+    assert data["omitted_high_frequency_message_types"]["unknown_233"]["count"] == 101
 
 @pytest.mark.asyncio
 async def test_get_activity_fit_data_calls_download(app_with_activity_analysis, mock_garmin_client):

--- a/tests/integration/test_activity_analysis_tools.py
+++ b/tests/integration/test_activity_analysis_tools.py
@@ -48,7 +48,7 @@ def _make_mock_fit_message(name, fields: dict):
 def _mock_fitfile(messages):
     """Create a mock FitFile that yields the given messages."""
     mock_ff = MagicMock()
-    mock_ff.get_messages.side_effect = lambda: iter(messages)
+    mock_ff.get_messages.return_value = iter(messages)
     return mock_ff
 
 


### PR DESCRIPTION
## Summary

Adds `get_activity_fit_messages`, a general-purpose MCP endpoint that downloads and parses an activity's original FIT file without applying sport-specific curation.

The endpoint:

- preserves every message type and field emitted by `fitparse`, including unknown and duplicate fields
- returns decoded and raw values, units, field definition numbers, profile metadata, and global message numbers when available
- inventories the complete FIT file while omitting the high-frequency `record` stream by default
- omits other unexpectedly high-frequency message types from unfiltered default responses
- supports case-insensitive message-type filtering and bounded offset/limit pagination
- resolves standard FIT profile labels, including context-dependent exercise names in `set` and `exercise_title` messages

## Why

Detailed activity analysis currently tends to require adding a new Garmin Connect endpoint or sport-specific parser for each use case. The original FIT file already contains the device-recorded source data across activity types.

This endpoint exposes that data through one stable interface, allowing callers to inspect strength, cycling, running, multisport, developer, and future FIT messages without expanding the MCP API for every activity-specific detail. Garmin Connect edits made after upload are intentionally not merged, so consumers can distinguish original device data from service-side changes.

High-frequency streams can make an unbounded MCP response impractical. The endpoint therefore returns a complete message inventory but requires explicit opt-in for records and explicit filtering for other large streams. Selected messages are paginated with a maximum of 5,000 per call, and only the requested page is serialized.

## Compatibility

The implementation is additive: it adds a new tool and private parsing helpers without changing the existing activity-analysis tools. The branch diff against `main` contains no deleted lines in the implementation, tests, or documentation.

## Testing

- 63 activity-analysis tests pass
- 503 deterministic integration and unit tests pass
- tests use real `fitparse.FieldData` objects for context-dependent profile decoding
- pagination tests verify that only fields in the requested page are serialized
- live validation against a strength activity confirmed retrieval of set, repetition, weight, category, subtype, and unknown FIT fields while large record/vendor streams remained bounded
