### PR TITLE
fix: harden null-section handling in HRV, sleep, progress, body-batte…

### DIFF
--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -268,7 +268,7 @@ def register_tools(app):
                     "events": []
                 }
 
-                for event in day.get('bodyBatteryActivityEvent', []):
+                for event in (day.get('bodyBatteryActivityEvent') or []):
                     entry["events"].append({
                         "type": event.get('eventType'),
                         "start_time": event.get('eventStartTimeGmt'),
@@ -474,9 +474,14 @@ def register_tools(app):
                 summary['sleep_start'] = daily_sleep.get('sleepStartTimestampGMT')
                 summary['sleep_end'] = daily_sleep.get('sleepEndTimestampGMT')
 
-                # Sleep score and quality
-                summary['sleep_score'] = daily_sleep.get('sleepScores', {}).get('overall', {}).get('value')
-                summary['sleep_score_qualifier'] = daily_sleep.get('sleepScores', {}).get('overall', {}).get('qualifierKey')
+                # Sleep score and quality. Guard each level with `or {}`: a
+                # sleep record can exist while `sleepScores` (or its `overall`
+                # block) is an explicit null, which would otherwise raise
+                # "'NoneType' object has no attribute 'get'".
+                sleep_scores = daily_sleep.get('sleepScores') or {}
+                overall_score = sleep_scores.get('overall') or {}
+                summary['sleep_score'] = overall_score.get('value')
+                summary['sleep_score_qualifier'] = overall_score.get('qualifierKey')
 
                 # Sleep phases (in seconds)
                 summary['deep_sleep_seconds'] = daily_sleep.get('deepSleepSeconds')

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -192,8 +192,10 @@ def register_tools(app):
                 "stats_by_activity_type": {},
             }
 
-            # Parse stats by activity type
-            stats = data.get("stats", {})
+            # Parse stats by activity type. `or {}` guards against an explicit
+            # null `stats` (Garmin sends null for empty sections), which would
+            # otherwise raise "'NoneType' object has no attribute 'items'".
+            stats = data.get("stats") or {}
             for activity_type, activity_stats in stats.items():
                 if metric in activity_stats:
                     metric_data = activity_stats[metric]
@@ -440,9 +442,13 @@ def register_tools(app):
             if not hrv_data:
                 return f"No HRV data found for {date}."
 
-            # Extract the summary from hrvSummary key
-            summary = hrv_data.get("hrvSummary", {})
-            baseline = summary.get("baseline", {})
+            # Extract the summary from hrvSummary key.
+            # Use `x.get(key) or {}` rather than `x.get(key, {})`: Garmin sends
+            # an explicit null for sections the user has no data in, and a
+            # default only applies when the key is absent. Same pattern as
+            # get_training_status.
+            summary = hrv_data.get("hrvSummary") or {}
+            baseline = summary.get("baseline") or {}
 
             # Curate to essential fields only
             curated = {

--- a/src/garmin_mcp/workouts.py
+++ b/src/garmin_mcp/workouts.py
@@ -608,8 +608,10 @@ def _is_already_scheduled(workout_id: int, calendar_date: str) -> bool:
             )
         }
         result = garmin_client.query_garmin_graphql(query) or {}
+        # GraphQL returns {"data": null} on error, so `result.get("data", {})`
+        # would yield None and the chained .get would crash. Guard with `or {}`.
         existing = (
-            result.get("data", {}).get("workoutScheduleSummariesScalar", []) or []
+            (result.get("data") or {}).get("workoutScheduleSummariesScalar") or []
         )
         for entry in existing:
             if (
@@ -1078,7 +1080,10 @@ def register_tools(app):
             if not result or "data" not in result:
                 return "No scheduled workouts found or error querying data."
 
-            scheduled = result.get("data", {}).get("workoutScheduleSummariesScalar", [])
+            # "data" can be present but explicitly null (GraphQL error response),
+            # which passes the check above; `or {}` stops the chained .get from
+            # crashing on None.
+            scheduled = (result.get("data") or {}).get("workoutScheduleSummariesScalar") or []
 
             if not scheduled:
                 return f"No workouts scheduled between {start_date} and {end_date}."

--- a/tests/integration/test_health_wellness_tools.py
+++ b/tests/integration/test_health_wellness_tools.py
@@ -628,3 +628,60 @@ async def test_get_sleep_data_exception(app_with_health_wellness, mock_garmin_cl
     # Verify error is handled gracefully
     assert result is not None
     # The tool should return an error message, not crash
+
+
+@pytest.mark.asyncio
+async def test_get_sleep_summary_handles_null_sleep_scores(app_with_health_wellness, mock_garmin_client):
+    """A present sleep record with a null sleepScores block must not crash.
+
+    `daily_sleep.get('sleepScores', {})` returns None when Garmin sends an
+    explicit null, so the chained `.get('overall', {}).get('value')` raised
+    "'NoneType' object has no attribute 'get'".
+    """
+    mock_garmin_client.get_sleep_data.return_value = {
+        "dailySleepDTO": {
+            "sleepTimeSeconds": 28800,
+            "deepSleepSeconds": 7200,
+            "lightSleepSeconds": 14400,
+            "remSleepSeconds": 7200,
+            "awakeSleepSeconds": 0,
+            "sleepScores": None,
+        },
+    }
+
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary",
+        {"date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "Error" not in text
+    assert "28800" in text  # the rest of the summary still surfaces
+
+
+@pytest.mark.asyncio
+async def test_get_body_battery_handles_null_activity_events(app_with_health_wellness, mock_garmin_client):
+    """A day whose bodyBatteryActivityEvent is an explicit null must not crash.
+
+    `day.get('bodyBatteryActivityEvent', [])` returns None when the key is
+    present but null, so `for event in ...` raised
+    "'NoneType' object is not iterable".
+    """
+    mock_garmin_client.get_body_battery.return_value = [
+        {
+            "date": "2024-01-15",
+            "charged": 100,
+            "drained": 20,
+            "bodyBatteryActivityEvent": None,
+            "bodyBatteryDynamicFeedbackEvent": None,
+        }
+    ]
+
+    result = await app_with_health_wellness.call_tool(
+        "get_body_battery",
+        {"start_date": "2024-01-15", "end_date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "Error" not in text
+    assert "100" in text

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -742,3 +742,47 @@ async def test_get_training_status_no_cycling_vo2_when_absent(app_with_training,
         assert "cycling_vo2_max_precise" not in data
     except (json.JSONDecodeError, AttributeError):
         assert "cycling_vo2_max" not in text
+
+
+@pytest.mark.asyncio
+async def test_get_hrv_data_handles_null_summary(app_with_training, mock_garmin_client):
+    """A null hrvSummary must not crash the tool.
+
+    Garmin returns an explicit null for sections the user has no data in.
+    `hrv_data.get("hrvSummary", {})` returns None in that case (the default
+    only applies when the key is absent), so `summary.get("baseline", {})`
+    raised "'NoneType' object has no attribute 'get'".
+    """
+    mock_garmin_client.get_hrv_data.return_value = {
+        "hrvSummary": None,
+        "sleepStartTimestampLocal": None,
+    }
+
+    result = await app_with_training.call_tool(
+        "get_hrv_data",
+        {"date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "Error" not in text
+
+
+@pytest.mark.asyncio
+async def test_get_progress_summary_handles_null_stats(app_with_training, mock_garmin_client):
+    """A null `stats` block must not crash the tool.
+
+    An empty range can come back with `stats` as an explicit null;
+    `data.get("stats", {})` then returns None and `.items()` raised
+    "'NoneType' object has no attribute 'items'".
+    """
+    mock_garmin_client.get_progress_summary_between_dates.return_value = [
+        {"date": "2024-01-15", "stats": None}
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_progress_summary_between_dates",
+        {"start_date": "2024-01-08", "end_date": "2024-01-15", "metric": "duration"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "Error" not in text

--- a/tests/integration/test_workouts_tools.py
+++ b/tests/integration/test_workouts_tools.py
@@ -2675,3 +2675,23 @@ async def test_get_scheduled_workouts_exposes_scheduled_id(app_with_workouts, mo
     workout = result_data["scheduled_workouts"][0]
     assert workout["scheduled_workout_id"] == 555
     assert workout["workout_id"] == 123456
+
+
+@pytest.mark.asyncio
+async def test_get_scheduled_workouts_handles_null_graphql_data(app_with_workouts, mock_garmin_client):
+    """A GraphQL error response ({"data": null}) must not crash the tool.
+
+    "data" is present but null, so it passes the `"data" not in result`
+    guard; `result.get("data", {})` then returns None and the chained
+    `.get("workoutScheduleSummariesScalar", [])` raised
+    "'NoneType' object has no attribute 'get'".
+    """
+    mock_garmin_client.query_garmin_graphql.return_value = {"data": None}
+
+    result = await app_with_workouts.call_tool(
+        "get_scheduled_workouts",
+        {"start_date": "2024-01-08", "end_date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "No workouts scheduled" in text


### PR DESCRIPTION
…ry, and scheduled-workout tools

Garmin returns an explicit null for sections a user has no data in, so `resp.get("key", {})` yields None (the default only applies when the key is *absent*) and the following .get()/.items()/iteration raises a "NoneType" error. This is the same class already fixed for get_endurance_score and documented in get_training_status ("use `(x.get(k) or {})` ... so explicit null values are treated as missing rather than causing NoneType errors").

Apply that guard to the remaining unguarded sites:
- get_hrv_data: null `hrvSummary` -> `baseline` access (training.py)
- get_progress_summary_between_dates: null `stats` -> `.items()` (training.py)
- get_sleep_summary: null `sleepScores`/`overall` chain (health_wellness.py)
- get_body_battery: null `bodyBatteryActivityEvent` iteration (health_wellness.py)
- get_scheduled_workouts + _is_already_scheduled: a GraphQL error response {"data": null} passes the `"data" not in result` guard, then the chained .get crashes (workouts.py)

Each fix ships a regression test that feeds the explicit-null payload and asserts the tool returns curated output instead of a NoneType error.