### PR TITLE
fix: bound Garmin call duration so a stalled request can't hang the s…

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,6 +436,7 @@ By default the server communicates over **stdio**, which is what Claude Desktop,
 - `GARMIN_MCP_TRANSPORT`: `stdio` (default), `streamable-http`, or `sse`
 - `GARMIN_MCP_HOST`: bind address for HTTP transports (default `127.0.0.1`; set to `0.0.0.0` only when the endpoint is fronted by an authenticating reverse proxy)
 - `GARMIN_MCP_PORT`: bind port for HTTP transports (default `8000`)
+- `GARMIN_MCP_CALL_TIMEOUT`: per-request timeout in seconds for calls to Garmin (default `90`). Garmin's API occasionally stalls a single request indefinitely; without this bound the call hangs until the MCP client's own timeout fires and reports the whole server as unresponsive. On timeout the tool returns a clear, retry-able error instead. Set to `0` to disable the bound.
 
 ```bash
 GARMIN_MCP_TRANSPORT=streamable-http garmin-mcp

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -5,6 +5,7 @@ Modular MCP Server for Garmin Connect Data
 import os
 import sys
 import base64
+import threading
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -112,14 +113,52 @@ disabled_tools = _parse_tool_set(os.getenv("GARMIN_DISABLED_TOOLS"))
 
 _VALID_TRANSPORTS = ("stdio", "streamable-http", "sse")
 
+# Default per-call timeout (seconds). Garmin's API occasionally stalls a single
+# request indefinitely; without a bound the blocking client call hangs until the
+# MCP client's own timeout (~4 min) fires, reporting the whole server as
+# unresponsive (see issue #248). 90s sits comfortably above a normal slow call
+# yet well below that ceiling. Override with GARMIN_MCP_CALL_TIMEOUT; set 0 to
+# disable the bound entirely.
+_DEFAULT_CALL_TIMEOUT = 90.0
+
+
+def _resolve_call_timeout() -> float:
+    """Read GARMIN_MCP_CALL_TIMEOUT; fall back to the default on bad/absent input.
+
+    A value <= 0 disables the timeout (returns 0.0).
+    """
+    raw = os.getenv("GARMIN_MCP_CALL_TIMEOUT")
+    if raw is None or not raw.strip():
+        return _DEFAULT_CALL_TIMEOUT
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        print(
+            f"Invalid GARMIN_MCP_CALL_TIMEOUT {raw!r}; using default "
+            f"{_DEFAULT_CALL_TIMEOUT}s.",
+            file=sys.stderr,
+        )
+        return _DEFAULT_CALL_TIMEOUT
+    return value if value > 0 else 0.0
+
 
 class _GarminProxy:
-    """Wraps the Garmin client to translate known runtime exceptions into clear messages.
+    """Wraps the Garmin client to bound call duration and clarify runtime errors.
 
-    Without this, token expiry or rate-limiting during a tool call surfaces raw
-    library tracebacks to the MCP client. The proxy intercepts each attribute
-    access and, if the result is callable, wraps the call so that known Garmin
-    exceptions become user-friendly strings rather than server errors.
+    Two jobs:
+
+    1. Timeout: each client call runs on a daemon worker thread and is abandoned
+       if it does not return within the configured timeout (issue #248 — an
+       occasional Garmin request stalls forever and the blocking call would
+       otherwise hang the whole server until the MCP client gives up minutes
+       later). A stalled call raises a clear, retry-able error instead; the
+       abandoned daemon thread dies with the process and never blocks shutdown.
+       Such stalls are rare and transient, so a fresh thread per call is cheap
+       relative to the network round-trip it guards.
+
+    2. Error translation: token expiry or rate-limiting during a tool call would
+       otherwise surface a raw library traceback. Known Garmin exceptions become
+       user-friendly messages instead.
     """
 
     _MESSAGES = {
@@ -135,15 +174,16 @@ class _GarminProxy:
         ),
     }
 
-    def __init__(self, client):
+    def __init__(self, client, timeout=None):
         self._client = client
+        self._timeout = _resolve_call_timeout() if timeout is None else timeout
 
     def __getattr__(self, name):
         attr = getattr(self._client, name)
         if not callable(attr):
             return attr
 
-        def _call(*args, **kwargs):
+        def _invoke(*args, **kwargs):
             try:
                 return attr(*args, **kwargs)
             except tuple(self._MESSAGES) as exc:
@@ -153,6 +193,38 @@ class _GarminProxy:
                         full_msg = f"{msg} (Details: {error_details})" if error_details else msg
                         raise type(exc)(full_msg) from None
                 raise
+
+        def _call(*args, **kwargs):
+            if not self._timeout:
+                return _invoke(*args, **kwargs)
+
+            # Run on a daemon thread and join with a timeout. The worker's
+            # return value or exception is captured and replayed in the caller
+            # so translated Garmin errors propagate unchanged.
+            outcome = {}
+
+            def _worker():
+                try:
+                    outcome["value"] = _invoke(*args, **kwargs)
+                except BaseException as exc:  # noqa: BLE001 - replayed below
+                    outcome["error"] = exc
+
+            worker = threading.Thread(
+                target=_worker, name=f"garmin-call:{name}", daemon=True
+            )
+            worker.start()
+            worker.join(self._timeout)
+            if worker.is_alive():
+                raise TimeoutError(
+                    f"Garmin request '{name}' did not return within "
+                    f"{self._timeout:g}s and was abandoned. This is usually a "
+                    f"transient stall on Garmin's side — please try again. "
+                    f"(Adjust with GARMIN_MCP_CALL_TIMEOUT, or set it to 0 to "
+                    f"disable the limit.)"
+                )
+            if "error" in outcome:
+                raise outcome["error"]
+            return outcome.get("value")
 
         return _call
 

--- a/tests/unit/test_garmin_proxy.py
+++ b/tests/unit/test_garmin_proxy.py
@@ -9,7 +9,7 @@ from garminconnect import (
     GarminConnectTooManyRequestsError,
 )
 
-from garmin_mcp import _GarminProxy
+from garmin_mcp import _GarminProxy, _resolve_call_timeout, _DEFAULT_CALL_TIMEOUT
 
 
 class TestGarminProxy:
@@ -60,3 +60,69 @@ class TestGarminProxy:
         proxy = _GarminProxy(client)
         proxy.get_activities(0, 10, activityType="running")
         client.get_activities.assert_called_once_with(0, 10, activityType="running")
+
+    def test_slow_call_times_out_with_actionable_message(self):
+        """A call that stalls past the timeout raises a clear, retry-able error (issue #248)."""
+        import threading
+
+        blocked = threading.Event()
+        client = Mock()
+        # Simulate a hung Garmin request: block until released by the test.
+        client.get_activities.side_effect = lambda *a, **k: blocked.wait(30)
+        proxy = _GarminProxy(client, timeout=0.05)
+        try:
+            with pytest.raises(TimeoutError) as exc:
+                proxy.get_activities()
+            assert "did not return within" in str(exc.value)
+            assert "GARMIN_MCP_CALL_TIMEOUT" in str(exc.value)
+        finally:
+            blocked.set()  # release the abandoned worker thread
+
+    def test_fast_call_returns_before_timeout(self):
+        """A normal call completes and returns through the timeout wrapper."""
+        client = Mock()
+        client.get_full_name.return_value = "Alice"
+        proxy = _GarminProxy(client, timeout=5)
+        assert proxy.get_full_name() == "Alice"
+
+    def test_timeout_zero_disables_bound(self):
+        """timeout=0 bypasses the executor and calls the client inline."""
+        client = Mock()
+        client.get_full_name.return_value = "Zed"
+        proxy = _GarminProxy(client, timeout=0)
+        assert proxy.get_full_name() == "Zed"
+
+    def test_known_exception_still_translated_through_timeout_wrapper(self):
+        """Error translation survives the worker-thread hop (future re-raises)."""
+        proxy = self._proxy(get_activities=GarminConnectAuthenticationError("expired"))
+        with pytest.raises(GarminConnectAuthenticationError) as exc:
+            proxy.get_activities()
+        assert "Re-run 'garmin-mcp-auth'" in str(exc.value)
+
+
+class TestResolveCallTimeout:
+    """Tests for GARMIN_MCP_CALL_TIMEOUT parsing."""
+
+    def test_absent_uses_default(self, monkeypatch):
+        monkeypatch.delenv("GARMIN_MCP_CALL_TIMEOUT", raising=False)
+        assert _resolve_call_timeout() == _DEFAULT_CALL_TIMEOUT
+
+    def test_blank_uses_default(self, monkeypatch):
+        monkeypatch.setenv("GARMIN_MCP_CALL_TIMEOUT", "   ")
+        assert _resolve_call_timeout() == _DEFAULT_CALL_TIMEOUT
+
+    def test_valid_value_is_used(self, monkeypatch):
+        monkeypatch.setenv("GARMIN_MCP_CALL_TIMEOUT", "5")
+        assert _resolve_call_timeout() == 5.0
+
+    def test_zero_disables(self, monkeypatch):
+        monkeypatch.setenv("GARMIN_MCP_CALL_TIMEOUT", "0")
+        assert _resolve_call_timeout() == 0.0
+
+    def test_negative_disables(self, monkeypatch):
+        monkeypatch.setenv("GARMIN_MCP_CALL_TIMEOUT", "-1")
+        assert _resolve_call_timeout() == 0.0
+
+    def test_invalid_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("GARMIN_MCP_CALL_TIMEOUT", "bogus")
+        assert _resolve_call_timeout() == _DEFAULT_CALL_TIMEOUT


### PR DESCRIPTION
…erver (#248)

Garmin's API occasionally stalls a single request indefinitely. Because each tool calls the garminconnect client synchronously, one stalled call blocks until the MCP client's own timeout (~4 min) fires and reports the whole server as unresponsive — the symptom in issue #248, where upload_workout / upload_workouts hang even on a minimal valid payload.

Wrap every proxied client call in _GarminProxy with a per-call timeout: the call runs on a daemon worker thread joined with a deadline, and if it does not return in time it is abandoned and the tool surfaces a clear, retry-able TimeoutError instead of hanging. The daemon thread dies with the process and never blocks shutdown; a fresh thread per call is cheap next to the network round-trip it guards. The worker's return value or exception is replayed in the caller, so existing Garmin-error translation is unchanged.

The bound defaults to 90s (well under the client ceiling, above a normal slow call) and is configurable via GARMIN_MCP_CALL_TIMEOUT; set 0 to disable it. Adds unit tests for the timeout path, error-translation through the worker hop, and env-var parsing, plus a README note.