### PR TITLE
fix(training): tolerate null device map entries

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -578,9 +578,8 @@ def register_tools(app):
                 return f"No training status data found for {date}."
 
             # Extract from nested structure
-            # Use `(x.get(key) or {})` instead of `x.get(key, {})` so that
-            # explicit null values in the API response are treated as missing
-            # rather than causing `NoneType has no attribute 'get'` errors.
+            # Use `_as_dict()` for nested Garmin sections so null or non-dict
+            # values are treated as missing instead of causing attribute errors.
             recent_status = _as_dict(status.get("mostRecentTrainingStatus"))
             latest_data = _as_dict(recent_status.get("latestTrainingStatusData"))
 

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -586,7 +586,7 @@ def register_tools(app):
             # Get first device data (usually the primary device)
             device_data = {}
             for data in latest_data.values():
-                if not isinstance(data, dict):
+                if not isinstance(data, dict) or not data:
                     continue
                 device_data = data
                 break
@@ -603,7 +603,7 @@ def register_tools(app):
             load_map = _as_dict(load_balance.get("metricsTrainingLoadBalanceDTOMap"))
             load_data = {}
             for data in load_map.values():
-                if not isinstance(data, dict):
+                if not isinstance(data, dict) or not data:
                     continue
                 load_data = data
                 break

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -573,7 +573,7 @@ def register_tools(app):
             date: Date in YYYY-MM-DD format
         """
         try:
-            status = garmin_client.get_training_status(date)
+            status = _as_dict(garmin_client.get_training_status(date))
             if not status:
                 return f"No training status data found for {date}."
 

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -581,26 +581,31 @@ def register_tools(app):
             # Use `(x.get(key) or {})` instead of `x.get(key, {})` so that
             # explicit null values in the API response are treated as missing
             # rather than causing `NoneType has no attribute 'get'` errors.
-            recent_status = (status.get("mostRecentTrainingStatus") or {})
-            latest_data = (recent_status.get("latestTrainingStatusData") or {})
+            recent_status = _as_dict(status.get("mostRecentTrainingStatus"))
+            latest_data = _as_dict(recent_status.get("latestTrainingStatusData"))
 
             # Get first device data (usually the primary device)
             device_data = {}
-            for device_id, data in latest_data.items():
+            for data in latest_data.values():
+                if not isinstance(data, dict):
+                    continue
                 device_data = data
                 break
 
-            acwr_data = (device_data.get("acuteTrainingLoadDTO") or {})
+            acwr_data = _as_dict(device_data.get("acuteTrainingLoadDTO"))
 
             # VO2 Max data
-            vo2_data = (status.get("mostRecentVO2Max") or {}).get("generic") or {}
-            cycling_vo2_data = (status.get("mostRecentVO2Max") or {}).get("cycling") or {}
+            most_recent_vo2 = _as_dict(status.get("mostRecentVO2Max"))
+            vo2_data = _as_dict(most_recent_vo2.get("generic"))
+            cycling_vo2_data = _as_dict(most_recent_vo2.get("cycling"))
 
             # Training load balance
-            load_balance = (status.get("mostRecentTrainingLoadBalance") or {})
-            load_map = (load_balance.get("metricsTrainingLoadBalanceDTOMap") or {})
+            load_balance = _as_dict(status.get("mostRecentTrainingLoadBalance"))
+            load_map = _as_dict(load_balance.get("metricsTrainingLoadBalanceDTOMap"))
             load_data = {}
-            for device_id, data in load_map.items():
+            for data in load_map.values():
+                if not isinstance(data, dict):
+                    continue
                 load_data = data
                 break
 

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -334,6 +334,22 @@ async def test_get_training_status_tolerates_all_null_device_maps(
 
 
 @pytest.mark.asyncio
+async def test_get_training_status_tolerates_non_mapping_response(
+    app_with_training, mock_garmin_client
+):
+    """Test truthy non-mapping training status responses are treated as empty."""
+    mock_garmin_client.get_training_status.return_value = [None]
+
+    result = await app_with_training.call_tool(
+        "get_training_status",
+        {"date": "2026-08-24"},
+    )
+
+    assert result[0][0].text == "No training status data found for 2026-08-24."
+    mock_garmin_client.get_training_status.assert_called_once_with("2026-08-24")
+
+
+@pytest.mark.asyncio
 async def test_get_vo2max_trend_falls_back_to_profile(
     app_with_training, mock_garmin_client
 ):

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -263,6 +263,77 @@ async def test_get_training_status_tool(app_with_training, mock_garmin_client):
 
 
 @pytest.mark.asyncio
+async def test_get_training_status_skips_null_device_entries(
+    app_with_training, mock_garmin_client
+):
+    """Test null device entries are skipped when selecting training status data."""
+    mock_garmin_client.get_training_status.return_value = {
+        "mostRecentTrainingStatus": {
+            "latestTrainingStatusData": {
+                "device-null": None,
+                "device-valid": {
+                    "calendarDate": "2026-08-24",
+                    "trainingStatus": "PRODUCTIVE",
+                    "acuteTrainingLoadDTO": {
+                        "dailyTrainingLoadAcute": 250,
+                    },
+                },
+            }
+        },
+        "mostRecentVO2Max": {
+            "generic": {"vo2MaxValue": 52.5},
+            "cycling": None,
+        },
+        "mostRecentTrainingLoadBalance": {
+            "metricsTrainingLoadBalanceDTOMap": {
+                "device-null": None,
+                "device-valid": {"monthlyLoadAerobicLow": 100},
+            }
+        },
+    }
+
+    result = await app_with_training.call_tool(
+        "get_training_status",
+        {"date": "2026-08-24"},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["date"] == "2026-08-24"
+    assert data["training_status"] == "PRODUCTIVE"
+    assert data["acute_load"] == 250
+    assert data["vo2_max"] == 52.5
+    assert data["monthly_load_aerobic_low"] == 100
+    mock_garmin_client.get_training_status.assert_called_once_with("2026-08-24")
+
+
+@pytest.mark.asyncio
+async def test_get_training_status_tolerates_all_null_device_maps(
+    app_with_training, mock_garmin_client
+):
+    """Test training status output contains only the requested date when maps are null."""
+    mock_garmin_client.get_training_status.return_value = {
+        "mostRecentTrainingStatus": {
+            "latestTrainingStatusData": {"device-null": None},
+        },
+        "mostRecentVO2Max": {
+            "generic": None,
+            "cycling": None,
+        },
+        "mostRecentTrainingLoadBalance": {
+            "metricsTrainingLoadBalanceDTOMap": {"device-null": None},
+        },
+    }
+
+    result = await app_with_training.call_tool(
+        "get_training_status",
+        {"date": "2026-08-24"},
+    )
+
+    assert json.loads(result[0][0].text) == {"date": "2026-08-24"}
+    mock_garmin_client.get_training_status.assert_called_once_with("2026-08-24")
+
+
+@pytest.mark.asyncio
 async def test_get_vo2max_trend_falls_back_to_profile(
     app_with_training, mock_garmin_client
 ):

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -307,6 +307,44 @@ async def test_get_training_status_skips_null_device_entries(
 
 
 @pytest.mark.asyncio
+async def test_get_training_status_skips_empty_device_entries(
+    app_with_training, mock_garmin_client
+):
+    """Test empty device entries are skipped when selecting training status data."""
+    mock_garmin_client.get_training_status.return_value = {
+        "mostRecentTrainingStatus": {
+            "latestTrainingStatusData": {
+                "device-empty": {},
+                "device-valid": {
+                    "calendarDate": "2026-08-24",
+                    "trainingStatus": "PRODUCTIVE",
+                    "acuteTrainingLoadDTO": {
+                        "dailyTrainingLoadAcute": 250,
+                    },
+                },
+            }
+        },
+        "mostRecentTrainingLoadBalance": {
+            "metricsTrainingLoadBalanceDTOMap": {
+                "device-empty": {},
+                "device-valid": {"monthlyLoadAerobicLow": 100},
+            }
+        },
+    }
+
+    result = await app_with_training.call_tool(
+        "get_training_status",
+        {"date": "2026-08-24"},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["training_status"] == "PRODUCTIVE"
+    assert data["acute_load"] == 250
+    assert data["monthly_load_aerobic_low"] == 100
+    mock_garmin_client.get_training_status.assert_called_once_with("2026-08-24")
+
+
+@pytest.mark.asyncio
 async def test_get_training_status_tolerates_all_null_device_maps(
     app_with_training, mock_garmin_client
 ):


### PR DESCRIPTION
## Summary

- Treat non-mapping training-status responses and nested sections as missing data.
- Skip null values, empty dictionaries, and other non-dictionary entries in Garmin's device-keyed status and load-balance maps while preserving valid later-device metrics.
- Cover null-first, empty-first, all-null, and non-mapping response shapes with integration regressions.

## Why

Garmin can return `null` or an empty object for an entry inside `latestTrainingStatusData` or `metricsTrainingLoadBalanceDTOMap`. The parser previously selected the first dictionary unconditionally, so an empty first entry hid valid data from a later device.

This keeps the existing API call and curated response schema unchanged. Missing sections still produce sparse output; valid later-device data is no longer discarded.

Addresses #264.

## Test plan

- Focused training integration suite: 30 passed.
- Full integration/unit suite: 498 passed on Python 3.10, 3.11, 3.12, and 3.13.
- `uv lock --check` passed.
- `uv build` passed.
