### PR TITLE
feat(training): expose Running Tolerance and heat/altitude acclimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 - Access cycling FTP and lactate threshold metrics
 - Manage gear and equipment
 - Access workouts and training plans
+- List races and events on your Garmin Connect calendar
 - Inspect detailed workout step structures, including repeat groups and swim pace targets
 - Weekly health aggregates (steps, stress, intensity minutes)
 - Advanced cycling analytics: power zones, FIT file analysis, DI2 electronic shift intelligence
@@ -40,10 +41,17 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ User Profile (3 tools)
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
 - ✅ Courses (3 tools) - list / upload GPX as course / delete course
+- ✅ Calendar Events (1 tool) - list races and events registered on the Garmin Connect calendar
 - ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 
 > **Note:** Activity Analysis tools require a compatible power meter (e.g., Garmin Rally, Favero Assioma, PowerTap P1) and/or Shimano Di2 / SRAM eTap electronic shifting. The `fitparse` dependency is installed automatically.
+
+### Calendar Events
+
+**`get_calendar_events(start_date, end_date)`** lists the races and events you added or subscribed to in Garmin Connect.
+
+These entries live in Garmin's calendar feed as `itemType: "event"`, separate from workouts. `get_scheduled_workouts` queries the workout schedule and never returns them, so this is the tool to reach for when asked which races are coming up. Each event reports its target distance, the local start time when the organiser published one, and two flags: `is_race`, and `primary_event` for the goal race an active training plan targets.
 
 ### Activity File Downloads
 

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -29,6 +29,7 @@ from garmin_mcp import nutrition
 from garmin_mcp import workout_builders
 from garmin_mcp import courses
 from garmin_mcp import activity_analysis
+from garmin_mcp import calendar_events
 
 
 def is_interactive_terminal() -> bool:
@@ -414,6 +415,7 @@ def main():
     workout_builders.configure(garmin_client)
     courses.configure(garmin_client)
     activity_analysis.configure(garmin_client)
+    calendar_events.configure(garmin_client)
 
     # Create the MCP app, wrapped so the env-var filter can drop tools.
     # host/port only matter for the HTTP transports; stdio ignores them.
@@ -440,6 +442,7 @@ def main():
     app = workout_builders.register_tools(app)
     app = courses.register_tools(app)
     app = activity_analysis.register_tools(app)
+    app = calendar_events.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/calendar_events.py
+++ b/src/garmin_mcp/calendar_events.py
@@ -1,0 +1,156 @@
+"""
+Calendar event (race) functions for Garmin Connect MCP Server
+"""
+import json
+import re
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# The garmin_client will be set by the main file
+garmin_client = None
+
+# Garmin's calendar-service groups every calendar entry under an itemType.
+# Races the user added or subscribed to arrive as "event"; workouts, weigh-ins
+# and badges share the same feed and are ignored here.
+EVENT_ITEM_TYPE = "event"
+
+
+def configure(client):
+    """Configure the module with the Garmin client instance"""
+    global garmin_client
+    garmin_client = client
+
+
+def _validate_date(value: str, field: str = "date") -> date:
+    if not _DATE_RE.match(value):
+        raise ValueError(f"Invalid {field} '{value}': expected YYYY-MM-DD")
+    return date.fromisoformat(value)
+
+
+def _month_range(start: date, end: date):
+    """Yield (year, month) pairs covering start..end inclusive."""
+    year, month = start.year, start.month
+    while (year, month) <= (end.year, end.month):
+        yield year, month
+        year, month = (year + 1, 1) if month == 12 else (year, month + 1)
+
+
+def _fetch_month(year: int, month: int) -> List[Dict[str, Any]]:
+    """Return the raw calendar items for one month.
+
+    Despite its name, the library's get_scheduled_workouts returns the whole
+    calendar feed for a month, events included. It takes a 1-indexed month and
+    converts it to the 0-indexed month Garmin's calendar-service expects.
+    """
+    data = garmin_client.get_scheduled_workouts(year, month)
+    if not isinstance(data, dict):
+        return []
+    items = data.get("calendarItems")
+    return items if isinstance(items, list) else []
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    """Return a dict for Garmin fields that may be null or another shape."""
+    return value if isinstance(value, dict) else {}
+
+
+def _target_distance_meters(item: Dict[str, Any]) -> Optional[float]:
+    """Return the event's distance goal, if it is expressed as a distance."""
+    target = _as_dict(item.get("completionTarget"))
+    if target.get("unitType") != "distance":
+        return None
+    value = target.get("value")
+    return value if isinstance(value, (int, float)) else None
+
+
+def _clean_str(value: Any) -> Optional[str]:
+    """Return a trimmed string, or None for the blanks Garmin sends."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _curate_event(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Curate one raw calendar event into a compact shape."""
+    event_time = _as_dict(item.get("eventTimeLocal"))
+    return {
+        "title": item.get("title"),
+        "date": item.get("date"),
+        "is_race": bool(item.get("isRace")),
+        "primary_event": bool(item.get("primaryEvent")),
+        "subscribed": bool(item.get("subscribed")),
+        "distance_meters": _target_distance_meters(item),
+        "start_time_local": event_time.get("startTimeHhMm"),
+        "time_zone": event_time.get("timeZoneId"),
+        "location": _clean_str(item.get("location")),
+        "url": item.get("url"),
+        "event_uuid": item.get("shareableEventUuid"),
+    }
+
+
+def register_tools(app):
+    """Register all calendar event tools with the MCP server app"""
+
+    @app.tool()
+    async def get_calendar_events(start_date: str, end_date: str) -> str:
+        """Get races and events on the Garmin Connect calendar between two dates
+
+        Returns calendar entries the user added or subscribed to in Garmin
+        Connect, such as upcoming races. Use this to answer questions about
+        which events or races are scheduled.
+
+        These entries are not returned by get_scheduled_workouts, which covers
+        only workouts, nor by get_goals. This is the only tool that exposes
+        them.
+
+        Each event reports its target distance in meters when Garmin stores one,
+        the local start time when the organiser published it, and two flags:
+        is_race marks the entry as a race rather than a general event, and
+        primary_event marks the goal race that an active training plan targets.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        try:
+            start = _validate_date(start_date, "start_date")
+            end = _validate_date(end_date, "end_date")
+            if start > end:
+                return "start_date must be on or before end_date."
+
+            events: List[Dict[str, Any]] = []
+            seen = set()
+            for year, month in _month_range(start, end):
+                for item in _fetch_month(year, month):
+                    if not isinstance(item, dict):
+                        continue
+                    if item.get("itemType") != EVENT_ITEM_TYPE:
+                        continue
+                    # The first and last month of the range extend past it.
+                    day = item.get("date")
+                    if not isinstance(day, str) or not start_date <= day <= end_date:
+                        continue
+                    # Multi-month responses can repeat an event at the seams.
+                    key = (item.get("shareableEventUuid"), item.get("title"), day)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    events.append(_curate_event(item))
+
+            events.sort(key=lambda event: (event["date"], event["title"] or ""))
+
+            curated = {
+                "count": len(events),
+                "date_range": {"start": start_date, "end": end_date},
+                "events": events,
+            }
+            return json.dumps(curated, indent=2, ensure_ascii=False)
+        except ValueError as e:
+            return str(e)
+        except Exception as e:
+            return f"Error retrieving calendar events: {str(e)}"
+
+    return app

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -995,6 +995,160 @@ def register_tools(app):
         return json.dumps(result, indent=2)
 
     @app.tool()
+    async def get_running_tolerance(
+        start_date: str, end_date: str, aggregation: str = "weekly"
+    ) -> str:
+        """Get Garmin's Running Tolerance — how much running this athlete's body
+        currently absorbs, fitted to their own history.
+
+        Tolerance is expressed in Garmin's impact-load units, not kilometres, and
+        is compared against the impact load actually accumulated. Unlike a rolling
+        maximum, tolerance **decays when running stops**, so it stays meaningful
+        after a break.
+
+        aggregation="weekly" returns one row per week with the week's total
+        distance, total impact load and the tolerance that applied.
+        aggregation="daily" returns the trailing-7-day (acute) load against the
+        acute tolerance, plus Garmin's own verdict in
+        running_tolerance_feedback — values such as ABOVE_TOLERANCE,
+        ABOVE_TOLERANCE_ONE_HARD_RUN, HIGH_LOAD, MEDIUM_LOAD, LOW_LOAD_7DAYS.
+
+        pct_of_tolerance is computed here as load / tolerance * 100; above 100
+        means the athlete is over their current tolerance.
+
+        This is a proprietary Firstbeat metric with no published validation.
+        Treat it as a personalised reference, not as an established threshold.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+            aggregation: "weekly" (default) or "daily"
+        """
+        if aggregation not in ("weekly", "daily"):
+            return f"Invalid aggregation '{aggregation}': expected 'weekly' or 'daily'."
+        try:
+            data = garmin_client.get_running_tolerance(
+                start_date, end_date, aggregation=aggregation
+            )
+        except Exception as e:
+            return f"Error retrieving running tolerance: {str(e)}"
+
+        if not isinstance(data, list) or not data:
+            return f"No running tolerance data found between {start_date} and {end_date}."
+
+        def _pct(load: Any, tolerance: Any) -> Optional[int]:
+            if not isinstance(load, (int, float)) or not isinstance(tolerance, (int, float)):
+                return None
+            if not tolerance:
+                return None
+            return round(load / tolerance * 100)
+
+        entries = []
+        for row in data:
+            if not isinstance(row, dict):
+                continue
+            if aggregation == "weekly":
+                load = row.get("totalImpactLoad")
+                tolerance = row.get("tolerance")
+                distance = row.get("totalDistance")
+                entry: Dict[str, Any] = {
+                    "week_of": row.get("startOfWeek"),
+                    "week_end": row.get("endOfWeek"),
+                }
+            else:
+                load = row.get("acuteImpactLoad")
+                tolerance = row.get("acuteTolerance")
+                distance = row.get("acuteDistance")
+                entry = {"date": row.get("calendarDate")}
+                feedback = row.get("runningToleranceFeedBackPhrase")
+                if feedback:
+                    entry["running_tolerance_feedback"] = feedback
+
+            if isinstance(distance, (int, float)):
+                entry["distance_km"] = round(distance / 1000.0, 2)
+            if load is not None:
+                entry["impact_load"] = load
+            if tolerance is not None:
+                entry["tolerance"] = tolerance
+            pct = _pct(load, tolerance)
+            if pct is not None:
+                entry["pct_of_tolerance"] = pct
+            entries.append(entry)
+
+        key = "week_of" if aggregation == "weekly" else "date"
+        entries.sort(key=lambda e: e.get(key) or "")
+
+        return json.dumps(
+            {
+                "aggregation": aggregation,
+                "date_range": {"start": start_date, "end": end_date},
+                "count": len(entries),
+                "entries": entries,
+            },
+            indent=2,
+        )
+
+    @app.tool()
+    async def get_acclimation(date: str) -> str:
+        """Get heat and altitude acclimation status.
+
+        Garmin tracks how adapted the athlete currently is to training in heat
+        and at altitude. heat_acclimation_percent runs 0-100 and decays without
+        continued exposure, so it is the direct measurement behind advice to keep
+        training outdoors before a warm-weather race.
+
+        heat_trend reports Garmin's own label, such as ACCLIMATIZED. The
+        `previous_*` fields are the prior reading, which makes the direction of
+        travel visible without a second call.
+
+        VO2 max is not returned here; use get_training_status or
+        get_vo2max_trend.
+
+        Args:
+            date: Date in YYYY-MM-DD format
+        """
+        try:
+            data = garmin_client.get_max_metrics(date)
+        except Exception as e:
+            return f"Error retrieving acclimation data: {str(e)}"
+
+        if isinstance(data, list):
+            data = data[0] if data else None
+        if not isinstance(data, dict):
+            return f"No acclimation data found for {date}."
+
+        acc = data.get("heatAltitudeAcclimation") or {}
+        if not acc:
+            return (
+                f"No acclimation data found for {date}. Garmin populates this only "
+                "after outdoor activities in heat or at altitude."
+            )
+
+        result: Dict[str, Any] = {"date": acc.get("calendarDate", date)}
+
+        for out_key, in_key in (
+            ("heat_acclimation_percent", "heatAcclimationPercentage"),
+            ("previous_heat_acclimation_percent", "previousHeatAcclimationPercentage"),
+            ("heat_trend", "heatTrend"),
+            ("heat_acclimation_date", "heatAcclimationDate"),
+            ("previous_heat_acclimation_date", "previousHeatAcclimationDate"),
+            ("altitude_acclimation_meters", "altitudeAcclimation"),
+            ("previous_altitude_acclimation_meters", "previousAltitudeAcclimation"),
+            ("altitude_trend", "altitudeTrend"),
+            ("current_altitude_meters", "currentAltitude"),
+        ):
+            value = acc.get(in_key)
+            if value is not None:
+                result[out_key] = value
+
+        heat = result.get("heat_acclimation_percent")
+        prev = result.get("previous_heat_acclimation_percent")
+        if isinstance(heat, (int, float)) and isinstance(prev, (int, float)):
+            result["heat_acclimation_change"] = heat - prev
+
+        return json.dumps(result, indent=2)
+
+    @app.tool()
     async def get_hrv_trend(start_date: str, end_date: str) -> str:
         """Get HRV (Heart Rate Variability) trend over a date range.
 

--- a/tests/integration/test_calendar_events_tools.py
+++ b/tests/integration/test_calendar_events_tools.py
@@ -1,0 +1,315 @@
+"""
+Integration tests for the calendar_events module MCP tools.
+
+Covers get_calendar_events using FastMCP integration with a mocked Garmin
+client. No real Garmin account or network access is used.
+"""
+import json
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import calendar_events
+
+
+@pytest.fixture
+def app_with_calendar_events(mock_garmin_client):
+    """Create a FastMCP app with the calendar event tools registered."""
+    calendar_events.configure(mock_garmin_client)
+    app = FastMCP("Test Calendar Events")
+    app = calendar_events.register_tools(app)
+    return app
+
+
+def _result_text(result):
+    """Extract the text payload from a FastMCP call_tool result."""
+    return result[0][0].text
+
+
+def _race(date, title="Some Marathon", uuid="uuid-1", **overrides):
+    """Build a raw calendar event item as Garmin returns it."""
+    item = {
+        "itemType": "event",
+        "activityTypeId": 1,
+        "title": title,
+        "date": date,
+        "url": "https://www.ahotu.com/event/some-marathon",
+        "isRace": True,
+        "shareableEventUuid": uuid,
+        "completionTarget": {"value": 42195.0, "unit": "meter", "unitType": "distance"},
+        "shareableEvent": True,
+        "subscribed": True,
+    }
+    item.update(overrides)
+    return item
+
+
+def _month(*items):
+    return {"calendarItems": list(items)}
+
+
+# --- get_calendar_events --------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_curates_fields(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A race is curated into a compact shape with its distance and start time."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race(
+            "2026-10-17",
+            title="Gyeongju Marathon",
+            eventTimeLocal={"startTimeHhMm": "08:00", "timeZoneId": "Asia/Seoul"},
+            primaryEvent=True,
+            location="KR",
+        )
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 1
+    event = data["events"][0]
+    assert event["title"] == "Gyeongju Marathon"
+    assert event["date"] == "2026-10-17"
+    assert event["is_race"] is True
+    assert event["primary_event"] is True
+    assert event["distance_meters"] == 42195.0
+    assert event["start_time_local"] == "08:00"
+    assert event["time_zone"] == "Asia/Seoul"
+    assert event["location"] == "KR"
+    assert event["event_uuid"] == "uuid-1"
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_requests_the_month_one_indexed(
+    app_with_calendar_events, mock_garmin_client
+):
+    """The library takes a 1-indexed month and handles Garmin's 0-indexing itself."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month()
+
+    await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    mock_garmin_client.get_scheduled_workouts.assert_called_once_with(2026, 10)
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_walks_months_across_a_year_boundary(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A range spanning December to January requests both months, in order."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month()
+
+    await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-12-20", "end_date": "2027-01-10"}
+    )
+
+    requested = [
+        call.args for call in mock_garmin_client.get_scheduled_workouts.call_args_list
+    ]
+    assert requested == [(2026, 12), (2027, 1)]
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_clips_to_the_requested_range(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Events outside the range are dropped even though Garmin returns whole months."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-03", title="Too Early", uuid="uuid-early"),
+        _race("2026-10-17", title="In Range", uuid="uuid-mid"),
+        _race("2026-10-31", title="Too Late", uuid="uuid-late"),
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-10", "end_date": "2026-10-20"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert [event["title"] for event in data["events"]] == ["In Range"]
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_ignores_non_event_items(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Workouts, weigh-ins and training plans share the feed and are skipped."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", title="Gyeongju Marathon"),
+        {"itemType": "fbtAdaptiveWorkout", "title": "Base", "date": "2026-10-15"},
+        {"itemType": "weight", "date": "2026-10-16", "weight": 70100.0},
+        {
+            "itemType": "trainingPlan",
+            "title": "Gyeongju Marathon Plan",
+            "date": "2026-10-17",
+        },
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 1
+    assert data["events"][0]["title"] == "Gyeongju Marathon"
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_deduplicates_across_months(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An event repeated in two monthly responses is reported once."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-11-15", title="MBN Seoul Marathon", uuid="uuid-seoul")
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-11-01", "end_date": "2026-12-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert mock_garmin_client.get_scheduled_workouts.call_count == 2
+    assert data["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_sorts_by_date(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Events are returned oldest first regardless of Garmin's ordering."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", title="Later", uuid="uuid-later"),
+        _race("2026-10-03", title="Earlier", uuid="uuid-earlier"),
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert [event["date"] for event in data["events"]] == ["2026-10-03", "2026-10-17"]
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_handles_missing_completion_target(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An event without a distance goal reports None rather than failing."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", completionTarget=None)
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["events"][0]["distance_meters"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_ignores_non_distance_target(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A duration goal is not reported as a distance."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race(
+            "2026-10-17",
+            completionTarget={"value": 3600.0, "unit": "second", "unitType": "time"},
+        )
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["events"][0]["distance_meters"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_normalises_blank_location(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Garmin sends an empty location string for many events; report None."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(_race("2026-10-17", location=""))
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["events"][0]["location"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_empty(app_with_calendar_events, mock_garmin_client):
+    """A month with no events returns count 0 and an empty list."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month()
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 0
+    assert data["events"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_handles_null_payload(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A null month response is treated as no events, not an error."""
+    mock_garmin_client.get_scheduled_workouts.return_value = None
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_rejects_reversed_range(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An end date before the start date is refused without calling Garmin."""
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-31", "end_date": "2026-10-01"}
+    )
+
+    assert "start_date must be on or before end_date" in _result_text(result)
+    mock_garmin_client.get_scheduled_workouts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_rejects_bad_date_format(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A malformed date is reported clearly without calling Garmin."""
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "10/01/2026", "end_date": "2026-10-31"}
+    )
+
+    assert "Invalid start_date" in _result_text(result)
+    mock_garmin_client.get_scheduled_workouts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_error_is_caught(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A client error is surfaced as a clean message, not a traceback."""
+    mock_garmin_client.get_scheduled_workouts.side_effect = Exception("boom")
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    assert "Error retrieving calendar events" in _result_text(result)

--- a/tests/integration/test_running_tolerance_tools.py
+++ b/tests/integration/test_running_tolerance_tools.py
@@ -1,0 +1,171 @@
+"""
+Integration tests for the Running Tolerance and acclimation MCP tools.
+
+Covers get_running_tolerance and get_acclimation using FastMCP integration with
+a mocked Garmin client. No real Garmin account or network access is used.
+"""
+import json
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import training
+
+
+@pytest.fixture
+def app_with_training(mock_garmin_client):
+    """Create a FastMCP app with the training tools registered."""
+    training.configure(mock_garmin_client)
+    app = FastMCP("Test Training")
+    app = training.register_tools(app)
+    return app
+
+
+def _result_text(result):
+    """Extract the text payload from a FastMCP call_tool result."""
+    return result[0][0].text
+
+
+def _weekly(start_of_week, distance_m, impact, tolerance):
+    return {
+        "userProfilePK": 1,
+        "calendarDate": start_of_week,
+        "startOfWeek": start_of_week,
+        "endOfWeek": start_of_week,
+        "totalDistance": distance_m,
+        "totalImpactLoad": impact,
+        "tolerance": tolerance,
+        "weekIndex": 1900,
+    }
+
+
+def _daily(date, distance_m, impact, tolerance, phrase="HIGH_LOAD"):
+    return {
+        "userProfilePK": 1,
+        "calendarDate": date,
+        "acuteDistance": distance_m,
+        "acuteImpactLoad": impact,
+        "acuteTolerance": tolerance,
+        "runningToleranceFeedBackPhrase": phrase,
+    }
+
+
+@pytest.mark.asyncio
+async def test_running_tolerance_weekly(app_with_training, mock_garmin_client):
+    mock_garmin_client.get_running_tolerance.return_value = [
+        _weekly("2026-08-16", 21829.0, 23660, 34571),
+        _weekly("2026-08-09", 29400.0, 33710, 34630),
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance", {"start_date": "2026-08-09", "end_date": "2026-08-22"}
+    )
+    data = json.loads(_result_text(result))
+
+    assert data["aggregation"] == "weekly"
+    assert data["count"] == 2
+    # sorted by week, oldest first, regardless of the order Garmin returned
+    assert [e["week_of"] for e in data["entries"]] == ["2026-08-09", "2026-08-16"]
+
+    latest = data["entries"][1]
+    assert latest["distance_km"] == 21.83
+    assert latest["impact_load"] == 23660
+    assert latest["tolerance"] == 34571
+    assert latest["pct_of_tolerance"] == 68  # 23660 / 34571
+
+
+@pytest.mark.asyncio
+async def test_running_tolerance_daily_carries_feedback(
+    app_with_training, mock_garmin_client
+):
+    mock_garmin_client.get_running_tolerance.return_value = [
+        _daily("2026-08-26", 33146.0, 37057, 34736, "ABOVE_TOLERANCE"),
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance",
+        {"start_date": "2026-08-26", "end_date": "2026-08-26", "aggregation": "daily"},
+    )
+    data = json.loads(_result_text(result))
+
+    entry = data["entries"][0]
+    assert entry["date"] == "2026-08-26"
+    assert entry["running_tolerance_feedback"] == "ABOVE_TOLERANCE"
+    # over tolerance must read as over 100, not be clamped
+    assert entry["pct_of_tolerance"] == 107
+
+
+@pytest.mark.asyncio
+async def test_running_tolerance_rejects_bad_aggregation(app_with_training):
+    result = await app_with_training.call_tool(
+        "get_running_tolerance",
+        {"start_date": "2026-08-01", "end_date": "2026-08-26", "aggregation": "monthly"},
+    )
+    assert "Invalid aggregation" in _result_text(result)
+
+
+@pytest.mark.asyncio
+async def test_running_tolerance_survives_zero_tolerance(
+    app_with_training, mock_garmin_client
+):
+    """A zero or missing tolerance must not raise ZeroDivisionError."""
+    mock_garmin_client.get_running_tolerance.return_value = [
+        _weekly("2026-07-26", 0.0, 0, 0),
+        {"startOfWeek": "2026-08-02", "totalDistance": 9800.0},
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance", {"start_date": "2026-07-26", "end_date": "2026-08-08"}
+    )
+    data = json.loads(_result_text(result))
+
+    assert data["count"] == 2
+    assert "pct_of_tolerance" not in data["entries"][0]
+    assert "pct_of_tolerance" not in data["entries"][1]
+    assert data["entries"][1]["distance_km"] == 9.8
+
+
+@pytest.mark.asyncio
+async def test_running_tolerance_empty(app_with_training, mock_garmin_client):
+    mock_garmin_client.get_running_tolerance.return_value = []
+    result = await app_with_training.call_tool(
+        "get_running_tolerance", {"start_date": "2026-08-01", "end_date": "2026-08-26"}
+    )
+    assert "No running tolerance data" in _result_text(result)
+
+
+@pytest.mark.asyncio
+async def test_acclimation(app_with_training, mock_garmin_client):
+    mock_garmin_client.get_max_metrics.return_value = [
+        {
+            "heatAltitudeAcclimation": {
+                "calendarDate": "2026-08-26",
+                "heatAcclimationPercentage": 100,
+                "previousHeatAcclimationPercentage": 88,
+                "heatTrend": "ACCLIMATIZED",
+                "heatAcclimationDate": "2026-08-25",
+                "previousHeatAcclimationDate": "2026-08-15",
+                "altitudeAcclimation": 0,
+                "previousAltitudeAcclimation": 0,
+                "altitudeTrend": None,
+                "currentAltitude": 0,
+            }
+        }
+    ]
+
+    result = await app_with_training.call_tool("get_acclimation", {"date": "2026-08-26"})
+    data = json.loads(_result_text(result))
+
+    assert data["heat_acclimation_percent"] == 100
+    assert data["heat_trend"] == "ACCLIMATIZED"
+    assert data["heat_acclimation_change"] == 12
+    # a null trend must be dropped rather than serialised as None
+    assert "altitude_trend" not in data
+
+
+@pytest.mark.asyncio
+async def test_acclimation_absent(app_with_training, mock_garmin_client):
+    """Garmin returns the envelope with no acclimation section for indoor-only users."""
+    mock_garmin_client.get_max_metrics.return_value = [{"heatAltitudeAcclimation": None}]
+    result = await app_with_training.call_tool("get_acclimation", {"date": "2026-08-26"})
+    assert "No acclimation data found" in _result_text(result)


### PR DESCRIPTION
Adds two read-only training tools backed by endpoints `python-garminconnect` already supports but this server does not surface.

## `get_running_tolerance`

Wraps `metrics-service/metrics/runningtolerance/stats`.

- `aggregation="weekly"` (default) — per week: distance, impact load, and the tolerance that applied
- `aggregation="daily"` — trailing-7-day (acute) load against acute tolerance, plus Garmin's own verdict (`ABOVE_TOLERANCE`, `ABOVE_TOLERANCE_ONE_HARD_RUN`, `HIGH_LOAD`, `MEDIUM_LOAD`, `LOW_LOAD_7DAYS`)

`pct_of_tolerance` is computed in the tool rather than left to the caller, and deliberately not clamped — being over tolerance has to read as over 100.

Unlike a rolling maximum, tolerance **decays when running stops**, so it stays meaningful after a break. The docstring states plainly that this is a proprietary Firstbeat metric with no published validation, so it reads as a personalised reference rather than an established threshold.

## `get_acclimation`

Surfaces the `heatAltitudeAcclimation` section of `get_max_metrics`, which no existing tool returns: `heat_acclimation_percent`, `heat_trend`, and the altitude equivalents. The `previous_*` readings come back alongside the current ones so the direction of travel is visible in a single call, with `heat_acclimation_change` derived from the pair.

VO2 max is intentionally not duplicated here — `get_training_status` and `get_vo2max_trend` already cover it.

## Tests

7 integration tests in `tests/integration/test_running_tolerance_tools.py`, following the existing FastMCP + mocked-client pattern. Beyond the happy paths they cover:

- zero or missing tolerance not raising `ZeroDivisionError`
- a null `altitudeTrend` being dropped rather than serialised as `None`
- rows returned out of order being sorted
- an invalid `aggregation` being rejected before the API call
- the empty-result and missing-section messages

Full suite: 516 passed.

Both tools were also exercised against a live account during development.

Note: stacked on top of #258 only in that both come from the same fork; this branch touches `training.py` and a new test file, so it should merge independently.