### PR TITLE
feat(training): add Running Tolerance tools (closes #239)

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -5,7 +5,7 @@ Training and performance functions for Garmin Connect MCP Server
 import json
 import datetime
 import math
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Dict, List, Literal, Optional, Tuple, Union
 
 # The garmin_client will be set by the main file
 garmin_client = None
@@ -1287,6 +1287,158 @@ def register_tools(app):
             "end_date": end_date,
             "days_with_data": len(trend),
             "period_avg_sleep_breaths_per_min": avg_sleep_overall,
+            "trend": trend,
+        }, indent=2)
+
+    @app.tool()
+    async def get_running_tolerance(date: str) -> str:
+        """Get Running Tolerance for a single day.
+
+        Returns Garmin's running load capacity model: how much running load the
+        athlete can currently absorb (tolerance), the intensity-adjusted load
+        their recent runs have produced (acute load), and the raw distance behind
+        that load. All three are expressed in km so they're directly comparable —
+        `load_ratio` (acute_load_km / distance_km) quantifies how much intensity
+        is inflating the cost of each kilometer run.
+
+        Args:
+            date: Date in YYYY-MM-DD format
+        """
+        try:
+            data = garmin_client.get_running_tolerance(date, date, aggregation="daily")
+        except Exception as e:
+            return f"Error retrieving running tolerance data: {str(e)}"
+
+        if not data:
+            return "Your device does not support this metric."
+
+        entry = data[0]
+        tolerance = entry.get("acuteTolerance")
+        acute_load = entry.get("acuteImpactLoad")
+        distance = entry.get("acuteDistance")
+
+        curated: Dict[str, Any] = {"date": entry.get("calendarDate", date)}
+        if tolerance is not None:
+            curated["tolerance_km"] = round(tolerance / 1000, 2)
+        if acute_load is not None:
+            curated["acute_load_km"] = round(acute_load / 1000, 2)
+        if distance is not None:
+            curated["distance_km"] = round(distance / 1000, 2)
+        if acute_load is not None and distance:
+            curated["load_ratio"] = round(acute_load / distance, 2)
+        feedback = entry.get("runningToleranceFeedBackPhrase")
+        if feedback:
+            curated["feedback_phrase"] = feedback
+
+        return json.dumps(curated, indent=2)
+
+    @app.tool()
+    async def get_running_tolerance_trend(
+        start_date: str,
+        end_date: str,
+        aggregation: Literal["daily", "weekly"] = "weekly",
+    ) -> str:
+        """Get Running Tolerance trend over a date range.
+
+        Running Tolerance moves slowly — its value is in the trajectory, not any
+        single day. Returns, per period: tolerance_km (current load capacity),
+        acute_load_km (intensity-adjusted load), distance_km (actual distance
+        run), and load_ratio (acute_load_km / distance_km — how much intensity
+        inflates the cost of each kilometer). Weekly aggregation (default) gives
+        a compact multi-month view; daily gives day-to-day resolution for a
+        shorter window.
+
+        Recommended range: 4-12 weeks. Maximum: 90 days for daily aggregation,
+        366 days for weekly (this endpoint returns the whole range in one call,
+        so the limit protects output size, not request volume).
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+            aggregation: "daily" or "weekly" (default "weekly")
+        """
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days < 1:
+            return "end_date must be on or after start_date."
+
+        max_days = 90 if aggregation == "daily" else 366
+        if days > max_days:
+            return (
+                f"Date range too large ({days} days). Maximum is {max_days} "
+                f"days for {aggregation} aggregation."
+            )
+
+        try:
+            data = garmin_client.get_running_tolerance(
+                start_date, end_date, aggregation=aggregation
+            )
+        except Exception as e:
+            return f"Error retrieving running tolerance trend: {str(e)}"
+
+        if not data:
+            return "Your device does not support this metric."
+
+        trend = []
+        for entry in data:
+            if aggregation == "daily":
+                tolerance = entry.get("acuteTolerance")
+                acute_load = entry.get("acuteImpactLoad")
+                distance = entry.get("acuteDistance")
+            else:
+                tolerance = entry.get("tolerance")
+                acute_load = entry.get("totalImpactLoad")
+                distance = entry.get("totalDistance")
+
+            point: Dict[str, Any] = {"date": entry.get("calendarDate")}
+            if tolerance is not None:
+                point["tolerance_km"] = round(tolerance / 1000, 2)
+            if acute_load is not None:
+                point["acute_load_km"] = round(acute_load / 1000, 2)
+            if distance is not None:
+                point["distance_km"] = round(distance / 1000, 2)
+            if acute_load is not None and distance:
+                point["load_ratio"] = round(acute_load / distance, 2)
+
+            if aggregation == "daily":
+                feedback = entry.get("runningToleranceFeedBackPhrase")
+                if feedback:
+                    point["feedback_phrase"] = feedback
+            else:
+                if entry.get("startOfWeek") is not None:
+                    point["start_of_week"] = entry.get("startOfWeek")
+                if entry.get("endOfWeek") is not None:
+                    point["end_of_week"] = entry.get("endOfWeek")
+                if entry.get("weekIndex") is not None:
+                    point["week_index"] = entry.get("weekIndex")
+
+            trend.append(point)
+
+        # The daily aggregation is not returned in chronological order by the API.
+        trend.sort(key=lambda p: p.get("date") or "")
+
+        tolerance_values = [p["tolerance_km"] for p in trend if "tolerance_km" in p]
+        first_tolerance = tolerance_values[0] if tolerance_values else None
+        latest_tolerance = tolerance_values[-1] if tolerance_values else None
+        change = (
+            round(latest_tolerance - first_tolerance, 2)
+            if first_tolerance is not None and latest_tolerance is not None
+            else None
+        )
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "aggregation": aggregation,
+            "data_points": len(trend),
+            "first_tolerance_km": first_tolerance,
+            "latest_tolerance_km": latest_tolerance,
+            "tolerance_change_km": change,
             "trend": trend,
         }, indent=2)
 

--- a/tests/fixtures/garmin_responses.py
+++ b/tests/fixtures/garmin_responses.py
@@ -972,3 +972,61 @@ MOCK_CYCLING_FTP = {
     "functionalThresholdPower": 294,
     "biometricSourceType": "CHANGE_LOG",
 }
+
+# Training - Running Tolerance
+# All three load fields are in meters despite the name — acuteImpactLoad is an
+# intensity-adjusted distance-equivalent, not an arbitrary load score.
+MOCK_RUNNING_TOLERANCE_DAILY = [
+    {
+        "userProfilePK": 12345678,
+        "calendarDate": "2024-01-15",
+        "acuteImpactLoad": 25000,
+        "acuteDistance": 22000,
+        "acuteTolerance": 34000,
+        "runningToleranceFeedBackPhrase": "MEDIUM_LOAD",
+    }
+]
+
+# Deliberately out of chronological order — the real API returns daily
+# aggregation this way, so the trend tool must sort it itself.
+MOCK_RUNNING_TOLERANCE_DAILY_TREND = [
+    {
+        "userProfilePK": 12345678,
+        "calendarDate": "2024-01-16",
+        "acuteImpactLoad": 26000,
+        "acuteDistance": 23000,
+        "acuteTolerance": 34500,
+        "runningToleranceFeedBackPhrase": "MEDIUM_LOAD",
+    },
+    {
+        "userProfilePK": 12345678,
+        "calendarDate": "2024-01-15",
+        "acuteImpactLoad": 25000,
+        "acuteDistance": 22000,
+        "acuteTolerance": 34000,
+        "runningToleranceFeedBackPhrase": "MEDIUM_LOAD",
+    },
+]
+
+MOCK_RUNNING_TOLERANCE_WEEKLY = [
+    {
+        "userProfilePK": 12345678,
+        "calendarDate": "2024-01-08",
+        "totalImpactLoad": 26000,
+        "totalDistance": 24000.0,
+        "tolerance": 33000,
+        "startOfWeek": "2024-01-02",
+        "endOfWeek": "2024-01-08",
+        "weekIndex": 1900,
+    },
+    {
+        "userProfilePK": 12345678,
+        "calendarDate": "2024-01-15",
+        "totalImpactLoad": 28000,
+        "totalDistance": 26000.0,
+        "tolerance": 34000,
+        "startOfWeek": "2024-01-09",
+        "endOfWeek": "2024-01-15",
+        "weekIndex": 1901,
+    },
+]

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -19,6 +19,9 @@ from tests.fixtures.garmin_responses import (
     MOCK_CYCLING_FTP,
     MOCK_ENDURANCE_SCORE,
     MOCK_ACTIVITY_TYPES,
+    MOCK_RUNNING_TOLERANCE_DAILY,
+    MOCK_RUNNING_TOLERANCE_DAILY_TREND,
+    MOCK_RUNNING_TOLERANCE_WEEKLY,
 )
 
 
@@ -716,6 +719,165 @@ async def test_get_training_status_includes_cycling_vo2_max(app_with_training, m
     except (json.JSONDecodeError, AttributeError):
         # Tool may return raw text; just check the values appear in output
         assert "55.0" in text or "55.12" in text
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_tool(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance tool converts meters to km and computes load_ratio"""
+    mock_garmin_client.get_running_tolerance.return_value = MOCK_RUNNING_TOLERANCE_DAILY
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance",
+        {"date": "2024-01-15"}
+    )
+
+    assert result is not None
+    mock_garmin_client.get_running_tolerance.assert_called_once_with(
+        "2024-01-15", "2024-01-15", aggregation="daily"
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["date"] == "2024-01-15"
+    assert data["tolerance_km"] == 34.0
+    assert data["acute_load_km"] == 25.0
+    assert data["distance_km"] == 22.0
+    assert data["load_ratio"] == round(25000 / 22000, 2)
+    assert data["feedback_phrase"] == "MEDIUM_LOAD"
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_unsupported_device(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance tool when the account/device has no Running Tolerance data"""
+    mock_garmin_client.get_running_tolerance.return_value = []
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance",
+        {"date": "2024-01-15"}
+    )
+
+    assert result is not None
+    assert result[0][0].text == "Your device does not support this metric."
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_error(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance tool when the API raises an exception"""
+    mock_garmin_client.get_running_tolerance.side_effect = Exception("API Error")
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance",
+        {"date": "2024-01-15"}
+    )
+
+    assert result is not None
+    assert "Error retrieving running tolerance data" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_trend_daily_sorts_by_date(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance_trend sorts the unordered daily response"""
+    mock_garmin_client.get_running_tolerance.return_value = MOCK_RUNNING_TOLERANCE_DAILY_TREND
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance_trend",
+        {"start_date": "2024-01-15", "end_date": "2024-01-16", "aggregation": "daily"}
+    )
+
+    assert result is not None
+    mock_garmin_client.get_running_tolerance.assert_called_once_with(
+        "2024-01-15", "2024-01-16", aggregation="daily"
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["aggregation"] == "daily"
+    assert data["data_points"] == 2
+    assert [p["date"] for p in data["trend"]] == ["2024-01-15", "2024-01-16"]
+    assert data["first_tolerance_km"] == 34.0
+    assert data["latest_tolerance_km"] == 34.5
+    assert data["tolerance_change_km"] == 0.5
+    assert data["trend"][0]["feedback_phrase"] == "MEDIUM_LOAD"
+    assert "start_of_week" not in data["trend"][0]
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_trend_weekly_default(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance_trend defaults to weekly aggregation"""
+    mock_garmin_client.get_running_tolerance.return_value = MOCK_RUNNING_TOLERANCE_WEEKLY
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance_trend",
+        {"start_date": "2024-01-02", "end_date": "2024-01-15"}
+    )
+
+    assert result is not None
+    mock_garmin_client.get_running_tolerance.assert_called_once_with(
+        "2024-01-02", "2024-01-15", aggregation="weekly"
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["aggregation"] == "weekly"
+    week = data["trend"][0]
+    assert week["start_of_week"] == "2024-01-02"
+    assert week["end_of_week"] == "2024-01-08"
+    assert week["week_index"] == 1900
+    assert week["tolerance_km"] == 33.0
+    assert week["acute_load_km"] == 26.0
+    assert week["distance_km"] == 24.0
+    assert "feedback_phrase" not in week
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_trend_unsupported_device(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance_trend when the account/device has no data"""
+    mock_garmin_client.get_running_tolerance.return_value = []
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance_trend",
+        {"start_date": "2024-01-01", "end_date": "2024-01-07"}
+    )
+
+    assert result is not None
+    assert result[0][0].text == "Your device does not support this metric."
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_trend_error(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance_trend when the API raises an exception"""
+    mock_garmin_client.get_running_tolerance.side_effect = Exception("API Error")
+
+    result = await app_with_training.call_tool(
+        "get_running_tolerance_trend",
+        {"start_date": "2024-01-01", "end_date": "2024-01-07"}
+    )
+
+    assert result is not None
+    assert "Error retrieving running tolerance trend" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_trend_invalid_range(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance_trend rejects end_date before start_date"""
+    result = await app_with_training.call_tool(
+        "get_running_tolerance_trend",
+        {"start_date": "2024-01-15", "end_date": "2024-01-01"}
+    )
+
+    assert result is not None
+    assert "end_date must be on or after start_date" in result[0][0].text
+    mock_garmin_client.get_running_tolerance.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_running_tolerance_trend_daily_range_too_large(app_with_training, mock_garmin_client):
+    """Test get_running_tolerance_trend enforces the 90-day cap for daily aggregation"""
+    result = await app_with_training.call_tool(
+        "get_running_tolerance_trend",
+        {"start_date": "2024-01-01", "end_date": "2024-04-15", "aggregation": "daily"}
+    )
+
+    assert result is not None
+    assert "Date range too large" in result[0][0].text
+    mock_garmin_client.get_running_tolerance.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes #239.

Adds two tools for Garmin's Running Tolerance metric — running load capacity
vs. the load recent runs have actually produced. Mirrors the existing
HRV/VO2max/respiration data + trend pattern already in this file.

## New tools

- `get_running_tolerance(date)` — single-day tolerance, acute load, and
  distance, plus the derived load_ratio and Garmin's feedback phrase
- `get_running_tolerance_trend(start_date, end_date, aggregation="daily"|"weekly")`
  — the same metrics over a range, in one ranged API call

Both tools:

- Convert Garmin's raw meter values to km (`tolerance_km`, `acute_load_km`,
  `distance_km`)
- Compute `load_ratio` (acute_load_km / distance_km) — how much intensity
  inflates the cost of each kilometer run, requested directly in the issue
- Return `"Your device does not support this metric."` when the
  account/device has no Running Tolerance data, instead of an empty or
  confusing payload — verified against a live account with real activity
  history and a real paired device, which returns an empty list (not an
  exception) when the metric is unsupported
- Normalize daily and weekly aggregation to a shared schema (`tolerance_km`,
  `acute_load_km`, `distance_km`, `load_ratio`), while keeping each
  aggregation's own extra fields (`feedback_phrase` for daily;
  `start_of_week`/`end_of_week`/`week_index` for weekly)

Notes for review:

- One endpoint backs both tools: `get_running_tolerance(date, date,
  aggregation="daily")` for the single-day tool, and the same call rangeified
  for the trend tool.
- The trend tool's `MAX_DAYS` guardrail differs from the other trend tools in
  this file (`get_hrv_trend`, `get_respiration_trend`,
  `get_training_load_trend`): those loop one API call per day, so their cap
  protects against request volume. This endpoint returns the whole range in a
  single call, so the cap here protects output size instead — 90 days for
  `daily`, 366 for `weekly` (weekly aggregation returns ~7x fewer rows for
  the same range).
- Garmin's daily aggregation is not returned in chronological order; the
  trend tool sorts it before returning.

## Tests

- 9 new integration tests covering the happy path, unsupported device/
  account, API errors, daily-vs-weekly field shape, out-of-order sorting,
  and date range validation
- All 9 tests pass

