### PR TITLE
fix(nutrition): separate query parameters from URL paths

### DIFF
--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -3,7 +3,6 @@ Nutrition/food logging functions for Garmin Connect MCP Server
 """
 import json
 from typing import Optional
-from urllib.parse import quote
 
 from garminconnect import GarminConnectConnectionError
 
@@ -165,12 +164,10 @@ def register_tools(app):
             limit: Maximum number of results per page (default 20)
         """
         try:
-            url = (
-                f"/nutrition-service/food/search"
-                f"?searchExpression={quote(query)}"
-                f"&start={start}&limit={limit}"
+            data = garmin_client.connectapi(
+                "/nutrition-service/food/search",
+                params={"searchExpression": query, "start": start, "limit": limit},
             )
-            data = garmin_client.connectapi(url)
             if not data:
                 return "No foods found."
 
@@ -236,13 +233,15 @@ def register_tools(app):
             limit: Maximum number of results (default 20)
         """
         try:
-            url = (
-                f"/nutrition-service/customFood"
-                f"?searchExpression={quote(search)}"
-                f"&start={start}&limit={limit}"
-                f"&includeContent=true"
+            data = garmin_client.connectapi(
+                "/nutrition-service/customFood",
+                params={
+                    "searchExpression": search,
+                    "start": start,
+                    "limit": limit,
+                    "includeContent": "true",
+                },
             )
-            data = garmin_client.connectapi(url)
             if not data:
                 return "No custom foods found."
             return json.dumps(data, indent=2)
@@ -435,12 +434,15 @@ def register_tools(app):
             existing_nutrition: dict = {}
             existing_brand: Optional[str] = None
             try:
-                search_url = (
-                    f"/nutrition-service/customFood"
-                    f"?searchExpression={quote(food_name)}"
-                    f"&start=0&limit=20&includeContent=true"
+                search_data = garmin_client.connectapi(
+                    "/nutrition-service/customFood",
+                    params={
+                        "searchExpression": food_name,
+                        "start": 0,
+                        "limit": 20,
+                        "includeContent": "true",
+                    },
                 )
-                search_data = garmin_client.connectapi(search_url)
                 foods = search_data.get("customFoods", []) if isinstance(search_data, dict) else []
                 for f in foods:
                     if str(f.get("foodMetaData", {}).get("foodId", "")) == food_id:
@@ -778,12 +780,15 @@ def register_tools(app):
             from datetime import datetime, timezone
 
             # 1. Search for existing custom food
-            search_url = (
-                f"/nutrition-service/customFood"
-                f"?searchExpression={quote(food_name)}"
-                f"&start=0&limit=10&includeContent=true"
+            search_data = garmin_client.connectapi(
+                "/nutrition-service/customFood",
+                params={
+                    "searchExpression": food_name,
+                    "start": 0,
+                    "limit": 10,
+                    "includeContent": "true",
+                },
             )
-            search_data = garmin_client.connectapi(search_url)
             foods = search_data.get("customFoods", []) if isinstance(search_data, dict) else []
 
             food_id = None
@@ -831,12 +836,15 @@ def register_tools(app):
                         serving_id = str(contents[0].get("servingId", ""))
                 # 204: no body — look up by name
                 if not food_id or not serving_id:
-                    lookup_url = (
-                        f"/nutrition-service/customFood"
-                        f"?searchExpression={quote(food_name)}"
-                        f"&start=0&limit=10&includeContent=true"
+                    lookup_data = garmin_client.connectapi(
+                        "/nutrition-service/customFood",
+                        params={
+                            "searchExpression": food_name,
+                            "start": 0,
+                            "limit": 10,
+                            "includeContent": "true",
+                        },
                     )
-                    lookup_data = garmin_client.connectapi(lookup_url)
                     lookup_foods = lookup_data.get("customFoods", []) if isinstance(lookup_data, dict) else []
                     for f in lookup_foods:
                         meta = f.get("foodMetaData", f)

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -6,7 +6,7 @@ Tests tools from:
 """
 import json
 import pytest
-from unittest.mock import Mock
+from unittest.mock import Mock, call
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import nutrition
@@ -173,7 +173,13 @@ async def test_get_custom_foods(app_with_nutrition, mock_garmin_client):
     result = await app_with_nutrition.call_tool("get_custom_foods", {})
     assert result is not None
     mock_garmin_client.connectapi.assert_called_once_with(
-        "/nutrition-service/customFood?searchExpression=&start=0&limit=20&includeContent=true"
+        "/nutrition-service/customFood",
+        params={
+            "searchExpression": "",
+            "start": 0,
+            "limit": 20,
+            "includeContent": "true",
+        },
     )
 
 
@@ -183,11 +189,17 @@ async def test_get_custom_foods_with_search(app_with_nutrition, mock_garmin_clie
     mock_garmin_client.connectapi.return_value = []
     result = await app_with_nutrition.call_tool(
         "get_custom_foods",
-        {"search": "cookie", "start": 0, "limit": 10}
+        {"search": "cookie & cream/é", "start": 0, "limit": 10}
     )
     assert result is not None
     mock_garmin_client.connectapi.assert_called_once_with(
-        "/nutrition-service/customFood?searchExpression=cookie&start=0&limit=10&includeContent=true"
+        "/nutrition-service/customFood",
+        params={
+            "searchExpression": "cookie & cream/é",
+            "start": 0,
+            "limit": 10,
+            "includeContent": "true",
+        },
     )
 
 
@@ -323,6 +335,15 @@ async def test_update_custom_food(app_with_nutrition, mock_garmin_client):
     assert payload["nutritionContents"][0]["carbs"] == "22"
     assert payload["nutritionContents"][0]["protein"] == "3"
     assert payload["nutritionContents"][0]["fat"] == "8"
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/customFood",
+        params={
+            "searchExpression": "Homemade Cookies Updated",
+            "start": 0,
+            "limit": 20,
+            "includeContent": "true",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -765,20 +786,33 @@ async def test_upsert_and_log_existing_food(app_with_nutrition, mock_garmin_clie
     assert item["foodId"] == "food001"
     assert item["servingId"] == "srv001"
     assert item["mealId"] == 20249  # BREAKFAST
+    assert mock_garmin_client.connectapi.call_args_list[0] == call(
+        "/nutrition-service/customFood",
+        params={
+            "searchExpression": "Greek Yogurt",
+            "start": 0,
+            "limit": 10,
+            "includeContent": "true",
+        },
+    )
 
 
 @pytest.mark.asyncio
 async def test_upsert_and_log_creates_new_food(app_with_nutrition, mock_garmin_client):
     """Test upsert_and_log creates food when not found then logs it"""
-    created_food = {
-        "foodMetaData": {"foodId": "food999", "foodName": "New Food"},
-        "nutritionContents": [{"servingId": "srv999"}],
-    }
     mock_garmin_client.connectapi.side_effect = [
         {"customFoods": []},  # search returns empty
+        {
+            "customFoods": [
+                {
+                    "foodMetaData": {"foodId": "food999", "foodName": "New Food"},
+                    "nutritionContents": [{"servingId": "srv999"}],
+                }
+            ]
+        },  # post-create lookup
         MOCK_MEALS,           # meal resolution
     ]
-    mock_garmin_client.client.put.side_effect = [created_food, {}]
+    mock_garmin_client.client.put.side_effect = [{}, {}]
     result = await app_with_nutrition.call_tool(
         "upsert_and_log",
         {
@@ -794,6 +828,26 @@ async def test_upsert_and_log_creates_new_food(app_with_nutrition, mock_garmin_c
     log_payload = mock_garmin_client.client.put.call_args_list[1][1]["json"]
     assert log_payload["foodLogItems"][0]["foodId"] == "food999"
     assert log_payload["foodLogItems"][0]["servingId"] == "srv999"
+    assert mock_garmin_client.connectapi.call_args_list[:2] == [
+        call(
+            "/nutrition-service/customFood",
+            params={
+                "searchExpression": "New Food",
+                "start": 0,
+                "limit": 10,
+                "includeContent": "true",
+            },
+        ),
+        call(
+            "/nutrition-service/customFood",
+            params={
+                "searchExpression": "New Food",
+                "start": 0,
+                "limit": 10,
+                "includeContent": "true",
+            },
+        ),
+    ]
 
 
 @pytest.mark.asyncio
@@ -990,7 +1044,7 @@ async def test_search_foods_returns_results(app_with_nutrition, mock_garmin_clie
 
     result = await app_with_nutrition.call_tool(
         "search_foods",
-        {"query": "Cheerios"},
+        {"query": "Cheerios & Oats/é"},
     )
     data = json.loads(result[0][0].text)
     assert data["count"] == 1
@@ -999,9 +1053,14 @@ async def test_search_foods_returns_results(app_with_nutrition, mock_garmin_clie
     assert data["results"][0]["brand"] == "General Mills"
     assert data["results"][0]["servings"][0]["calories"] == 100.0
     assert not data["has_more"]
-    mock_garmin_client.connectapi.assert_called_once()
-    called_url = mock_garmin_client.connectapi.call_args[0][0]
-    assert "Cheerios" in called_url
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/food/search",
+        params={
+            "searchExpression": "Cheerios & Oats/é",
+            "start": 0,
+            "limit": 20,
+        },
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -800,19 +800,15 @@ async def test_upsert_and_log_existing_food(app_with_nutrition, mock_garmin_clie
 @pytest.mark.asyncio
 async def test_upsert_and_log_creates_new_food(app_with_nutrition, mock_garmin_client):
     """Test upsert_and_log creates food when not found then logs it"""
+    created_food = {
+        "foodMetaData": {"foodId": "food999", "foodName": "New Food"},
+        "nutritionContents": [{"servingId": "srv999"}],
+    }
     mock_garmin_client.connectapi.side_effect = [
         {"customFoods": []},  # search returns empty
-        {
-            "customFoods": [
-                {
-                    "foodMetaData": {"foodId": "food999", "foodName": "New Food"},
-                    "nutritionContents": [{"servingId": "srv999"}],
-                }
-            ]
-        },  # post-create lookup
         MOCK_MEALS,           # meal resolution
     ]
-    mock_garmin_client.client.put.side_effect = [{}, {}]
+    mock_garmin_client.client.put.side_effect = [created_food, {}]
     result = await app_with_nutrition.call_tool(
         "upsert_and_log",
         {
@@ -828,26 +824,49 @@ async def test_upsert_and_log_creates_new_food(app_with_nutrition, mock_garmin_c
     log_payload = mock_garmin_client.client.put.call_args_list[1][1]["json"]
     assert log_payload["foodLogItems"][0]["foodId"] == "food999"
     assert log_payload["foodLogItems"][0]["servingId"] == "srv999"
-    assert mock_garmin_client.connectapi.call_args_list[:2] == [
-        call(
-            "/nutrition-service/customFood",
-            params={
-                "searchExpression": "New Food",
-                "start": 0,
-                "limit": 10,
-                "includeContent": "true",
-            },
-        ),
-        call(
-            "/nutrition-service/customFood",
-            params={
-                "searchExpression": "New Food",
-                "start": 0,
-                "limit": 10,
-                "includeContent": "true",
-            },
-        ),
+    assert mock_garmin_client.connectapi.call_args_list[0] == call(
+        "/nutrition-service/customFood",
+        params={
+            "searchExpression": "New Food",
+            "start": 0,
+            "limit": 10,
+            "includeContent": "true",
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_and_log_recovers_ids_after_bodyless_create(app_with_nutrition, mock_garmin_client):
+    """Test upsert_and_log looks up IDs after a bodyless create response."""
+    mock_garmin_client.connectapi.side_effect = [
+        {"customFoods": []},  # search returns empty
+        MOCK_CUSTOM_FOODS,      # post-create lookup
+        MOCK_MEALS,              # meal resolution
     ]
+    mock_garmin_client.client.put.side_effect = [{}, {}]
+    result = await app_with_nutrition.call_tool(
+        "upsert_and_log",
+        {
+            "meal_date": "2024-01-15",
+            "meal_time": "12:00:00",
+            "food_name": "Greek Yogurt",
+            "calories": 200,
+        }
+    )
+    assert "Food logged successfully" in result[0][0].text
+    log_payload = mock_garmin_client.client.put.call_args_list[1][1]["json"]
+    assert log_payload["foodLogItems"][0]["foodId"] == "food001"
+    assert log_payload["foodLogItems"][0]["servingId"] == "srv001"
+    expected_lookup = call(
+        "/nutrition-service/customFood",
+        params={
+            "searchExpression": "Greek Yogurt",
+            "start": 0,
+            "limit": 10,
+            "includeContent": "true",
+        },
+    )
+    assert mock_garmin_client.connectapi.call_args_list[:2] == [expected_lookup, expected_lookup]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #263 via clean apply.

Uses the `params={}` kwarg of `connectapi()` for all nutrition search and lookup calls instead of manually URL-encoding query strings with `urllib.parse.quote`. This lets the underlying HTTP client (requests) handle encoding correctly, avoids potential URL injection, and simplifies the code.

Changes:
- `search_foods`: `params={"searchExpression": query, "start": start, "limit": limit}`
- `get_custom_foods`: same pattern
- `update_custom_food` (internal search): same pattern
- `upsert_and_log` (internal search, twice): same pattern
- Test: updated assertion to use keyword argument form; added special characters to the test query to confirm they pass through correctly

All 495 integration + unit tests pass.

Co-authored-by: wouterrodeyns <wouterrodeyns@users.noreply.github.com>