### PR TITLE
fix(workouts): emit repeat groups so multi-set strength exercises keep their set count

### DIFF
--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -261,11 +261,14 @@ def build_strength_json(
 ) -> dict:
     """Build the Garmin Connect JSON for a strength workout.
 
-    Each exercise becomes a reps-based work step. The name is preserved in the step
-    "description", which is what survives the round trip. It is also sent as
-    "exerciseName", but Garmin only retains that when it matches one of its own
-    exercise keys (e.g. "FARMERS_CARRY"); any other value is accepted and then
-    stored as an empty string.
+    Each exercise becomes a reps-based work step. When "sets" > 1 the exercise is
+    emitted as a RepeatGroupDTO iterated that many times (work + rest per set), so
+    Garmin shows the real set count — previously "sets" only ever reached the
+    description text and every exercise displayed as 1 set. The name is preserved
+    in the step "description", which is what survives the round trip. It is also
+    sent as "exerciseName", but Garmin only retains that when it matches one of
+    its own exercise keys (e.g. "FARMERS_CARRY"); any other value is accepted and
+    then stored as an empty string.
 
     "category" is optional and only emitted when the caller supplies one, uppercased
     and otherwise passed through untouched. Garmin validates it against its own enum
@@ -304,6 +307,37 @@ def build_strength_json(
                     f"category for exercise {ex_name!r} must be a non-empty string"
                 )
             step["category"] = category.strip().upper()
+
+        if sets > 1:
+            # N sets = a repeat group iterated N times (work + rest per iteration).
+            # The explicit stepTypeId 6 / endCondition "iterations" shape matches
+            # what _sanitize_repeat_group enforces on the upload path: the Garmin
+            # API silently corrupts a RepeatGroupDTO without a valid iterations
+            # endCondition.
+            group_steps = [{**step, "stepOrder": 1}]
+            if rest_seconds > 0:
+                group_steps.append({
+                    "type": "ExecutableStepDTO",
+                    "stepOrder": 2,
+                    "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
+                    "description": f"Rest {rest_seconds}s",
+                    "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
+                    "endConditionValue": float(rest_seconds),
+                    "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+                })
+            steps.append({
+                "type": "RepeatGroupDTO",
+                "stepOrder": step_order,
+                "stepType": {"stepTypeId": 6, "stepTypeKey": "repeat"},
+                "numberOfIterations": sets,
+                "smartRepeat": False,
+                "endCondition": {"conditionTypeId": 7, "conditionTypeKey": "iterations"},
+                "workoutSteps": group_steps,
+            })
+            step_order += 1
+            # The in-group rest after the final set already separates this exercise
+            # from the next one — no extra inter-exercise rest step.
+            continue
 
         steps.append(step)
         step_order += 1
@@ -487,7 +521,9 @@ def register_tools(app):
     ) -> str:
         """Create a strength workout and upload it to Garmin Connect.
 
-        Each exercise becomes a reps-based step. The name is kept in the step
+        Each exercise becomes a reps-based step; when sets > 1 the exercise is
+        emitted as a repeat group of that many iterations (work + rest per set),
+        so Garmin shows the real set count. The name is kept in the step
         description; it is also sent as exerciseName, which Garmin only retains when
         it matches one of its own exercise keys (e.g. "FARMERS_CARRY").
 

--- a/tests/unit/test_workout_builders.py
+++ b/tests/unit/test_workout_builders.py
@@ -125,10 +125,60 @@ def test_build_strength_json_structure():
     assert result["sportType"]["sportTypeKey"] == "strength_training"
     assert result["sportType"]["sportTypeId"] == 5
     steps = result["workoutSegments"][0]["workoutSteps"]
-    # 2 exercises + 1 rest between them = 3 steps
+    # Multi-set exercises each become one repeat group; rest lives inside the
+    # group (after every set), so no separate inter-exercise rest step.
+    assert len(steps) == 2
+    assert [s["type"] for s in steps] == ["RepeatGroupDTO", "RepeatGroupDTO"]
+    assert steps[0]["numberOfIterations"] == 3
+    assert steps[0]["workoutSteps"][0]["exerciseName"] == "Sentadillas"
+    assert steps[1]["workoutSteps"][0]["exerciseName"] == "Flexiones"
+
+
+def test_strength_single_set_stays_flat():
+    result = build_strength_json(
+        name="Singles",
+        exercises=[
+            {"name": "Plank Hold", "sets": 1, "reps": 1, "rest_seconds": 60},
+            {"name": "Dead Hang", "sets": 1, "reps": 1, "rest_seconds": 0},
+        ],
+    )
+    steps = result["workoutSegments"][0]["workoutSteps"]
+    # 2 flat work steps + 1 rest between them; no repeat group for a single set
     assert len(steps) == 3
-    assert steps[0]["exerciseName"] == "Sentadillas"
-    assert steps[2]["exerciseName"] == "Flexiones"
+    assert [s["type"] for s in steps] == ["ExecutableStepDTO"] * 3
+    assert steps[0]["exerciseName"] == "Plank Hold"
+    assert steps[1]["stepType"]["stepTypeKey"] == "recovery"
+
+
+def test_strength_multi_set_repeat_group_shape():
+    result = build_strength_json(
+        name="Sets",
+        exercises=[{"name": "Goblet Squat", "sets": 4, "reps": 8, "rest_seconds": 90}],
+    )
+    (group,) = result["workoutSegments"][0]["workoutSteps"]
+    # The shape _sanitize_repeat_group enforces on upload: without a valid
+    # iterations endCondition the Garmin API silently corrupts the group.
+    assert group["type"] == "RepeatGroupDTO"
+    assert group["stepType"] == {"stepTypeId": 6, "stepTypeKey": "repeat"}
+    assert group["numberOfIterations"] == 4
+    assert group["endCondition"]["conditionTypeKey"] == "iterations"
+    work, rest = group["workoutSteps"]
+    assert work["endCondition"]["conditionTypeKey"] == "reps"
+    assert work["endConditionValue"] == 8.0
+    assert "4 sets x 8 reps" in work["description"]
+    assert rest["stepType"]["stepTypeKey"] == "recovery"
+    assert rest["endConditionValue"] == 90.0
+
+
+def test_strength_multi_set_without_rest_has_no_recovery_step():
+    result = build_strength_json(
+        name="No rest",
+        exercises=[{"name": "Push Up", "sets": 3, "reps": 12, "rest_seconds": 0}],
+    )
+    (group,) = result["workoutSegments"][0]["workoutSteps"]
+    assert group["numberOfIterations"] == 3
+    assert len(group["workoutSteps"]) == 1
+    assert group["workoutSteps"][0]["stepType"]["stepTypeKey"] == "interval"
 
 
 # ---------------------------------------------------------------------------
@@ -141,9 +191,18 @@ def test_build_strength_json_structure():
 
 
 def _work_steps(result):
-    """Only the exercise steps; rest steps are recovery steps and carry no category."""
+    """Only the exercise steps; rest steps are recovery steps and carry no category.
+
+    Multi-set exercises nest their work step inside a RepeatGroupDTO, so look
+    through repeat groups as well as at top-level steps.
+    """
     steps = result["workoutSegments"][0]["workoutSteps"]
-    return [s for s in steps if s["stepType"]["stepTypeKey"] == "interval"]
+    flat = []
+    for s in steps:
+        for child in s.get("workoutSteps", [s]):
+            if child["stepType"]["stepTypeKey"] == "interval":
+                flat.append(child)
+    return flat
 
 
 def test_strength_omits_category_when_not_supplied():


### PR DESCRIPTION
Closes #273 via clean apply.

`create_strength_workout` / `build_strength_json` previously put the sets value only in the step description text and always uploaded every exercise as 1 set. Garmin Connect showed "1 set" regardless of how many sets were specified.

Fix: when `sets > 1`, wrap the work step (and optional rest step) inside a `RepeatGroupDTO` iterated `sets` times. The repeat group shape matches what `_sanitize_repeat_group` enforces on the upload path: `stepTypeId=6 / conditionTypeKey="iterations"`. Single-set exercises remain flat steps for backward compatibility.

Co-authored-by: cmatte <cmatte@users.noreply.github.com>