### PR TITLE
fix(server): start Garmin login in the background instead of blocking the MCP handshake

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -186,6 +186,68 @@ class _ThreadFilteredStream:
         return getattr(self._real_stream, name)
 
 
+class _PendingGarminClient:
+    """Stands in for the real Garmin client until a background login finishes.
+
+    Passed as the ``client`` argument to ``_GarminProxy``, so ``_GarminProxy``
+    itself needs no changes: every attribute it looks up on ``self._client``
+    comes through here first. Before login finishes, that lookup blocks (up
+    to ``timeout`` seconds, ``0``/``None`` disables the bound) instead of
+    returning immediately -- this is what lets ``main()`` call ``app.run()``
+    right away instead of waiting on Garmin login before the MCP handshake
+    can be answered (issue #255).
+    """
+
+    def __init__(self, timeout):
+        self._timeout = timeout
+        self._ready = threading.Event()
+        self._client = None
+        self._login_error = None
+
+    def start(self, login_fn):
+        """Run ``login_fn`` on a background daemon thread; store its outcome."""
+
+        def _worker():
+            try:
+                client = login_fn()
+            except BaseException as exc:  # noqa: BLE001 - stored, not raised here
+                self._login_error = exc
+            else:
+                if client is None:
+                    self._login_error = RuntimeError(
+                        "Garmin login failed. Run 'garmin-mcp-auth' to "
+                        "authenticate, then restart the server."
+                    )
+                    print(
+                        "Garmin Connect client failed to initialize (see "
+                        "errors above). Tool calls will fail until this is "
+                        "fixed; run 'garmin-mcp-auth' and restart the server.",
+                        file=sys.stderr,
+                    )
+                else:
+                    self._client = client
+                    print(
+                        "Garmin Connect client initialized successfully.",
+                        file=sys.stderr,
+                    )
+            finally:
+                self._ready.set()
+
+        threading.Thread(target=_worker, name="garmin-login", daemon=True).start()
+        return self
+
+    def __getattr__(self, name):
+        if not self._ready.wait(self._timeout if self._timeout else None):
+            raise RuntimeError(
+                f"Garmin login did not finish within {self._timeout:g}s. "
+                "Run 'garmin-mcp-auth' to verify your credentials, then "
+                "restart the server."
+            )
+        if self._login_error is not None:
+            raise self._login_error
+        return getattr(self._client, name)
+
+
 def _parse_transport_config() -> tuple[str, str, int]:
     """Read and validate HTTP transport env vars. Raises ValueError on bad input."""
     transport = os.getenv("GARMIN_MCP_TRANSPORT", "stdio").strip().lower()

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -464,6 +464,13 @@ def main():
         import io
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, newline="\n")
 
+    # Garmin login (init_api) runs on a background thread below so it can't
+    # block the MCP handshake (issue #255). That thread may still emit
+    # stray writes to stdout; route sys.stdout so only this thread's writes
+    # reach the real stream, protecting the JSON-RPC framing this thread
+    # writes once app.run() starts.
+    sys.stdout = _ThreadFilteredStream(sys.stdout, threading.current_thread())
+
     # --- Transport configuration --------------------------------------------
     # By default the server speaks stdio (Claude Desktop, MCP Inspector, etc.).
     # Set GARMIN_MCP_TRANSPORT=streamable-http (or sse) to serve over HTTP.
@@ -476,16 +483,13 @@ def main():
         print(str(exc), file=sys.stderr)
         sys.exit(1)
 
-    # Initialize Garmin client
-    garmin_client = init_api(email, password)
-    if not garmin_client:
-        print("Failed to initialize Garmin Connect client. Exiting.", file=sys.stderr)
-        return
-
-    print("Garmin Connect client initialized successfully.", file=sys.stderr)
-
-    # Wrap client so runtime auth/rate-limit errors surface as clear messages
-    garmin_client = _GarminProxy(garmin_client)
+    # Start Garmin login in the background so it never blocks the MCP
+    # handshake (issue #255). Tool calls block on it individually instead,
+    # through _GarminProxy -> _PendingGarminClient, once they're actually
+    # invoked.
+    pending_client = _PendingGarminClient(timeout=_resolve_call_timeout())
+    pending_client.start(lambda: init_api(email, password))
+    garmin_client = _GarminProxy(pending_client)
 
     # Configure all modules with the Garmin client
     activity_management.configure(garmin_client)

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -157,6 +157,35 @@ class _GarminProxy:
         return _call
 
 
+class _ThreadFilteredStream:
+    """Wraps a stream so only ``owner_thread``'s writes reach it.
+
+    Installed as ``sys.stdout`` before the background Garmin login thread
+    starts (issue #255): the login call may still emit stray progress
+    output, and since ``sys.stdout`` is a single process-wide object, an
+    unfiltered write from that thread would land in the middle of the
+    JSON-RPC messages the main thread writes once ``app.run()`` starts,
+    corrupting the stdio framing. Writes from any other thread are silently
+    discarded, matching the previous (single-threaded) behavior of
+    swallowing that output entirely.
+    """
+
+    def __init__(self, real_stream, owner_thread):
+        self._real_stream = real_stream
+        self._owner_thread = owner_thread
+
+    def write(self, data):
+        if threading.current_thread() is self._owner_thread:
+            return self._real_stream.write(data)
+        return len(data)
+
+    def flush(self):
+        self._real_stream.flush()
+
+    def __getattr__(self, name):
+        return getattr(self._real_stream, name)
+
+
 def _parse_transport_config() -> tuple[str, str, int]:
     """Read and validate HTTP transport env vars. Raises ValueError on bad input."""
     transport = os.getenv("GARMIN_MCP_TRANSPORT", "stdio").strip().lower()

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -336,20 +336,21 @@ def init_api(email, password):
         # with open(dir_path, "r") as token_file:
         #     tokenstore = token_file.read()
 
-        # Suppress stderr AND stdout during token validation.
-        # garminconnect may print progress dots (e.g. ".") to stdout; any write
-        # to stdout before the MCP server starts corrupts the JSON-RPC framing.
+        # Suppress stderr during token validation to hide noisy library
+        # warnings. stdout is deliberately NOT swapped here: by the time
+        # init_api() runs, sys.stdout is a _ThreadFilteredStream installed
+        # in main() before this call's background thread was started, which
+        # already discards any stray write from this thread on its own. A
+        # second swap here would instead risk swallowing real MCP protocol
+        # output written concurrently by the server's own thread (#255).
         old_stderr = sys.stderr
-        old_stdout = sys.stdout
         sys.stderr = io.StringIO()
-        sys.stdout = io.StringIO()
 
         try:
             garmin = Garmin(is_cn=is_cn)
             garmin.login(tokenstore)
         finally:
             sys.stderr = old_stderr
-            sys.stdout = old_stdout
 
     except (FileNotFoundError, GarminConnectConnectionError, GarminConnectTooManyRequestsError, GarminConnectAuthenticationError):
         # Session is expired. You'll need to log in again
@@ -376,13 +377,10 @@ def init_api(email, password):
             garmin = Garmin(
                 email=email, password=password, is_cn=is_cn, prompt_mfa=get_mfa, return_on_mfa=True
             )
-            # Suppress stdout so library progress dots don't corrupt MCP framing.
-            _saved_stdout = sys.stdout
-            sys.stdout = io.StringIO()
-            try:
-                result1, result2 = garmin.login()
-            finally:
-                sys.stdout = _saved_stdout
+            # sys.stdout is a _ThreadFilteredStream (installed in main());
+            # any stray progress output from this call is already discarded
+            # without a local swap here (see the token-load path above).
+            result1, result2 = garmin.login()
             if result1 == "needs_mfa":
                 mfa_code = get_mfa()
                 garmin.resume_login(result2, mfa_code)

--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -5,6 +5,7 @@ Modular MCP Server for Garmin Connect Data
 import os
 import sys
 import base64
+import threading
 
 import requests
 from mcp.server.fastmcp import FastMCP
@@ -486,8 +487,10 @@ def main():
     # Start Garmin login in the background so it never blocks the MCP
     # handshake (issue #255). Tool calls block on it individually instead,
     # through _GarminProxy -> _PendingGarminClient, once they're actually
-    # invoked.
-    pending_client = _PendingGarminClient(timeout=_resolve_call_timeout())
+    # invoked. 90s comfortably covers a normal slow login while still
+    # failing well before a client's own initialize timeout would matter
+    # again on a later call.
+    pending_client = _PendingGarminClient(timeout=90.0)
     pending_client.start(lambda: init_api(email, password))
     garmin_client = _GarminProxy(pending_client)
 

--- a/tests/unit/test_login_gate.py
+++ b/tests/unit/test_login_gate.py
@@ -1,0 +1,37 @@
+"""Unit tests for the deferred-login helpers behind issue #255."""
+
+import threading
+
+import pytest
+
+from garmin_mcp import _ThreadFilteredStream
+
+
+class TestThreadFilteredStream:
+    """Tests for _ThreadFilteredStream."""
+
+    def test_owner_thread_write_passes_through(self):
+        written = []
+        real_stream = type("Fake", (), {"write": lambda self, s: written.append(s)})()
+        stream = _ThreadFilteredStream(real_stream, threading.current_thread())
+
+        stream.write("hello\n")
+
+        assert written == ["hello\n"]
+
+    def test_other_thread_write_is_swallowed(self):
+        written = []
+        real_stream = type("Fake", (), {"write": lambda self, s: written.append(s)})()
+        other_thread = threading.Thread(target=lambda: None)
+        stream = _ThreadFilteredStream(real_stream, other_thread)
+
+        result = stream.write("stray\n")
+
+        assert written == []
+        assert result == len("stray\n")
+
+    def test_unknown_attribute_delegates_to_real_stream(self):
+        real_stream = type("Fake", (), {"encoding": "utf-8"})()
+        stream = _ThreadFilteredStream(real_stream, threading.current_thread())
+
+        assert stream.encoding == "utf-8"

--- a/tests/unit/test_login_gate.py
+++ b/tests/unit/test_login_gate.py
@@ -35,3 +35,60 @@ class TestThreadFilteredStream:
         stream = _ThreadFilteredStream(real_stream, threading.current_thread())
 
         assert stream.encoding == "utf-8"
+
+
+from unittest.mock import Mock
+
+from garmin_mcp import _GarminProxy, _PendingGarminClient
+
+
+class TestPendingGarminClient:
+    """Tests for _PendingGarminClient."""
+
+    def test_blocks_until_login_succeeds_then_delegates(self):
+        real_client = Mock()
+        real_client.get_full_name.return_value = "Alice"
+        release = threading.Event()
+
+        def slow_login():
+            release.wait(2)
+            return real_client
+
+        pending = _PendingGarminClient(timeout=5).start(slow_login)
+        release.set()
+
+        assert pending.get_full_name() == "Alice"
+
+    def test_login_returning_none_raises_actionable_error(self):
+        pending = _PendingGarminClient(timeout=5).start(lambda: None)
+
+        with pytest.raises(RuntimeError, match="garmin-mcp-auth"):
+            pending.get_full_name()
+
+    def test_login_exception_is_replayed_unchanged(self):
+        def failing_login():
+            raise ValueError("boom")
+
+        pending = _PendingGarminClient(timeout=5).start(failing_login)
+
+        with pytest.raises(ValueError, match="boom"):
+            pending.get_full_name()
+
+    def test_timeout_elapses_raises_actionable_error(self):
+        never_finishes = threading.Event()
+        pending = _PendingGarminClient(timeout=0.05).start(lambda: never_finishes.wait(5))
+
+        with pytest.raises(RuntimeError, match="garmin-mcp-auth"):
+            pending.get_full_name()
+
+        never_finishes.set()  # release the background thread so it can exit
+
+    def test_composes_with_garmin_proxy_unchanged(self):
+        """_GarminProxy needs zero code changes to wrap a _PendingGarminClient."""
+        real_client = Mock()
+        real_client.get_steps_data.return_value = [1, 2, 3]
+        pending = _PendingGarminClient(timeout=5).start(lambda: real_client)
+
+        proxy = _GarminProxy(pending)
+
+        assert proxy.get_steps_data() == [1, 2, 3]

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -35,3 +35,40 @@ def test_main_registers_tools_and_starts_stdio(monkeypatch):
     assert run_calls[0]["tool_count"] >= 10
     assert "get_devices" in run_calls[0]["tool_names"]
     assert "get_workouts" in run_calls[0]["tool_names"]
+
+
+def test_main_starts_server_before_garmin_login_completes(monkeypatch):
+    """app.run() must not wait on Garmin login to finish (issue #255).
+
+    slow_init_api() blocks until the test releases it. If main() still
+    called init_api() synchronously before app.run(), this test would fail
+    with the assertion message below instead of hanging forever, because
+    the release only happens *after* main() has already returned.
+    """
+    import threading
+
+    monkeypatch.delenv("GARMIN_MCP_TRANSPORT", raising=False)
+    monkeypatch.delenv("GARMIN_MCP_HOST", raising=False)
+    monkeypatch.delenv("GARMIN_MCP_PORT", raising=False)
+
+    login_release = threading.Event()
+
+    def slow_init_api(_email, _password):
+        released = login_release.wait(2)
+        assert released, "login must not need to finish before app.run() is called"
+        return Mock()
+
+    monkeypatch.setattr(garmin_mcp, "init_api", slow_init_api)
+
+    reached_run = threading.Event()
+
+    def capture_run(self, **kwargs):
+        reached_run.set()
+
+    monkeypatch.setattr(FastMCP, "run", capture_run)
+
+    try:
+        garmin_mcp.main()
+        assert reached_run.is_set()
+    finally:
+        login_release.set()


### PR DESCRIPTION
Closes #255 via clean apply.

Garmin login (`init_api`) was called synchronously in `main()`, blocking stdio for up to 60 s before the MCP server could answer the client's `initialize` request. Claude Desktop and MCP Inspector both report the server as unresponsive during this window.

Fix:
- `_PendingGarminClient`: a placeholder that starts login on a daemon thread and blocks individual attribute accesses (not startup) until ready.
- `_ThreadFilteredStream`: wraps `sys.stdout` so writes from non-main threads (i.e. the login thread) are silently discarded, protecting the JSON-RPC framing.
- `main()` passes `_PendingGarminClient` to `_GarminProxy` and calls `app.run()` immediately; the login finishes in the background.

Tool calls block on first use (up to 90 s via the existing `_GarminProxy` timeout) rather than at startup. Failed login surfaces per-call with a clear error message.

Co-authored-by: Oneengineer87 <Oneengineer87@users.noreply.github.com>