### PR TITLE
fix(training): correct lactate threshold speed unit conversion

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -723,10 +723,13 @@ def register_tools(app):
                 # Process speed history
                 speed_history = threshold.get("speed", [])
                 if speed_history:
+                    # Garmin returns speed as seconds/metre (inverse pace); invert to m/s.
                     curated["speed_history"] = [
                         {
                             "date": entry.get("from"),
-                            "speed_mps": entry.get("value"),
+                            "speed_mps": (
+                                1 / entry.get("value") if entry.get("value") else None
+                            ),
                             "series": entry.get("series"),
                         }
                         for entry in speed_history
@@ -760,9 +763,11 @@ def register_tools(app):
                 speed_hr = threshold.get("speed_and_heart_rate", {})
                 power = threshold.get("power", {})
 
+                raw_speed = speed_hr.get("speed")
                 curated = {
                     # Speed and heart rate data
-                    "lactate_threshold_speed_mps": speed_hr.get("speed"),
+                    # Garmin returns speed as seconds/metre (inverse pace); invert to m/s.
+                    "lactate_threshold_speed_mps": 1 / raw_speed if raw_speed else None,
                     "lactate_threshold_heart_rate_bpm": speed_hr.get("heartRate"),
                     "heart_rate_cycling_bpm": speed_hr.get("heartRateCycling"),
                     "speed_hr_date": speed_hr.get("calendarDate"),

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -749,7 +749,8 @@ async def test_get_lactate_threshold_tool_latest(app_with_training, mock_garmin_
 
     # Verify output structure
     data = json.loads(result[0][0].text)
-    assert data["lactate_threshold_speed_mps"] == 0.32222132
+    # Garmin returns speed as seconds/metre (inverse pace); the tool inverts it to m/s.
+    assert abs(data["lactate_threshold_speed_mps"] - 1 / 0.32222132) < 1e-6
     assert data["lactate_threshold_heart_rate_bpm"] == 169
     assert data["functional_threshold_power_watts"] == 334
     assert data["sport"] == "RUNNING"
@@ -783,6 +784,8 @@ async def test_get_lactate_threshold_tool_range(app_with_training, mock_garmin_c
     assert "speed_history" in data
     assert len(data["speed_history"]) == 3
     assert data["speed_history"][0]["date"] == "2024-01-08"
+    # Garmin returns speed as seconds/metre (inverse pace); the tool inverts it to m/s.
+    assert abs(data["speed_history"][0]["speed_mps"] - 1 / 0.29444) < 1e-4
     assert "heart_rate_history" in data
     assert len(data["heart_rate_history"]) == 3
     assert "power_history" in data


### PR DESCRIPTION
Garmin returns the threshold speed as seconds/metre (inverse pace), not metres/second. The tool was exposing the raw Garmin value, which appears as ~0.32 instead of the expected ~3.1 m/s.

Fix: invert with `1 / raw_speed` in both response shapes:
- `latest=True` → `lactate_threshold_speed_mps`  
- `latest=False` → each `speed_history[].speed_mps` entry

Tests updated to assert the inverted value.

Related: #272 (which bundled this fix with garminconnect 0.3.7 upgrade and Python 3.12 — applied here as a standalone fix instead).