### PR TITLE
fix(server): reject nonblank empty tool allowlists

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -106,8 +106,16 @@ def _parse_tool_set(value):
     return {name.strip().lower() for name in value.split(",") if name.strip()}
 
 
-enabled_tools = _parse_tool_set(os.getenv("GARMIN_ENABLED_TOOLS"))
-disabled_tools = _parse_tool_set(os.getenv("GARMIN_DISABLED_TOOLS"))
+def _resolve_tool_filters():
+    """Read and validate tool filter environment variables at server startup."""
+    enabled_value = os.getenv("GARMIN_ENABLED_TOOLS")
+    enabled_tools = _parse_tool_set(enabled_value)
+    if enabled_value and enabled_value.strip() and not enabled_tools:
+        raise ValueError(
+            "Invalid GARMIN_ENABLED_TOOLS: expected at least one tool name"
+        )
+    disabled_tools = _parse_tool_set(os.getenv("GARMIN_DISABLED_TOOLS"))
+    return enabled_tools, disabled_tools
 
 
 _VALID_TRANSPORTS = ("stdio", "streamable-http", "sse")
@@ -382,6 +390,7 @@ def main():
     #   GARMIN_MCP_HOST      - bind address for HTTP transports (default 127.0.0.1)
     #   GARMIN_MCP_PORT      - bind port for HTTP transports (default 8000)
     try:
+        enabled_tools, disabled_tools = _resolve_tool_filters()
         transport, http_host, http_port = _parse_transport_config()
     except ValueError as exc:
         print(str(exc), file=sys.stderr)

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -4,6 +4,7 @@ import asyncio
 from unittest.mock import Mock
 
 import garmin_mcp
+import pytest
 from mcp.server.fastmcp import FastMCP
 
 
@@ -35,3 +36,22 @@ def test_main_registers_tools_and_starts_stdio(monkeypatch):
     assert run_calls[0]["tool_count"] >= 10
     assert "get_devices" in run_calls[0]["tool_names"]
     assert "get_workouts" in run_calls[0]["tool_names"]
+
+
+def test_main_rejects_malformed_allowlist_before_garmin_initialization(
+    monkeypatch, capsys
+):
+    init_api = Mock()
+    monkeypatch.setenv("GARMIN_ENABLED_TOOLS", ",,  ,")
+    monkeypatch.setattr(garmin_mcp, "init_api", init_api)
+    monkeypatch.setattr(FastMCP, "run", lambda _self, **_kwargs: None)
+
+    with pytest.raises(SystemExit) as exc_info:
+        garmin_mcp.main()
+
+    assert exc_info.value.code == 1
+    assert (
+        "Invalid GARMIN_ENABLED_TOOLS: expected at least one tool name"
+        in capsys.readouterr().err
+    )
+    init_api.assert_not_called()

--- a/tests/unit/test_server_startup.py
+++ b/tests/unit/test_server_startup.py
@@ -15,6 +15,8 @@ def test_main_registers_tools_and_starts_stdio(monkeypatch):
     monkeypatch.delenv("GARMIN_MCP_TRANSPORT", raising=False)
     monkeypatch.delenv("GARMIN_MCP_HOST", raising=False)
     monkeypatch.delenv("GARMIN_MCP_PORT", raising=False)
+    monkeypatch.delenv("GARMIN_ENABLED_TOOLS", raising=False)
+    monkeypatch.delenv("GARMIN_DISABLED_TOOLS", raising=False)
     monkeypatch.setattr(garmin_mcp, "init_api", lambda _email, _password: Mock())
 
     def capture_run(self, **kwargs):

--- a/tests/unit/test_tool_filter.py
+++ b/tests/unit/test_tool_filter.py
@@ -1,5 +1,8 @@
 """Unit tests for the env-var tool filter (_ToolFilter)."""
 
+import pytest
+
+import garmin_mcp
 from garmin_mcp import _ToolFilter
 
 
@@ -39,6 +42,26 @@ def test_no_filter_registers_all():
     filt = _ToolFilter(app, set(), set())
     _register(filt, ["get_a", "get_b"])
     assert app.registered == ["get_a", "get_b"]
+
+
+def test_blank_allowlist_keeps_denylist_behavior(monkeypatch):
+    monkeypatch.setenv("GARMIN_ENABLED_TOOLS", "  \t")
+    monkeypatch.setenv("GARMIN_DISABLED_TOOLS", "get_b")
+
+    enabled, disabled = garmin_mcp._resolve_tool_filters()
+
+    assert enabled == set()
+    assert disabled == {"get_b"}
+
+
+def test_malformed_nonblank_allowlist_is_rejected(monkeypatch):
+    monkeypatch.setenv("GARMIN_ENABLED_TOOLS", ",,  ,")
+
+    with pytest.raises(
+        ValueError,
+        match="Invalid GARMIN_ENABLED_TOOLS: expected at least one tool name",
+    ):
+        garmin_mcp._resolve_tool_filters()
 
 
 def test_allowlist_only_registers_listed():


### PR DESCRIPTION
Closes #262 via clean apply.

A `GARMIN_ENABLED_TOOLS` value like `",,  ,"` (commas only) previously parsed to an empty set and silently behaved as if no allowlist was set, which was misleading. This PR rejects such values at startup with a clear error before Garmin login, so the misconfiguration is immediately visible rather than silently ignored.

Changes:
- New `_resolve_tool_filters()` validates the parsed result and raises `ValueError` if a non-blank allowlist parsed to empty.
- Called in `main()` before login; exits with code 1 on error.
- Blank/whitespace-only values still work (treated as "no filter").

Co-authored-by: wouterrodeyns <wouterrodeyns@users.noreply.github.com>