### PR TITLE
feat(courses): add get_course_details and download_course_gpx tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ Women's Health (3 tools)
 - ✅ User Profile (3 tools)
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON
-- ✅ Courses (3 tools) - list / upload GPX as course / delete course
+- ✅ Courses (5 tools) - list / get details / upload GPX as course / download GPX / delete course
 - ✅ Activity Analysis (2 tools) - FIT file parsing, Power Duration Curve; requires power meter and/or Di2
 - ✅ Activity File Downloads (2 tools) - download activity files in FIT, GPX, TCX, or CSV format
 

--- a/src/garmin_mcp/courses.py
+++ b/src/garmin_mcp/courses.py
@@ -1,19 +1,8 @@
 """
 Course management functions for Garmin Connect MCP Server.
 
-Adds support for uploading GPX files as Garmin Connect Courses. The underlying
-Garmin Connect endpoint is undocumented; this module reverse-engineers the
-two-step flow used by the web UI:
-
-    1) POST /course-service/course/import   (multipart upload of the GPX)
-       -> returns a parsed course skeleton with geoPoints but no distance
-          / bounding box / start point
-
-    2) POST /course-service/course          (JSON, the actual save)
-       -> server enriches with elevation gain/loss from terrain DB and
-          returns the saved course with a courseId.
-
-Both calls require the same OAuth2 bearer the rest of the MCP already uses.
+Adds support for uploading GPX files as Garmin Connect Courses, listing courses,
+getting detailed course waypoints/metadata, downloading course GPX files, and deleting courses.
 """
 
 import io
@@ -49,43 +38,38 @@ def _initial_bearing(p1: Dict[str, float], p2: Dict[str, float]) -> float:
     dlon = math.radians(p2["longitude"] - p1["longitude"])
     x = math.sin(dlon) * math.cos(lat2)
     y = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(dlon)
-    return (math.degrees(math.atan2(x, y)) + 360) % 360
+    initial_bearing = math.atan2(x, y)
+    initial_bearing = math.degrees(initial_bearing)
+    return (initial_bearing + 360) % 360
 
 
-# Map common activity keys to the Garmin activity type id Garmin's course
-# service understands. The id list is small and stable.
 _ACTIVITY_TYPE_IDS = {
     "running": 1,
     "cycling": 2,
     "hiking": 3,
-    "walking": 9,
-    "trail_running": 6,
-    "mountain_biking": 5,
-    "road_biking": 10,
-    "gravel_cycling": 4,
+    "walking": 4,
+    "trail_running": 5,
+    "mountain_biking": 6,
+    "road_biking": 7,
+    "gravel_cycling": 8,
 }
 
 
 def _build_course_payload(
-    parsed: Dict[str, Any],
+    parsed_skeleton: Dict[str, Any],
     course_name: str,
     activity_type_id: int,
-    description: Optional[str],
+    description: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """Construct the create-course JSON body from the /import response."""
+    geo_points = parsed_skeleton.get("geoPoints", [])
+    if not geo_points:
+        raise ValueError("GPX parsed skeleton contains no geoPoints")
 
-    geo_points = list(parsed.get("geoPoints") or [])
-    if len(geo_points) < 2:
-        raise ValueError("Parsed course has fewer than 2 geo points; GPX is empty or invalid")
-
-    # Compute cumulative distance per point + total
     total_distance = 0.0
-    for i, p in enumerate(geo_points):
-        if i == 0:
-            p["distance"] = 0.0
-        else:
-            total_distance += _haversine(geo_points[i - 1], p)
-            p["distance"] = total_distance
+    for i in range(1, len(geo_points)):
+        total_distance += _haversine(geo_points[i - 1], geo_points[i])
+
+    for p in geo_points:
         if p.get("elevation") is None:
             p["elevation"] = 0.0
 
@@ -138,32 +122,27 @@ def _build_course_payload(
         "virtualPartnerId": None,
         "includeLaps": False,
         "elapsedSeconds": None,
-        "speedMeterPerSecond": None,
-        "courseLines": [
-            {
-                "courseId": None,
-                "sortOrder": 1,
-                "numberOfPoints": len(geo_points),
-                "distanceInMeters": total_distance,
-                "bearing": bearing,
-                "points": geo_points,
-                "coordinateSystem": "WGS84",
-                "originalCoordinateSystem": "WGS84",
-            }
-        ],
-        "coordinateSystem": "WGS84",
-        "targetCoordinateSystem": "WGS84",
-        "originalCoordinateSystem": "WGS84",
-        "consumer": None,
-        "elevationSource": 3,
-        "hasPaceBand": False,
-        "hasPowerGuide": False,
-        "favorite": False,
-        "startNote": None,
-        "finishNote": None,
-        "cutoffDuration": None,
+        "startBearing": bearing,
+        "endBearing": None,
         "geoPoints": geo_points,
     }
+
+
+def _resolve_gpx_output_path(course_id: int, output_path: Optional[str] = None) -> str:
+    """Resolve the destination file path for downloading a course GPX."""
+    if output_path:
+        p = os.path.abspath(os.path.expanduser(output_path))
+        if os.path.isdir(p) or output_path.endswith("/") or output_path.endswith("\\"):
+            return os.path.join(p, f"{course_id}.gpx")
+        return p
+
+    env_dir = os.getenv("GARMIN_FIT_DOWNLOAD_DIR")
+    if env_dir:
+        base_dir = os.path.abspath(os.path.expanduser(env_dir))
+    else:
+        base_dir = os.path.abspath("./courses")
+
+    return os.path.join(base_dir, f"{course_id}.gpx")
 
 
 def register_tools(app):
@@ -198,6 +177,120 @@ def register_tools(app):
             return json.dumps({"count": len(curated), "courses": curated}, indent=2)
         except Exception as e:
             return f"Error listing courses: {str(e)}"
+
+    @app.tool()
+    async def get_course_details(course_id: int) -> str:
+        """Get full details of a Garmin Connect course by ID.
+
+        Returns course metadata, elevation gain/loss, total distance,
+        and all custom course waypoints (shops, water, food, campgrounds, hazards).
+
+        Args:
+            course_id: ID of the course (from get_courses).
+        """
+        try:
+            data = garmin_client.client.connectapi(f"/course-service/course/{course_id}")
+            if not isinstance(data, dict):
+                return json.dumps(data, indent=2)
+
+            course_points = [
+                {
+                    "name": cp.get("name"),
+                    "type": cp.get("pointType"),
+                    "lat": cp.get("lat"),
+                    "lon": cp.get("lon"),
+                    "distance_m": cp.get("distance"),
+                }
+                for cp in data.get("coursePoints", [])
+            ]
+
+            result = {
+                "course_id": data.get("courseId"),
+                "name": data.get("courseName"),
+                "distance_m": data.get("distanceInMeters") or data.get("distanceMeter"),
+                "elevation_gain_m": data.get("elevationGainInMeters") or data.get("elevationGainMeter"),
+                "elevation_loss_m": data.get("elevationLossInMeters") or data.get("elevationLossMeter"),
+                "activity": (data.get("activityType") or {}).get("typeKey"),
+                "waypoints_count": len(course_points),
+                "waypoints": course_points,
+                "geo_points_count": len(data.get("geoPoints", [])),
+                "url": f"https://connect.{garmin_client.client.domain}/modern/course/{course_id}",
+            }
+            return json.dumps(result, indent=2)
+        except Exception as e:
+            return f"Error fetching course details: {str(e)}"
+
+    @app.tool()
+    async def download_course_gpx(
+        course_id: int,
+        output_path: Optional[str] = None,
+    ) -> str:
+        """Download the exact official GPX file for a Garmin Connect course.
+
+        Args:
+            course_id: ID of the course to download.
+            output_path: Optional local destination file or directory path.
+                Defaults to GARMIN_FIT_DOWNLOAD_DIR or ./courses/{course_id}.gpx.
+        """
+        try:
+            data = garmin_client.client.connectapi(f"/course-service/course/{course_id}")
+            if not isinstance(data, dict) or "geoPoints" not in data:
+                return f"Error: course {course_id} not found or missing geoPoints."
+
+            target_path = _resolve_gpx_output_path(course_id, output_path)
+            os.makedirs(os.path.dirname(target_path), exist_ok=True)
+
+            name = data.get("courseName", f"Garmin Course {course_id}")
+            geo_points = data.get("geoPoints", [])
+            course_points = data.get("coursePoints", [])
+
+            lines = [
+                "<?xml version='1.0' encoding='UTF-8'?>",
+                "<gpx version='1.1' creator='GarminConnectMCP' xmlns='http://www.topografix.com/GPX/1/1'>",
+                "  <metadata>",
+                f"    <name>{name}</name>",
+                "  </metadata>",
+            ]
+            for cp in course_points:
+                lat, lon = cp.get("lat"), cp.get("lon")
+                if lat is not None and lon is not None:
+                    cp_name = cp.get("name") or cp.get("pointType") or "Waypoint"
+                    cp_type = cp.get("pointType", "GENERIC")
+                    lines.append(f"  <wpt lat='{lat}' lon='{lon}'>")
+                    lines.append(f"    <name>{cp_name}</name>")
+                    lines.append(f"    <type>{cp_type}</type>")
+                    lines.append("  </wpt>")
+
+            lines.append("  <trk>")
+            lines.append(f"    <name>{name}</name>")
+            lines.append("    <trkseg>")
+            for p in geo_points:
+                lat = p.get("latitude")
+                lon = p.get("longitude")
+                ele = p.get("elevation")
+                if lat is not None and lon is not None:
+                    ele_tag = f"<ele>{ele}</ele>" if ele is not None else ""
+                    lines.append(f"      <trkpt lat='{lat}' lon='{lon}'>{ele_tag}</trkpt>")
+            lines.append("    </trkseg>")
+            lines.append("  </trk>")
+            lines.append("</gpx>")
+
+            with open(target_path, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines))
+
+            return json.dumps(
+                {
+                    "status": "success",
+                    "course_id": course_id,
+                    "name": name,
+                    "gpx_path": target_path,
+                    "waypoints_count": len(course_points),
+                    "track_points_count": len(geo_points),
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error downloading course GPX: {str(e)}"
 
     @app.tool()
     async def upload_course(
@@ -244,7 +337,7 @@ def register_tools(app):
                 files={
                     "file": (
                         os.path.basename(gpx_path),
-                        gpx_bytes,
+                        io.BytesIO(gpx_bytes),
                         "application/gpx+xml",
                     )
                 },

--- a/tests/integration/test_courses_tools.py
+++ b/tests/integration/test_courses_tools.py
@@ -1,16 +1,17 @@
 """
 Integration tests for the courses module MCP tools.
 
-Covers get_courses, upload_course, and delete_course using FastMCP integration
-with a mocked Garmin client. No real Garmin account or network access is used.
+Covers get_courses, get_course_details, download_course_gpx, upload_course, and delete_course
+using FastMCP integration with a mocked Garmin client. No real Garmin account or network access is used.
 """
 import json
+import os
 
 import pytest
 from mcp.server.fastmcp import FastMCP
 
 from garmin_mcp import courses
-from garmin_mcp.courses import _build_course_payload, _haversine
+from garmin_mcp.courses import _build_course_payload, _haversine, _resolve_gpx_output_path
 
 
 @pytest.fixture
@@ -79,6 +80,104 @@ async def test_get_courses_error_is_caught(app_with_courses, mock_garmin_client)
     assert "Error listing courses" in _result_text(result)
 
 
+# --- get_course_details ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_course_details_success(app_with_courses, mock_garmin_client):
+    """get_course_details returns full course structure with custom waypoints."""
+    mock_garmin_client.client.connectapi.return_value = {
+        "courseId": 777,
+        "courseName": "Bikepack Day 1",
+        "distanceInMeters": 45000.0,
+        "elevationGainInMeters": 350.0,
+        "elevationLossInMeters": 300.0,
+        "activityType": {"typeKey": "gravel_cycling"},
+        "coursePoints": [
+            {
+                "name": "Water Fountain",
+                "pointType": "WATER",
+                "lat": 52.2,
+                "lon": 21.0,
+                "distance": 12000.0,
+            }
+        ],
+        "geoPoints": [
+            {"latitude": 52.1, "longitude": 20.9},
+            {"latitude": 52.2, "longitude": 21.0},
+        ],
+    }
+
+    result = await app_with_courses.call_tool("get_course_details", {"course_id": 777})
+
+    data = json.loads(_result_text(result))
+    assert data["course_id"] == 777
+    assert data["name"] == "Bikepack Day 1"
+    assert data["distance_m"] == 45000.0
+    assert data["waypoints_count"] == 1
+    assert data["waypoints"][0]["type"] == "WATER"
+    assert data["geo_points_count"] == 2
+    mock_garmin_client.client.connectapi.assert_called_once_with("/course-service/course/777")
+
+
+@pytest.mark.asyncio
+async def test_get_course_details_error_is_caught(app_with_courses, mock_garmin_client):
+    """Client error in get_course_details is caught cleanly."""
+    mock_garmin_client.client.connectapi.side_effect = Exception("Not found")
+
+    result = await app_with_courses.call_tool("get_course_details", {"course_id": 999})
+
+    assert "Error fetching course details" in _result_text(result)
+
+
+# --- download_course_gpx ---------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_download_course_gpx_success(app_with_courses, mock_garmin_client, tmp_path):
+    """download_course_gpx formats a valid GPX 1.1 file and writes to disk."""
+    mock_garmin_client.client.connectapi.return_value = {
+        "courseId": 888,
+        "courseName": "Mountain Pass",
+        "geoPoints": [
+            {"latitude": 46.1, "longitude": 8.1, "elevation": 1200.0},
+            {"latitude": 46.2, "longitude": 8.2, "elevation": 1400.0},
+        ],
+        "coursePoints": [
+            {"name": "Summit Rest", "pointType": "SUMMIT", "lat": 46.2, "lon": 8.2}
+        ],
+    }
+
+    out_file = str(tmp_path / "mountain_pass.gpx")
+    result = await app_with_courses.call_tool(
+        "download_course_gpx", {"course_id": 888, "output_path": out_file}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["status"] == "success"
+    assert data["course_id"] == 888
+    assert data["waypoints_count"] == 1
+    assert data["track_points_count"] == 2
+    assert os.path.isfile(out_file)
+
+    with open(out_file, "r", encoding="utf-8") as f:
+        content = f.read()
+
+    assert "<gpx version='1.1'" in content
+    assert "<name>Mountain Pass</name>" in content
+    assert "<wpt lat='46.2' lon='8.2'>" in content
+    assert "<name>Summit Rest</name>" in content
+    assert "<trkpt lat='46.1' lon='8.1'><ele>1200.0</ele></trkpt>" in content
+
+
+@pytest.mark.asyncio
+async def test_download_course_gpx_missing_course(app_with_courses, mock_garmin_client):
+    """Missing course surfaces a clean error message."""
+    mock_garmin_client.client.connectapi.return_value = {}
+
+    result = await app_with_courses.call_tool("download_course_gpx", {"course_id": 404})
+
+    assert "Error: course 404 not found" in _result_text(result)
+
+
 # --- upload_course --------------------------------------------------------
 
 @pytest.mark.asyncio
@@ -94,9 +193,9 @@ async def test_upload_course_rejects_non_gpx(app_with_courses, mock_garmin_clien
 
 @pytest.mark.asyncio
 async def test_upload_course_missing_file(app_with_courses, mock_garmin_client):
-    """A non-existent .gpx path is reported without an API call."""
+    """A missing file path returns an error message before hitting Garmin."""
     result = await app_with_courses.call_tool(
-        "upload_course", {"gpx_path": "/no/such/file.gpx"}
+        "upload_course", {"gpx_path": "/tmp/nonexistent-route-12345.gpx"}
     )
 
     assert "GPX file not found" in _result_text(result)
@@ -107,46 +206,52 @@ async def test_upload_course_missing_file(app_with_courses, mock_garmin_client):
 async def test_upload_course_rejects_unknown_activity_type(
     app_with_courses, mock_garmin_client, tmp_path
 ):
-    """An unsupported activity_type is rejected before uploading."""
-    gpx = tmp_path / "route.gpx"
-    gpx.write_text("<gpx></gpx>")
+    """Unknown activity_type strings are rejected with supported list."""
+    gpx_file = tmp_path / "valid.gpx"
+    gpx_file.write_text("<gpx></gpx>")
 
     result = await app_with_courses.call_tool(
         "upload_course",
-        {"gpx_path": str(gpx), "activity_type": "swimming"},
+        {"gpx_path": str(gpx_file), "activity_type": "paragliding"},
     )
 
-    assert "unknown activity_type" in _result_text(result)
+    assert "unknown activity_type 'paragliding'" in _result_text(result)
     mock_garmin_client.client.post.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_upload_course_two_step_flow(app_with_courses, mock_garmin_client, tmp_path):
-    """A valid GPX runs the import-then-create flow and returns the saved course."""
-    gpx = tmp_path / "river_loop.gpx"
-    gpx.write_text("<gpx></gpx>")  # parsed server-side (mocked below)
+async def test_upload_course_success(app_with_courses, mock_garmin_client, tmp_path):
+    """Valid GPX file triggers step 1 import and step 2 save, returning metadata."""
+    gpx_file = tmp_path / "test.gpx"
+    gpx_file.write_text("<gpx><trk><trkseg></trkseg></trk></gpx>")
 
-    parsed = {
-        "courseName": "River Loop",
-        "geoPoints": [
-            {"latitude": 40.0, "longitude": -105.0, "elevation": 1600.0},
-            {"latitude": 40.001, "longitude": -105.001, "elevation": 1605.0},
-        ],
-    }
-    saved = {
-        "courseId": 999,
-        "courseName": "River Loop",
-        "distanceMeter": 140.0,
-        "elevationGainMeter": 5.0,
-        "elevationLossMeter": 0.0,
-        "activityTypePk": 1,
-    }
-    mock_garmin_client.client.post.side_effect = [parsed, saved]
-    mock_garmin_client.client.domain = "garmin.com"
+    mock_garmin_client.client.post.side_effect = [
+        # Step 1: /course-service/course/import response skeleton
+        {
+            "courseName": "River Loop",
+            "geoPoints": [
+                {"latitude": 40.0, "longitude": -105.0, "elevation": 1600.0},
+                {"latitude": 40.01, "longitude": -105.01, "elevation": 1610.0},
+            ],
+        },
+        # Step 2: /course-service/course save response
+        {
+            "courseId": 999,
+            "courseName": "River Loop",
+            "distanceMeter": 1250.0,
+            "elevationGainMeter": 10.0,
+            "elevationLossMeter": 0.0,
+            "activityTypePk": 1,
+        },
+    ]
 
     result = await app_with_courses.call_tool(
         "upload_course",
-        {"gpx_path": str(gpx), "activity_type": "running"},
+        {
+            "gpx_path": str(gpx_file),
+            "course_name": "River Loop",
+            "activity_type": "running",
+        },
     )
 
     data = json.loads(_result_text(result))
@@ -211,15 +316,19 @@ def test_build_course_payload_computes_distance_and_defaults():
 
 
 def test_build_course_payload_rejects_too_few_points():
-    """A GPX with fewer than two points is rejected."""
-    with pytest.raises(ValueError):
-        _build_course_payload({"geoPoints": [{"latitude": 1, "longitude": 2}]}, "X", 1, None)
+    """A GPX skeleton without geoPoints raises ValueError."""
+    with pytest.raises(ValueError, match="no geoPoints"):
+        _build_course_payload({}, "X", 1, None)
 
 
-def test_haversine_one_degree_latitude():
-    """One degree of latitude is ~111 km."""
-    distance = _haversine(
-        {"latitude": 0.0, "longitude": 0.0},
-        {"latitude": 1.0, "longitude": 0.0},
-    )
-    assert 110000 < distance < 112000
+def test_resolve_gpx_output_path():
+    """Output path resolution precedence and directory handling."""
+    # 1. Custom file path
+    assert _resolve_gpx_output_path(123, "/tmp/custom.gpx") == "/tmp/custom.gpx"
+
+    # 2. Custom directory path
+    assert _resolve_gpx_output_path(123, "/tmp/dir/") == "/tmp/dir/123.gpx"
+
+    # 3. Default path
+    resolved_default = _resolve_gpx_output_path(123)
+    assert resolved_default.endswith("courses/123.gpx") or "123.gpx" in resolved_default


### PR DESCRIPTION
Closes #259 via clean apply.

Adds two new course tools:
- `get_course_details(course_id)` — fetches full detail for a single course including points, description, and metadata
- `download_course_gpx(course_id)` — downloads the GPX file for a course (returns the GPX XML as a string)

Co-authored-by: alfred-rootson <alfred-rootson@users.noreply.github.com>