### PR TITLE
feat(health): add get_sleep_summary_range for multi-night sleep queries

### DIFF
--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -15,6 +15,66 @@ def configure(client):
     garmin_client = client
 
 
+def _extract_sleep_summary(sleep_data: Dict[str, Any]) -> Dict[str, Any]:
+    """Curate a single night's raw Garmin sleep payload down to essential metrics.
+
+    Shared by get_sleep_summary (single night) and get_sleep_summary_range
+    (multi-night) so both endpoints stay in sync.
+    """
+    summary: Dict[str, Any] = {}
+
+    # Extract data from dailySleepDTO if available
+    daily_sleep = sleep_data.get('dailySleepDTO', {})
+    if daily_sleep:
+        # Sleep duration and timing
+        summary['sleep_seconds'] = daily_sleep.get('sleepTimeSeconds')
+        summary['nap_seconds'] = daily_sleep.get('napTimeSeconds')
+        summary['sleep_start'] = daily_sleep.get('sleepStartTimestampGMT')
+        summary['sleep_end'] = daily_sleep.get('sleepEndTimestampGMT')
+
+        # Sleep score and quality
+        summary['sleep_score'] = daily_sleep.get('sleepScores', {}).get('overall', {}).get('value')
+        summary['sleep_score_qualifier'] = daily_sleep.get('sleepScores', {}).get('overall', {}).get('qualifierKey')
+
+        # Sleep phases (in seconds)
+        summary['deep_sleep_seconds'] = daily_sleep.get('deepSleepSeconds')
+        summary['light_sleep_seconds'] = daily_sleep.get('lightSleepSeconds')
+        summary['rem_sleep_seconds'] = daily_sleep.get('remSleepSeconds')
+        summary['awake_seconds'] = daily_sleep.get('awakeSleepSeconds')
+
+        # Sleep disruptions
+        summary['awake_count'] = daily_sleep.get('awakeCount')
+        summary['restless_moments_count'] = daily_sleep.get('restlessMomentsCount')
+
+        # Average physiological metrics
+        summary['avg_sleep_stress'] = daily_sleep.get('avgSleepStress')
+        summary['resting_heart_rate_bpm'] = daily_sleep.get('restingHeartRate')
+
+    # Extract SpO2 summary if available
+    spo2_summary = sleep_data.get('wellnessSpO2SleepSummaryDTO', {})
+    if spo2_summary:
+        summary['avg_spo2_percent'] = spo2_summary.get('averageSpo2')
+        summary['lowest_spo2_percent'] = spo2_summary.get('lowestSpo2')
+
+    # Add HRV data if available at top level
+    if 'avgOvernightHrv' in sleep_data:
+        summary['avg_overnight_hrv'] = sleep_data.get('avgOvernightHrv')
+
+    # Calculate sleep phase percentages if total sleep time is available
+    total_sleep = summary.get('sleep_seconds', 0)
+    if total_sleep and total_sleep > 0:
+        summary['deep_sleep_percent'] = round((summary.get('deep_sleep_seconds', 0) / total_sleep) * 100, 1)
+        summary['light_sleep_percent'] = round((summary.get('light_sleep_seconds', 0) / total_sleep) * 100, 1)
+        summary['rem_sleep_percent'] = round((summary.get('rem_sleep_seconds', 0) / total_sleep) * 100, 1)
+
+    # Convert sleep duration to hours for convenience
+    if total_sleep:
+        summary['sleep_hours'] = round(total_sleep / 3600, 2)
+
+    # Remove None values
+    return {k: v for k, v in summary.items() if v is not None}
+
+
 def register_tools(app):
     """Register all health and wellness tools with the MCP server app"""
 
@@ -462,63 +522,67 @@ def register_tools(app):
             if not sleep_data:
                 return f"No sleep summary found for {date}"
 
-            # Extract only essential summary metrics
-            summary = {}
-
-            # Extract data from dailySleepDTO if available
-            daily_sleep = sleep_data.get('dailySleepDTO', {})
-            if daily_sleep:
-                # Sleep duration and timing
-                summary['sleep_seconds'] = daily_sleep.get('sleepTimeSeconds')
-                summary['nap_seconds'] = daily_sleep.get('napTimeSeconds')
-                summary['sleep_start'] = daily_sleep.get('sleepStartTimestampGMT')
-                summary['sleep_end'] = daily_sleep.get('sleepEndTimestampGMT')
-
-                # Sleep score and quality
-                summary['sleep_score'] = daily_sleep.get('sleepScores', {}).get('overall', {}).get('value')
-                summary['sleep_score_qualifier'] = daily_sleep.get('sleepScores', {}).get('overall', {}).get('qualifierKey')
-
-                # Sleep phases (in seconds)
-                summary['deep_sleep_seconds'] = daily_sleep.get('deepSleepSeconds')
-                summary['light_sleep_seconds'] = daily_sleep.get('lightSleepSeconds')
-                summary['rem_sleep_seconds'] = daily_sleep.get('remSleepSeconds')
-                summary['awake_seconds'] = daily_sleep.get('awakeSleepSeconds')
-
-                # Sleep disruptions
-                summary['awake_count'] = daily_sleep.get('awakeCount')
-                summary['restless_moments_count'] = daily_sleep.get('restlessMomentsCount')
-
-                # Average physiological metrics
-                summary['avg_sleep_stress'] = daily_sleep.get('avgSleepStress')
-                summary['resting_heart_rate_bpm'] = daily_sleep.get('restingHeartRate')
-
-            # Extract SpO2 summary if available
-            spo2_summary = sleep_data.get('wellnessSpO2SleepSummaryDTO', {})
-            if spo2_summary:
-                summary['avg_spo2_percent'] = spo2_summary.get('averageSpo2')
-                summary['lowest_spo2_percent'] = spo2_summary.get('lowestSpo2')
-
-            # Add HRV data if available at top level
-            if 'avgOvernightHrv' in sleep_data:
-                summary['avg_overnight_hrv'] = sleep_data.get('avgOvernightHrv')
-
-            # Calculate sleep phase percentages if total sleep time is available
-            total_sleep = summary.get('sleep_seconds', 0)
-            if total_sleep and total_sleep > 0:
-                summary['deep_sleep_percent'] = round((summary.get('deep_sleep_seconds', 0) / total_sleep) * 100, 1)
-                summary['light_sleep_percent'] = round((summary.get('light_sleep_seconds', 0) / total_sleep) * 100, 1)
-                summary['rem_sleep_percent'] = round((summary.get('rem_sleep_seconds', 0) / total_sleep) * 100, 1)
-
-            # Convert sleep duration to hours for convenience
-            if total_sleep:
-                summary['sleep_hours'] = round(total_sleep / 3600, 2)
-
-            # Remove None values
-            summary = {k: v for k, v in summary.items() if v is not None}
+            summary = _extract_sleep_summary(sleep_data)
 
             return json.dumps(summary, indent=2)
         except Exception as e:
             return f"Error retrieving sleep summary: {str(e)}"
+
+    @app.tool()
+    async def get_sleep_summary_range(start_date: str, end_date: str) -> str:
+        """Get lightweight sleep summaries for every night in a date range.
+
+        Returns the same curated metrics as get_sleep_summary (sleep score, duration,
+        sleep stages, HRV, resting HR, etc.) for each night between start_date and
+        end_date, inclusive. Use this instead of calling get_sleep_summary once per
+        night when analyzing sleep trends over weeks or months.
+
+        Note: Garmin Connect does not expose a native range endpoint for sleep, so
+        this makes one request per night internally. Recommended range: up to a
+        few weeks for quick checks. Maximum: 90 nights per call.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 90
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days > MAX_DAYS:
+            return f"Date range too large ({days} days). Maximum is {MAX_DAYS} days."
+        if days < 1:
+            return "end_date must be on or after start_date."
+
+        nights = []
+        current = start
+        while current <= end:
+            date_str = current.isoformat()
+            try:
+                sleep_data = garmin_client.get_sleep_data(date_str)
+                if sleep_data:
+                    entry = {"date": date_str}
+                    entry.update(_extract_sleep_summary(sleep_data))
+                    if len(entry) > 1:  # has more than just date
+                        nights.append(entry)
+            except Exception:
+                pass  # skip nights with no data / transient errors
+            current += datetime.timedelta(days=1)
+
+        if not nights:
+            return f"No sleep data found between {start_date} and {end_date}."
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "nights_requested": days,
+            "nights_returned": len(nights),
+            "nights": nights,
+        }, indent=2)
 
     @app.tool()
     async def get_stress_data(date: str) -> str:

--- a/tests/integration/test_health_wellness_tools.py
+++ b/tests/integration/test_health_wellness_tools.py
@@ -3,6 +3,8 @@ Integration tests for health_wellness module MCP tools
 
 Tests all 22 health and wellness tools using FastMCP integration with mocked Garmin API responses.
 """
+import json
+
 import pytest
 from unittest.mock import Mock
 from mcp.server.fastmcp import FastMCP
@@ -353,6 +355,96 @@ async def test_get_sleep_summary_tool(app_with_health_wellness, mock_garmin_clie
 
     # Verify it's a summary (smaller than full sleep data)
     # The summary should contain key metrics but not the full time-series data
+
+
+@pytest.mark.asyncio
+async def test_get_sleep_summary_range_tool(app_with_health_wellness, mock_garmin_client):
+    """Test get_sleep_summary_range returns one curated summary per night"""
+    # Setup mock: return sleep data for each of the 3 requested nights
+    mock_garmin_client.get_sleep_data.side_effect = lambda date: {
+        **MOCK_SLEEP_DATA,
+        "dailySleepDTO": {**MOCK_SLEEP_DATA["dailySleepDTO"], "calendarDate": date},
+    }
+
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary_range",
+        {"start_date": "2024-01-13", "end_date": "2024-01-15"},
+    )
+
+    assert result is not None
+    data = json.loads(result[0][0].text)
+    assert data["start_date"] == "2024-01-13"
+    assert data["end_date"] == "2024-01-15"
+    assert data["nights_requested"] == 3
+    assert data["nights_returned"] == 3
+    assert [n["date"] for n in data["nights"]] == [
+        "2024-01-13",
+        "2024-01-14",
+        "2024-01-15",
+    ]
+    # Each night should carry the same curated fields as get_sleep_summary
+    assert data["nights"][0]["sleep_score"] == 85
+    assert data["nights"][0]["sleep_hours"] == 8.0
+    assert mock_garmin_client.get_sleep_data.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_get_sleep_summary_range_skips_nights_without_data(
+    app_with_health_wellness, mock_garmin_client
+):
+    """Nights with no Garmin data (or a per-night error) are skipped, not fatal"""
+
+    def side_effect(date):
+        if date == "2024-01-14":
+            return None
+        if date == "2024-01-15":
+            raise Exception("transient API error")
+        return MOCK_SLEEP_DATA
+
+    mock_garmin_client.get_sleep_data.side_effect = side_effect
+
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary_range",
+        {"start_date": "2024-01-13", "end_date": "2024-01-15"},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["nights_requested"] == 3
+    assert data["nights_returned"] == 1
+    assert data["nights"][0]["date"] == "2024-01-13"
+
+
+@pytest.mark.asyncio
+async def test_get_sleep_summary_range_rejects_invalid_dates(
+    app_with_health_wellness, mock_garmin_client
+):
+    """Malformed dates and inverted ranges return a clear error, no API calls"""
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary_range",
+        {"start_date": "not-a-date", "end_date": "2024-01-15"},
+    )
+    assert "Invalid date format" in result[0][0].text
+
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary_range",
+        {"start_date": "2024-01-15", "end_date": "2024-01-13"},
+    )
+    assert "end_date must be on or after start_date" in result[0][0].text
+
+    mock_garmin_client.get_sleep_data.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_sleep_summary_range_enforces_max_days(
+    app_with_health_wellness, mock_garmin_client
+):
+    """Ranges over 90 days are rejected before making any API calls"""
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary_range",
+        {"start_date": "2024-01-01", "end_date": "2024-04-15"},  # 106 days
+    )
+    assert "too large" in result[0][0].text
+    mock_garmin_client.get_sleep_data.assert_not_called()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #256 via clean apply.

Adds `get_sleep_summary_range(start_date, end_date)` tool that fetches and curates sleep data for a date range, returning one summary per night. Also refactors `get_sleep_summary` to share a new `_extract_sleep_summary()` helper so both tools stay in sync.

Co-authored-by: alfonsoleonm <alfonsoleonm@users.noreply.github.com>