### PR TITLE
feat(calendar): expose races and events from the Garmin calendar

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -30,6 +30,7 @@ from garmin_mcp import nutrition
 from garmin_mcp import workout_builders
 from garmin_mcp import courses
 from garmin_mcp import activity_analysis
+from garmin_mcp import calendar_events
 
 
 def is_interactive_terminal() -> bool:
@@ -590,6 +591,7 @@ def main():
     workout_builders.configure(garmin_client)
     courses.configure(garmin_client)
     activity_analysis.configure(garmin_client)
+    calendar_events.configure(garmin_client)
 
     # Create the MCP app, wrapped so the env-var filter can drop tools.
     # host/port only matter for the HTTP transports; stdio ignores them.
@@ -616,6 +618,7 @@ def main():
     app = workout_builders.register_tools(app)
     app = courses.register_tools(app)
     app = activity_analysis.register_tools(app)
+    app = calendar_events.register_tools(app)
 
     # Register resources (workout templates)
     app = workout_templates.register_resources(app)

--- a/src/garmin_mcp/calendar_events.py
+++ b/src/garmin_mcp/calendar_events.py
@@ -1,0 +1,156 @@
+"""
+Calendar event (race) functions for Garmin Connect MCP Server
+"""
+import json
+import re
+from datetime import date
+from typing import Any, Dict, List, Optional
+
+_DATE_RE = re.compile(r"^\d{4}-\d{2}-\d{2}$")
+
+# The garmin_client will be set by the main file
+garmin_client = None
+
+# Garmin's calendar-service groups every calendar entry under an itemType.
+# Races the user added or subscribed to arrive as "event"; workouts, weigh-ins
+# and badges share the same feed and are ignored here.
+EVENT_ITEM_TYPE = "event"
+
+
+def configure(client):
+    """Configure the module with the Garmin client instance"""
+    global garmin_client
+    garmin_client = client
+
+
+def _validate_date(value: str, field: str = "date") -> date:
+    if not _DATE_RE.match(value):
+        raise ValueError(f"Invalid {field} '{value}': expected YYYY-MM-DD")
+    return date.fromisoformat(value)
+
+
+def _month_range(start: date, end: date):
+    """Yield (year, month) pairs covering start..end inclusive."""
+    year, month = start.year, start.month
+    while (year, month) <= (end.year, end.month):
+        yield year, month
+        year, month = (year + 1, 1) if month == 12 else (year, month + 1)
+
+
+def _fetch_month(year: int, month: int) -> List[Dict[str, Any]]:
+    """Return the raw calendar items for one month.
+
+    Despite its name, the library's get_scheduled_workouts returns the whole
+    calendar feed for a month, events included. It takes a 1-indexed month and
+    converts it to the 0-indexed month Garmin's calendar-service expects.
+    """
+    data = garmin_client.get_scheduled_workouts(year, month)
+    if not isinstance(data, dict):
+        return []
+    items = data.get("calendarItems")
+    return items if isinstance(items, list) else []
+
+
+def _as_dict(value: Any) -> Dict[str, Any]:
+    """Return a dict for Garmin fields that may be null or another shape."""
+    return value if isinstance(value, dict) else {}
+
+
+def _target_distance_meters(item: Dict[str, Any]) -> Optional[float]:
+    """Return the event's distance goal, if it is expressed as a distance."""
+    target = _as_dict(item.get("completionTarget"))
+    if target.get("unitType") != "distance":
+        return None
+    value = target.get("value")
+    return value if isinstance(value, (int, float)) else None
+
+
+def _clean_str(value: Any) -> Optional[str]:
+    """Return a trimmed string, or None for the blanks Garmin sends."""
+    if not isinstance(value, str):
+        return None
+    trimmed = value.strip()
+    return trimmed or None
+
+
+def _curate_event(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Curate one raw calendar event into a compact shape."""
+    event_time = _as_dict(item.get("eventTimeLocal"))
+    return {
+        "title": item.get("title"),
+        "date": item.get("date"),
+        "is_race": bool(item.get("isRace")),
+        "primary_event": bool(item.get("primaryEvent")),
+        "subscribed": bool(item.get("subscribed")),
+        "distance_meters": _target_distance_meters(item),
+        "start_time_local": event_time.get("startTimeHhMm"),
+        "time_zone": event_time.get("timeZoneId"),
+        "location": _clean_str(item.get("location")),
+        "url": item.get("url"),
+        "event_uuid": item.get("shareableEventUuid"),
+    }
+
+
+def register_tools(app):
+    """Register all calendar event tools with the MCP server app"""
+
+    @app.tool()
+    async def get_calendar_events(start_date: str, end_date: str) -> str:
+        """Get races and events on the Garmin Connect calendar between two dates
+
+        Returns calendar entries the user added or subscribed to in Garmin
+        Connect, such as upcoming races. Use this to answer questions about
+        which events or races are scheduled.
+
+        These entries are not returned by get_scheduled_workouts, which covers
+        only workouts, nor by get_goals. This is the only tool that exposes
+        them.
+
+        Each event reports its target distance in meters when Garmin stores one,
+        the local start time when the organiser published it, and two flags:
+        is_race marks the entry as a race rather than a general event, and
+        primary_event marks the goal race that an active training plan targets.
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        try:
+            start = _validate_date(start_date, "start_date")
+            end = _validate_date(end_date, "end_date")
+            if start > end:
+                return "start_date must be on or before end_date."
+
+            events: List[Dict[str, Any]] = []
+            seen = set()
+            for year, month in _month_range(start, end):
+                for item in _fetch_month(year, month):
+                    if not isinstance(item, dict):
+                        continue
+                    if item.get("itemType") != EVENT_ITEM_TYPE:
+                        continue
+                    # The first and last month of the range extend past it.
+                    day = item.get("date")
+                    if not isinstance(day, str) or not start_date <= day <= end_date:
+                        continue
+                    # Multi-month responses can repeat an event at the seams.
+                    key = (item.get("shareableEventUuid"), item.get("title"), day)
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    events.append(_curate_event(item))
+
+            events.sort(key=lambda event: (event["date"], event["title"] or ""))
+
+            curated = {
+                "count": len(events),
+                "date_range": {"start": start_date, "end": end_date},
+                "events": events,
+            }
+            return json.dumps(curated, indent=2, ensure_ascii=False)
+        except ValueError as e:
+            return str(e)
+        except Exception as e:
+            return f"Error retrieving calendar events: {str(e)}"
+
+    return app

--- a/tests/integration/test_calendar_events_tools.py
+++ b/tests/integration/test_calendar_events_tools.py
@@ -1,0 +1,315 @@
+"""
+Integration tests for the calendar_events module MCP tools.
+
+Covers get_calendar_events using FastMCP integration with a mocked Garmin
+client. No real Garmin account or network access is used.
+"""
+import json
+
+import pytest
+from mcp.server.fastmcp import FastMCP
+
+from garmin_mcp import calendar_events
+
+
+@pytest.fixture
+def app_with_calendar_events(mock_garmin_client):
+    """Create a FastMCP app with the calendar event tools registered."""
+    calendar_events.configure(mock_garmin_client)
+    app = FastMCP("Test Calendar Events")
+    app = calendar_events.register_tools(app)
+    return app
+
+
+def _result_text(result):
+    """Extract the text payload from a FastMCP call_tool result."""
+    return result[0][0].text
+
+
+def _race(date, title="Some Marathon", uuid="uuid-1", **overrides):
+    """Build a raw calendar event item as Garmin returns it."""
+    item = {
+        "itemType": "event",
+        "activityTypeId": 1,
+        "title": title,
+        "date": date,
+        "url": "https://www.ahotu.com/event/some-marathon",
+        "isRace": True,
+        "shareableEventUuid": uuid,
+        "completionTarget": {"value": 42195.0, "unit": "meter", "unitType": "distance"},
+        "shareableEvent": True,
+        "subscribed": True,
+    }
+    item.update(overrides)
+    return item
+
+
+def _month(*items):
+    return {"calendarItems": list(items)}
+
+
+# --- get_calendar_events --------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_curates_fields(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A race is curated into a compact shape with its distance and start time."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race(
+            "2026-10-17",
+            title="Gyeongju Marathon",
+            eventTimeLocal={"startTimeHhMm": "08:00", "timeZoneId": "Asia/Seoul"},
+            primaryEvent=True,
+            location="KR",
+        )
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 1
+    event = data["events"][0]
+    assert event["title"] == "Gyeongju Marathon"
+    assert event["date"] == "2026-10-17"
+    assert event["is_race"] is True
+    assert event["primary_event"] is True
+    assert event["distance_meters"] == 42195.0
+    assert event["start_time_local"] == "08:00"
+    assert event["time_zone"] == "Asia/Seoul"
+    assert event["location"] == "KR"
+    assert event["event_uuid"] == "uuid-1"
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_requests_the_month_one_indexed(
+    app_with_calendar_events, mock_garmin_client
+):
+    """The library takes a 1-indexed month and handles Garmin's 0-indexing itself."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month()
+
+    await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    mock_garmin_client.get_scheduled_workouts.assert_called_once_with(2026, 10)
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_walks_months_across_a_year_boundary(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A range spanning December to January requests both months, in order."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month()
+
+    await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-12-20", "end_date": "2027-01-10"}
+    )
+
+    requested = [
+        call.args for call in mock_garmin_client.get_scheduled_workouts.call_args_list
+    ]
+    assert requested == [(2026, 12), (2027, 1)]
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_clips_to_the_requested_range(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Events outside the range are dropped even though Garmin returns whole months."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-03", title="Too Early", uuid="uuid-early"),
+        _race("2026-10-17", title="In Range", uuid="uuid-mid"),
+        _race("2026-10-31", title="Too Late", uuid="uuid-late"),
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-10", "end_date": "2026-10-20"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert [event["title"] for event in data["events"]] == ["In Range"]
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_ignores_non_event_items(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Workouts, weigh-ins and training plans share the feed and are skipped."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", title="Gyeongju Marathon"),
+        {"itemType": "fbtAdaptiveWorkout", "title": "Base", "date": "2026-10-15"},
+        {"itemType": "weight", "date": "2026-10-16", "weight": 70100.0},
+        {
+            "itemType": "trainingPlan",
+            "title": "Gyeongju Marathon Plan",
+            "date": "2026-10-17",
+        },
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 1
+    assert data["events"][0]["title"] == "Gyeongju Marathon"
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_deduplicates_across_months(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An event repeated in two monthly responses is reported once."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-11-15", title="MBN Seoul Marathon", uuid="uuid-seoul")
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-11-01", "end_date": "2026-12-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert mock_garmin_client.get_scheduled_workouts.call_count == 2
+    assert data["count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_sorts_by_date(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Events are returned oldest first regardless of Garmin's ordering."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", title="Later", uuid="uuid-later"),
+        _race("2026-10-03", title="Earlier", uuid="uuid-earlier"),
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert [event["date"] for event in data["events"]] == ["2026-10-03", "2026-10-17"]
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_handles_missing_completion_target(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An event without a distance goal reports None rather than failing."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", completionTarget=None)
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["events"][0]["distance_meters"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_ignores_non_distance_target(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A duration goal is not reported as a distance."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race(
+            "2026-10-17",
+            completionTarget={"value": 3600.0, "unit": "second", "unitType": "time"},
+        )
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["events"][0]["distance_meters"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_normalises_blank_location(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Garmin sends an empty location string for many events; report None."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(_race("2026-10-17", location=""))
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["events"][0]["location"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_empty(app_with_calendar_events, mock_garmin_client):
+    """A month with no events returns count 0 and an empty list."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month()
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 0
+    assert data["events"] == []
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_handles_null_payload(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A null month response is treated as no events, not an error."""
+    mock_garmin_client.get_scheduled_workouts.return_value = None
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_rejects_reversed_range(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An end date before the start date is refused without calling Garmin."""
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-31", "end_date": "2026-10-01"}
+    )
+
+    assert "start_date must be on or before end_date" in _result_text(result)
+    mock_garmin_client.get_scheduled_workouts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_rejects_bad_date_format(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A malformed date is reported clearly without calling Garmin."""
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "10/01/2026", "end_date": "2026-10-31"}
+    )
+
+    assert "Invalid start_date" in _result_text(result)
+    mock_garmin_client.get_scheduled_workouts.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_error_is_caught(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A client error is surfaced as a clean message, not a traceback."""
+    mock_garmin_client.get_scheduled_workouts.side_effect = Exception("boom")
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    assert "Error retrieving calendar events" in _result_text(result)


### PR DESCRIPTION
Closes #258 via clean apply on current main.

Adds `get_calendar_events(start_date, end_date)` tool that lists races and events the user added or subscribed to in Garmin Connect. These entries live in Garmin's calendar feed as `itemType: "event"`, separate from workouts — `get_scheduled_workouts` never returns them.

Each result includes: date, title, target distance, local start time (when published), `is_race` and `primary_event` flags.

Co-authored-by: pajireg <pajireg@users.noreply.github.com>