### PR TITLE
feat(training): add get_acclimation for heat and altitude acclimation status

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -1498,4 +1498,62 @@ def register_tools(app):
             "trend": trend,
         }, indent=2)
 
+    @app.tool()
+    async def get_acclimation(date: str) -> str:
+        """Get heat and altitude acclimation status for a given date.
+
+        Garmin tracks how adapted the athlete currently is to training in heat
+        and at altitude. heat_acclimation_percent runs 0-100 and decays without
+        continued exposure; use it to judge readiness for a warm-weather race.
+
+        heat_trend reports Garmin's own label (e.g. ACCLIMATIZED). The
+        previous_* fields hold the prior reading so direction of travel is
+        visible without a second call.
+
+        VO2 max is not returned here; use get_training_status or get_vo2max_trend.
+
+        Args:
+            date: Date in YYYY-MM-DD format
+        """
+        try:
+            data = garmin_client.get_max_metrics(date)
+        except Exception as e:
+            return f"Error retrieving acclimation data: {str(e)}"
+
+        if isinstance(data, list):
+            data = data[0] if data else None
+        if not isinstance(data, dict):
+            return f"No acclimation data found for {date}."
+
+        acc = _as_dict(data.get("heatAltitudeAcclimation"))
+        if not acc:
+            return (
+                f"No acclimation data found for {date}. Garmin populates this only "
+                "after outdoor activities in heat or at altitude."
+            )
+
+        result: Dict[str, Any] = {"date": acc.get("calendarDate", date)}
+
+        for out_key, in_key in (
+            ("heat_acclimation_percent", "heatAcclimationPercentage"),
+            ("previous_heat_acclimation_percent", "previousHeatAcclimationPercentage"),
+            ("heat_trend", "heatTrend"),
+            ("heat_acclimation_date", "heatAcclimationDate"),
+            ("previous_heat_acclimation_date", "previousHeatAcclimationDate"),
+            ("altitude_acclimation_meters", "altitudeAcclimation"),
+            ("previous_altitude_acclimation_meters", "previousAltitudeAcclimation"),
+            ("altitude_trend", "altitudeTrend"),
+            ("current_altitude_meters", "currentAltitude"),
+        ):
+            value = acc.get(in_key)
+            if value is not None:
+                result[out_key] = value
+
+        heat = result.get("heat_acclimation_percent")
+        prev = result.get("previous_heat_acclimation_percent")
+        if isinstance(heat, (int, float)) and isinstance(prev, (int, float)):
+            result["heat_acclimation_change"] = round(heat - prev, 1)
+
+        return json.dumps(result, indent=2)
+
     return app

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -1133,3 +1133,65 @@ async def test_get_progress_summary_handles_null_stats(app_with_training, mock_g
     text = result[0][0].text
     assert "NoneType" not in text
     assert "Error" not in text
+
+
+@pytest.mark.asyncio
+async def test_get_acclimation_returns_heat_data(app_with_training, mock_garmin_client):
+    """Test get_acclimation returns curated heat/altitude acclimation data."""
+    mock_garmin_client.get_max_metrics.return_value = [
+        {
+            "heatAltitudeAcclimation": {
+                "calendarDate": "2024-07-15",
+                "heatAcclimationPercentage": 72.5,
+                "previousHeatAcclimationPercentage": 65.0,
+                "heatTrend": "ACCLIMATIZED",
+                "heatAcclimationDate": "2024-07-15",
+                "altitudeAcclimation": 1200,
+                "altitudeTrend": "INCREASING",
+                "currentAltitude": 850,
+            }
+        }
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_acclimation",
+        {"date": "2024-07-15"},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["date"] == "2024-07-15"
+    assert data["heat_acclimation_percent"] == 72.5
+    assert data["previous_heat_acclimation_percent"] == 65.0
+    assert data["heat_trend"] == "ACCLIMATIZED"
+    assert data["heat_acclimation_change"] == 7.5
+    assert data["altitude_acclimation_meters"] == 1200
+    assert data["altitude_trend"] == "INCREASING"
+    mock_garmin_client.get_max_metrics.assert_called_once_with("2024-07-15")
+
+
+@pytest.mark.asyncio
+async def test_get_acclimation_no_data(app_with_training, mock_garmin_client):
+    """Test get_acclimation handles missing heatAltitudeAcclimation."""
+    mock_garmin_client.get_max_metrics.return_value = [
+        {"generic": {"calendarDate": "2024-07-15", "vo2MaxValue": 48.0}}
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_acclimation",
+        {"date": "2024-07-15"},
+    )
+
+    assert "No acclimation data" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_acclimation_exception(app_with_training, mock_garmin_client):
+    """Test get_acclimation error handling."""
+    mock_garmin_client.get_max_metrics.side_effect = Exception("API Error")
+
+    result = await app_with_training.call_tool(
+        "get_acclimation",
+        {"date": "2024-07-15"},
+    )
+
+    assert "Error" in result[0][0].text


### PR DESCRIPTION
Inspired by PR #267 (applied on current main).

Adds `get_acclimation(date)` to training.py, using the already-available `get_max_metrics()` endpoint to expose the `heatAltitudeAcclimation` section:

- `heat_acclimation_percent` (0–100, decays without continued heat exposure)
- `heat_trend` (e.g. "ACCLIMATIZED") 
- `altitude_acclimation_meters` / `altitude_trend` / `current_altitude_meters`
- `previous_*` counterparts for direction-of-travel without a second call
- `heat_acclimation_change` — computed delta from previous reading

Co-authored-by: pajireg <pajireg@users.noreply.github.com>