### PR TITLE
fix(workouts): build real repeat groups for strength sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,10 +138,12 @@ Returns: `{"status": "success", "workout_id": 1234567890, ...}`
 
 ### `create_strength_workout`
 
-Creates a strength workout from a list of exercises. Each becomes a reps-based step, with the
-name kept in the step description. The name is also sent as `exerciseName`, but Garmin only
-retains that when it matches one of its own exercise keys (e.g. `FARMERS_CARRY`) — any other
-value is accepted and then stored empty.
+Creates a strength workout from a list of exercises. An exercise with more than one set
+becomes a repeat group of `sets` x (reps step + rest step), so the watch counts the sets
+down; a single-set exercise stays a flat step with its rest alongside. The name is kept in
+the step description. The name is also sent as `exerciseName`, but Garmin only retains that
+when it matches one of its own exercise keys (e.g. `FARMERS_CARRY`) — any other value is
+accepted and then stored empty.
 
 `category` is optional and passed straight through. Omit it and the key is left out of the
 payload entirely, which Garmin accepts. Supply it and it must be one of Garmin's exercise

--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -255,17 +255,37 @@ def build_z2_walk_json(
     }
 
 
+def _assign_step_orders(steps: List[dict], counter: Optional[List[int]] = None) -> None:
+    """Number every step in document order, descending into repeat groups.
+
+    Garmin expects stepOrder to be a single sequence across the whole workout, so a
+    nested step continues the outer numbering rather than restarting at 1.
+    """
+    if counter is None:
+        counter = [1]
+
+    for step in steps:
+        step["stepOrder"] = counter[0]
+        counter[0] += 1
+        nested = step.get("workoutSteps")
+        if nested:
+            _assign_step_orders(nested, counter)
+
+
 def build_strength_json(
     name: str,
     exercises: List[Dict[str, Any]],
 ) -> dict:
     """Build the Garmin Connect JSON for a strength workout.
 
-    Each exercise becomes a reps-based work step. The name is preserved in the step
-    "description", which is what survives the round trip. It is also sent as
-    "exerciseName", but Garmin only retains that when it matches one of its own
-    exercise keys (e.g. "FARMERS_CARRY"); any other value is accepted and then
-    stored as an empty string.
+    Each exercise with more than one set becomes a repeat group of
+    sets x (work step + rest step), so the set count is structural and the watch
+    actually counts it down. A single-set exercise stays a flat step with the rest
+    as a sibling. The name is preserved in the step "description", which is what
+    survives the round trip. It is also sent as "exerciseName", but Garmin only
+    retains that when it matches one of its own exercise keys (e.g.
+    "FARMERS_CARRY"); any other value is accepted and then stored as an empty
+    string.
 
     "category" is optional and only emitted when the caller supplies one, uppercased
     and otherwise passed through untouched. Garmin validates it against its own enum
@@ -274,20 +294,21 @@ def build_strength_json(
     https://connect.garmin.com/web-data/exercises/Exercises.json
     """
     steps: List[dict] = []
-    step_order = 1
 
-    for ex in exercises:
+    for index, ex in enumerate(exercises):
         ex_name = ex.get("name", "Exercise")
         sets = int(ex.get("sets", 1))
         reps = int(ex.get("reps", 1))
         rest_seconds = int(ex.get("rest_seconds", 60))
+        is_last = index == len(exercises) - 1
 
-        # Work step
-        step = {
+        # Work step. The set count is carried by the enclosing repeat group, so the
+        # description names the exercise only — labelling a step "3 sets" when Garmin
+        # runs it once is what made earlier workouts contradict themselves.
+        work = {
             "type": "ExecutableStepDTO",
-            "stepOrder": step_order,
             "stepType": {"stepTypeId": 3, "stepTypeKey": "interval"},
-            "description": f"{ex_name}: {sets} sets x {reps} reps",
+            "description": ex_name,
             "endCondition": {"conditionTypeId": 10, "conditionTypeKey": "reps"},
             "endConditionValue": float(reps),
             "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
@@ -303,23 +324,39 @@ def build_strength_json(
                 raise ValueError(
                     f"category for exercise {ex_name!r} must be a non-empty string"
                 )
-            step["category"] = category.strip().upper()
+            work["category"] = category.strip().upper()
 
-        steps.append(step)
-        step_order += 1
-
-        # Rest step (skip after last exercise)
-        if rest_seconds > 0 and ex != exercises[-1]:
-            steps.append({
+        rest = None
+        if rest_seconds > 0:
+            rest = {
                 "type": "ExecutableStepDTO",
-                "stepOrder": step_order,
                 "stepType": {"stepTypeId": 4, "stepTypeKey": "recovery"},
                 "description": f"Rest {rest_seconds}s",
                 "endCondition": {"conditionTypeId": 2, "conditionTypeKey": "time"},
                 "endConditionValue": float(rest_seconds),
                 "targetType": {"workoutTargetTypeId": 1, "workoutTargetTypeKey": "no.target"},
+            }
+
+        if sets > 1:
+            # One repeat group per exercise: sets x (work + rest between sets).
+            steps.append({
+                "type": "RepeatGroupDTO",
+                "stepType": {"stepTypeId": 6, "stepTypeKey": "repeat"},
+                "numberOfIterations": sets,
+                "smartRepeat": False,
+                "endCondition": {"conditionTypeId": 7, "conditionTypeKey": "iterations"},
+                "workoutSteps": [work] + ([rest] if rest else []),
             })
-            step_order += 1
+        else:
+            steps.append(work)
+            # A single-set exercise keeps its rest as a sibling, skipped after the
+            # last one so the workout does not end on a recovery step. Compared by
+            # index, not by value: two identical exercise dicts would otherwise make
+            # the earlier one look like the last.
+            if rest and not is_last:
+                steps.append(rest)
+
+    _assign_step_orders(steps)
 
     return {
         "workoutName": name,

--- a/tests/unit/test_workout_builders.py
+++ b/tests/unit/test_workout_builders.py
@@ -125,10 +125,11 @@ def test_build_strength_json_structure():
     assert result["sportType"]["sportTypeKey"] == "strength_training"
     assert result["sportType"]["sportTypeId"] == 5
     steps = result["workoutSegments"][0]["workoutSteps"]
-    # 2 exercises + 1 rest between them = 3 steps
-    assert len(steps) == 3
-    assert steps[0]["exerciseName"] == "Sentadillas"
-    assert steps[2]["exerciseName"] == "Flexiones"
+    # Each multi-set exercise is one repeat group of sets x (work + rest).
+    assert len(steps) == 2
+    assert [s["type"] for s in steps] == ["RepeatGroupDTO", "RepeatGroupDTO"]
+    assert steps[0]["workoutSteps"][0]["exerciseName"] == "Sentadillas"
+    assert steps[1]["workoutSteps"][0]["exerciseName"] == "Flexiones"
 
 
 # ---------------------------------------------------------------------------
@@ -140,9 +141,22 @@ def test_build_strength_json_structure():
 # ---------------------------------------------------------------------------
 
 
+def _flatten(steps):
+    """Every step in document order, descending into repeat groups."""
+    out = []
+    for step in steps:
+        out.append(step)
+        out.extend(_flatten(step.get("workoutSteps") or []))
+    return out
+
+
 def _work_steps(result):
-    """Only the exercise steps; rest steps are recovery steps and carry no category."""
-    steps = result["workoutSegments"][0]["workoutSteps"]
+    """Only the exercise steps; rest steps are recovery steps and carry no category.
+
+    Multi-set exercises nest their work step inside a repeat group, so this walks
+    the tree rather than reading only the top level.
+    """
+    steps = _flatten(result["workoutSegments"][0]["workoutSteps"])
     return [s for s in steps if s["stepType"]["stepTypeKey"] == "interval"]
 
 
@@ -157,7 +171,7 @@ def test_strength_omits_category_when_not_supplied():
     for step in _work_steps(result):
         assert "category" not in step
     # The name survives the Garmin round trip in the description, not exerciseName.
-    assert _work_steps(result)[0]["description"].startswith("Back Squat:")
+    assert _work_steps(result)[0]["description"] == "Back Squat"
 
 
 def test_strength_passes_through_supplied_category():
@@ -181,3 +195,61 @@ def test_strength_rejects_empty_category():
                 name="Bad",
                 exercises=[{"name": "Back Squat", "sets": 1, "reps": 1, "category": bad}],
             )
+
+
+# ---------------------------------------------------------------------------
+# Set counts
+#
+# "sets" used to reach the payload only as description text, so a 3x12 exercise
+# uploaded as a single 12-rep step and the watch counted one set while the
+# description claimed three.
+# ---------------------------------------------------------------------------
+
+
+def test_multi_set_exercise_becomes_a_repeat_group():
+    result = build_strength_json(
+        name="Legs",
+        exercises=[{"name": "Back Squat", "sets": 3, "reps": 12, "rest_seconds": 90}],
+    )
+    (group,) = result["workoutSegments"][0]["workoutSteps"]
+    assert group["type"] == "RepeatGroupDTO"
+    assert group["numberOfIterations"] == 3
+    # Omitting conditionTypeId makes Garmin silently corrupt the repeat count.
+    assert group["endCondition"] == {"conditionTypeId": 7, "conditionTypeKey": "iterations"}
+    work, rest = group["workoutSteps"]
+    assert work["endConditionValue"] == 12.0
+    assert rest["stepType"]["stepTypeKey"] == "recovery"
+    assert rest["endConditionValue"] == 90.0
+
+
+def test_single_set_exercise_stays_flat():
+    result = build_strength_json(
+        name="Singles",
+        exercises=[
+            {"name": "Deadlift", "sets": 1, "reps": 5, "rest_seconds": 120},
+            {"name": "Plank", "sets": 1, "reps": 1, "rest_seconds": 60},
+        ],
+    )
+    steps = result["workoutSegments"][0]["workoutSteps"]
+    # work, rest, work — no rest after the last exercise, and no repeat groups.
+    assert [s["stepType"]["stepTypeKey"] for s in steps] == ["interval", "recovery", "interval"]
+
+
+def test_step_orders_are_sequential_through_repeat_groups():
+    result = build_strength_json(
+        name="Ordering",
+        exercises=[
+            {"name": "Back Squat", "sets": 2, "reps": 5, "rest_seconds": 60},
+            {"name": "Row", "sets": 2, "reps": 8, "rest_seconds": 60},
+        ],
+    )
+    orders = [s["stepOrder"] for s in _flatten(result["workoutSegments"][0]["workoutSteps"])]
+    assert orders == list(range(1, len(orders) + 1))
+
+
+def test_identical_exercises_each_keep_their_rest():
+    """The last-exercise check compares by index; equal dicts used to collide."""
+    same = {"name": "Plank", "sets": 1, "reps": 1, "rest_seconds": 45}
+    result = build_strength_json(name="Dupes", exercises=[dict(same), dict(same)])
+    steps = result["workoutSegments"][0]["workoutSteps"]
+    assert [s["stepType"]["stepTypeKey"] for s in steps] == ["interval", "recovery", "interval"]


### PR DESCRIPTION
## Problem

`build_strength_json` reads the `sets` value from each exercise but only interpolates it into the step description. No `RepeatGroupDTO` is ever emitted, so a `{"sets": 3, "reps": 12}` exercise uploads as a **single 12-rep step** whose description reads `"Back Squat: 3 sets x 12 reps"`.

The watch counts one set while the description promises three. Confirmed by reading an uploaded workout back:

```json
{
  "order": 1,
  "type": "interval",
  "description": "Sentadilla peso corporal: 3 sets x 12 reps",
  "end_condition": "reps",
  "end_condition_value": 12.0
}
```

## Fix

Each exercise with more than one set now becomes a `RepeatGroupDTO` of `sets` x (work step + rest step), so the set count is structural and the watch counts it down. Single-set exercises keep the previous flat shape, with the rest as a sibling.

Two supporting changes:

- **Step ordering.** `stepOrder` is now assigned by a recursive walk, so nested steps continue the outer numbering rather than restarting — which is what Garmin expects.
- **Adjacent bug.** The "skip the rest after the last exercise" check compared exercise dicts by value (`ex != exercises[-1]`), so two identical exercises made the earlier one lose its rest step. It now compares by index.

The `sets` label is dropped from the step description, since the count is no longer text.

## Verification

Uploaded to a real account and read back — `repeat_count: 3` on every group, with the reps step and rest step nested inside.

Four existing tests encoded the old flat-step behaviour and were updated. Four new tests cover the repeat group and its `endCondition`, the single-set shape, sequential step ordering through groups, and the identical-exercises case. Full suite: **498 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
