### PR TITLE
feat(nutrition): add get_nutrition_summary_between_dates for multi-day intake totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ This MCP server implements **110+ tools** covering ~90% of the [python-garmincon
 - ✅ Gear Management (5 tools)
 - ✅ Weight Tracking (5 tools)
 - ✅ Challenges & Badges (10 tools)
-- ✅ Nutrition (8 tools) - food logs, meals, custom foods, and food logging
+- ✅ Nutrition (9 tools) - food logs, meals, custom foods, food logging, and multi-day intake summaries
 - ✅ Women's Health (3 tools)
 - ✅ User Profile (3 tools)
 - ✅ High-Level Workout Builders (4 tools) - create and schedule workouts without writing JSON

--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -1,6 +1,7 @@
 """
 Nutrition/food logging functions for Garmin Connect MCP Server
 """
+import datetime
 import json
 from typing import Optional
 
@@ -45,6 +46,76 @@ def register_tools(app):
             return json.dumps(data, indent=2)
         except Exception as e:
             return f"Error retrieving food log data: {str(e)}"
+
+    @app.tool()
+    async def get_nutrition_summary_between_dates(start_date: str, end_date: str) -> str:
+        """Get per-day nutrition totals for every day in a date range.
+
+        Returns one lightweight entry per day (date, calories, carbs, protein,
+        fat, item_count) instead of the full per-item food log that
+        get_nutrition_daily_food_log returns for a single date. Use this for
+        multi-day intake analysis (e.g. mean intake for a TDEE estimate)
+        instead of calling get_nutrition_daily_food_log once per day.
+
+        item_count is the number of logged food items that day. A day with
+        item_count == 0 has no logged food at all, and a low but nonzero
+        item_count may mean only part of the day was logged (e.g. breakfast
+        only). Both cases read as low intake in the totals alone -- exclude
+        low-item_count days explicitly before averaging intake or deriving
+        TDEE; don't infer "unlogged" from a low calorie total.
+
+        Maximum range: 61 days per call (Garmin's own limit for this endpoint).
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 61
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days = (end - start).days + 1
+        if days < 1:
+            return "end_date must be on or after start_date."
+        if days > MAX_DAYS:
+            return f"Date range too large ({days} days). Maximum is {MAX_DAYS} days."
+
+        try:
+            data = garmin_client.connectapi(
+                "/nutrition-service/food/logs/range",
+                params={"startDate": start_date, "endDate": end_date},
+            )
+        except Exception as e:
+            return f"Error retrieving nutrition summary: {str(e)}"
+
+        summaries = (data or {}).get("dailyNutritionSummaries") or []
+        if not summaries:
+            return f"No nutrition data found between {start_date} and {end_date}."
+
+        daily = []
+        for day in summaries:
+            content = day.get("dailyNutritionContent") or {}
+            item_count = sum(
+                len(meal.get("loggedFoods") or [])
+                for meal in (day.get("mealDetails") or [])
+            )
+            daily.append({
+                "date": day.get("mealDate"),
+                "calories": content.get("calories"),
+                "carbs": content.get("carbs"),
+                "protein": content.get("protein"),
+                "fat": content.get("fat"),
+                "item_count": item_count,
+            })
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "days": daily,
+        }, indent=2)
 
     @app.tool()
     async def get_nutrition_daily_meals(date: str) -> str:

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -2,7 +2,7 @@
 Integration tests for nutrition module MCP tools
 
 Tests tools from:
-- nutrition (8 tools: 5 read + 2 write + 1 metadata)
+- nutrition (9 tools: 6 read + 2 write + 1 metadata)
 """
 import json
 import pytest
@@ -68,6 +68,116 @@ async def test_get_nutrition_daily_food_log_error(app_with_nutrition, mock_garmi
         {"date": "2024-01-15"}
     )
     assert "Error retrieving food log data" in result[0][0].text
+
+
+# get_nutrition_summary_between_dates tests
+
+@pytest.mark.asyncio
+async def test_get_nutrition_summary_between_dates(app_with_nutrition, mock_garmin_client):
+    """Curates per-day totals and derives item_count from mealDetails.
+
+    Response shape mirrors what Garmin's /nutrition-service/food/logs/range
+    actually returns: a logged day carries dailyNutritionContent and
+    non-empty loggedFoods; a fully unlogged day has no dailyNutritionContent
+    key at all (not null -- absent) and every meal's loggedFoods is [].
+    """
+    mock_garmin_client.connectapi.return_value = {
+        "dailyNutritionSummaries": [
+            {
+                "mealDate": "2024-01-14",
+                "mealDetails": [
+                    {"mealName": "BREAKFAST", "loggedFoods": []},
+                    {"mealName": "LUNCH", "loggedFoods": []},
+                ],
+            },
+            {
+                "mealDate": "2024-01-15",
+                "dailyNutritionContent": {
+                    "calories": 1499,
+                    "carbs": 107.0,
+                    "fat": 63.0,
+                    "protein": 142.0,
+                },
+                "mealDetails": [
+                    {"mealName": "BREAKFAST", "loggedFoods": [{"foodMetaData": {}}]},
+                    {
+                        "mealName": "LUNCH",
+                        "loggedFoods": [{"foodMetaData": {}}, {"foodMetaData": {}}],
+                    },
+                ],
+            },
+        ]
+    }
+
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_summary_between_dates",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"},
+    )
+
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/nutrition-service/food/logs/range",
+        params={"startDate": "2024-01-14", "endDate": "2024-01-15"},
+    )
+    data = json.loads(result[0][0].text)
+    assert data["start_date"] == "2024-01-14"
+    assert data["end_date"] == "2024-01-15"
+
+    unlogged, logged = data["days"]
+    assert unlogged["date"] == "2024-01-14"
+    assert unlogged["item_count"] == 0
+    assert unlogged["calories"] is None
+
+    assert logged["date"] == "2024-01-15"
+    assert logged["item_count"] == 3
+    assert logged["calories"] == 1499
+    assert logged["carbs"] == 107.0
+    assert logged["protein"] == 142.0
+    assert logged["fat"] == 63.0
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_summary_between_dates_rejects_oversized_range(
+    app_with_nutrition, mock_garmin_client
+):
+    """The tool enforces Garmin's own 61-day cap before making a request."""
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_summary_between_dates",
+        {"start_date": "2024-01-01", "end_date": "2024-04-01"},
+    )
+    assert "too large" in result[0][0].text
+    mock_garmin_client.connectapi.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_summary_between_dates_rejects_inverted_range(
+    app_with_nutrition, mock_garmin_client
+):
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_summary_between_dates",
+        {"start_date": "2024-01-15", "end_date": "2024-01-01"},
+    )
+    assert "end_date must be on or after start_date" in result[0][0].text
+    mock_garmin_client.connectapi.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_summary_between_dates_empty(app_with_nutrition, mock_garmin_client):
+    mock_garmin_client.connectapi.return_value = {"dailyNutritionSummaries": []}
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_summary_between_dates",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"},
+    )
+    assert "No nutrition data found" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_nutrition_summary_between_dates_error(app_with_nutrition, mock_garmin_client):
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_nutrition.call_tool(
+        "get_nutrition_summary_between_dates",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"},
+    )
+    assert "Error retrieving nutrition summary" in result[0][0].text
 
 
 # get_nutrition_daily_meals tests


### PR DESCRIPTION
## Summary
- All existing nutrition read tools (`get_nutrition_daily_food_log`, `get_nutrition_daily_meals`, `get_nutrition_daily_settings`) take a single `date`, so multi-week intake analysis needed one call per day, each returning a full per-item food log just to get the daily total.
- Adds `get_nutrition_summary_between_dates(start_date, end_date)`, backed by Garmin's `/nutrition-service/food/logs/range` endpoint — confirmed live to be the same endpoint behind Connect's web nutrition report, and not previously used anywhere in this repo or `garminconnect`. One call returns every day in the range.
- Garmin caps this endpoint at 61 days per call (verified live: `400` with `"cannot be more than 61 days"`); the tool checks the range client-side first and returns a clear message instead of letting the raw Garmin error surface.
- Each day is curated to `date`, `calories`, `carbs`, `protein`, `fat`, and `item_count` — the number of logged food items that day. `item_count` is a completeness signal: a fully unlogged day and a partially-logged day both read as "low intake" from the totals alone, so a consumer computing mean intake / TDEE needs `item_count` to exclude incomplete days rather than guessing from a low calorie total.

## Test plan
- [x] `test_get_nutrition_summary_between_dates` — mirrors the exact raw response shape observed live (an unlogged day has no `dailyNutritionContent` key at all, not null) and asserts curated output + `item_count`.
- [x] `test_get_nutrition_summary_between_dates_rejects_oversized_range` / `_rejects_inverted_range` — client-side validation before any API call.
- [x] `test_get_nutrition_summary_between_dates_empty` / `_error` — standard empty/error paths matching the other nutrition tools.
- [x] Full non-e2e suite passes (593 tests).
- [x] Verified live against a real Garmin account: 5-day pull returns correct per-day totals; 128-day and inverted-range requests are rejected client-side with the expected messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PWVmt99Ar44VHc4TErxLgb