### PR TITLE
fix(nutrition): use calorieGoal and nested macroGoals settings

### DIFF
--- a/src/garmin_mcp/nutrition.py
+++ b/src/garmin_mcp/nutrition.py
@@ -2,6 +2,7 @@
 Nutrition/food logging functions for Garmin Connect MCP Server
 """
 import json
+from copy import deepcopy
 from typing import Optional
 
 from garminconnect import GarminConnectConnectionError
@@ -99,9 +100,10 @@ def register_tools(app):
         and writes the merged result back.  Only the fields you provide are
         changed; omitted fields keep their existing values.
 
-        Garmin stores macros as grams.  The calorie goal should match
-        4*carbs + 4*protein + 9*fat to within a small rounding margin — Garmin
-        accepts minor mismatches but will silently correct large discrepancies.
+        Macro arguments retain their existing names and are passed through to
+        Garmin's macroGoals without unit conversion. The endpoint's macro units
+        have not been independently verified. Returned goals come from Garmin's
+        response, or a settings read-back when the update has no response body.
 
         Args:
             date: Date in YYYY-MM-DD format (settings are typically set once and
@@ -118,23 +120,39 @@ def register_tools(app):
             current = garmin_client.connectapi(url)
             if not current:
                 return f"Could not read current nutrition settings for {date} — cannot apply update."
+            current = deepcopy(current)
             if calorie_goal is not None:
-                current["activeDailyCalories"] = calorie_goal
-            if carbs_grams is not None:
-                current["activeDailyCarbohydrateGrams"] = carbs_grams
-            if fat_grams is not None:
-                current["activeDailyFatGrams"] = fat_grams
-            if protein_grams is not None:
-                current["activeDailyProteinGrams"] = protein_grams
+                current["calorieGoal"] = calorie_goal
+            macro_overrides = {
+                "carbs": carbs_grams,
+                "fat": fat_grams,
+                "protein": protein_grams,
+            }
+            if any(value is not None for value in macro_overrides.values()):
+                macros = current.get("macroGoals")
+                if macros is None:
+                    macros = {}
+                if not isinstance(macros, dict):
+                    return "Could not read current macro goals — cannot apply update."
+                macros.update({key: value for key, value in macro_overrides.items() if value is not None})
+                current["macroGoals"] = macros
             resp = garmin_client.client.put("connectapi", url, json=current, api=True)
-            result = resp if resp else current
+            result = resp
+            if not result:
+                try:
+                    result = garmin_client.connectapi(url)
+                except Exception as e:
+                    return f"Nutrition update submitted, but could not verify stored settings: {e}"
+            if not isinstance(result, dict) or not result:
+                return "Nutrition update submitted, but could not verify stored settings."
+            result_macros = result.get("macroGoals") or {}
             return json.dumps({
                 "status": "updated",
                 "date": date,
-                "calorie_goal": result.get("activeDailyCalories"),
-                "carbs_grams": result.get("activeDailyCarbohydrateGrams"),
-                "fat_grams": result.get("activeDailyFatGrams"),
-                "protein_grams": result.get("activeDailyProteinGrams"),
+                "calorie_goal": result.get("calorieGoal"),
+                "carbs_grams": result_macros.get("carbs"),
+                "fat_grams": result_macros.get("fat"),
+                "protein_grams": result_macros.get("protein"),
             }, indent=2)
         except Exception as e:
             return f"Error updating nutrition settings: {str(e)}"

--- a/tests/integration/test_nutrition_tools.py
+++ b/tests/integration/test_nutrition_tools.py
@@ -5,6 +5,7 @@ Tests tools from:
 - nutrition (8 tools: 5 read + 2 write + 1 metadata)
 """
 import json
+from copy import deepcopy
 import pytest
 from unittest.mock import Mock, call
 from mcp.server.fastmcp import FastMCP
@@ -930,61 +931,87 @@ async def test_delete_food_log_accepts_hex_uuid(app_with_nutrition, mock_garmin_
 
 # set_nutrition_daily_settings tests
 
+# Field names follow the reporter's settings payload in issue #294.
+# Numeric values are synthetic and do not establish Garmin's macro units.
 _CURRENT_SETTINGS = {
-    "activeDailyCalories": 2000,
-    "activeDailyCarbohydrateGrams": 250,
-    "activeDailyFatGrams": 65,
-    "activeDailyProteinGrams": 120,
-    "planDate": "2024-01-15",
+    "weightChangeType": "LOSS",
+    "targetDate": "2024-06-01",
+    "weightChangeRate": 0.25,
+    "activeDailyCalories": 400,
+    "userDefinedActiveCalories": False,
+    "calorieGoal": 2000,
+    "macroGoals": {"carbs": 250, "fat": 65, "protein": 120},
+    "autoCalorieAdjustment": False,
+    "startingWeight": 80,
+    "targetWeightGoal": 75,
+    "nutritionStatus": "ACTIVE",
 }
 
 
 @pytest.mark.asyncio
 async def test_set_nutrition_daily_settings_updates_all_fields(app_with_nutrition, mock_garmin_client):
-    """All four fields are updated and the merged payload is PUT back."""
-    mock_garmin_client.connectapi.return_value = dict(_CURRENT_SETTINGS)
+    original = deepcopy(_CURRENT_SETTINGS)
+    mock_garmin_client.connectapi.return_value = original
+    # Server values can differ from the requested values.
     mock_garmin_client.client.put.return_value = {
-        "activeDailyCalories": 1800,
-        "activeDailyCarbohydrateGrams": 200,
-        "activeDailyFatGrams": 60,
-        "activeDailyProteinGrams": 140,
+        "calorieGoal": 1850,
+        "macroGoals": {"carbs": 205, "fat": 60, "protein": 140},
     }
-
     result = await app_with_nutrition.call_tool(
         "set_nutrition_daily_settings",
         {"date": "2024-01-15", "calorie_goal": 1800, "carbs_grams": 200, "fat_grams": 60, "protein_grams": 140},
     )
-
-    data = json.loads(result[0][0].text)
-    assert data["status"] == "updated"
-    assert data["calorie_goal"] == 1800
-    assert data["carbs_grams"] == 200
-    assert data["fat_grams"] == 60
-    assert data["protein_grams"] == 140
-    # Verify the PUT was called with the merged payload
-    put_call = mock_garmin_client.client.put.call_args
-    assert put_call.args[1] == "/nutrition-service/settings/2024-01-15"
-    assert put_call.kwargs["json"]["activeDailyCalories"] == 1800
+    assert json.loads(result[0][0].text) == {
+        "status": "updated", "date": "2024-01-15", "calorie_goal": 1850,
+        "carbs_grams": 205, "fat_grams": 60, "protein_grams": 140,
+    }
+    expected = deepcopy(_CURRENT_SETTINGS)
+    expected.update(calorieGoal=1800, macroGoals={"carbs": 200, "fat": 60, "protein": 140})
+    mock_garmin_client.client.put.assert_called_once_with(
+        "connectapi", "/nutrition-service/settings/2024-01-15", json=expected, api=True
+    )
+    assert original == _CURRENT_SETTINGS
 
 
 @pytest.mark.asyncio
-async def test_set_nutrition_daily_settings_partial_update(app_with_nutrition, mock_garmin_client):
-    """Only the supplied fields are changed; others keep their existing values."""
-    mock_garmin_client.connectapi.return_value = dict(_CURRENT_SETTINGS)
-    mock_garmin_client.client.put.return_value = None  # some endpoints return nothing
-
+@pytest.mark.parametrize("overrides, key, value", [
+    ({"calorie_goal": 1900}, "calorieGoal", 1900),
+    ({"carbs_grams": 0}, "carbs", 0),
+    ({"fat_grams": 55}, "fat", 55),
+    ({"protein_grams": 130}, "protein", 130),
+])
+async def test_set_nutrition_daily_settings_partial_update(
+    app_with_nutrition, mock_garmin_client, overrides, key, value
+):
+    expected = deepcopy(_CURRENT_SETTINGS)
+    if key == "calorieGoal":
+        expected[key] = value
+    else:
+        expected["macroGoals"][key] = value
+    stored = deepcopy(expected)
+    stored["calorieGoal"] = 1950
+    mock_garmin_client.connectapi.side_effect = [deepcopy(_CURRENT_SETTINGS), stored]
+    mock_garmin_client.client.put.return_value = None
     result = await app_with_nutrition.call_tool(
-        "set_nutrition_daily_settings",
-        {"date": "2024-01-15", "calorie_goal": 1900},
+        "set_nutrition_daily_settings", {"date": "2024-01-15", **overrides}
     )
-
     data = json.loads(result[0][0].text)
-    assert data["status"] == "updated"
-    assert data["calorie_goal"] == 1900
-    # Unchanged fields come back from the merged current settings (since resp=None)
-    assert data["carbs_grams"] == _CURRENT_SETTINGS["activeDailyCarbohydrateGrams"]
-    put_call = mock_garmin_client.client.put.call_args
-    assert put_call.kwargs["json"]["activeDailyCarbohydrateGrams"] == 250
+    assert data["calorie_goal"] == 1950
+    assert data["carbs_grams"] == stored["macroGoals"]["carbs"]
+    assert mock_garmin_client.client.put.call_args.kwargs["json"] == expected
+    assert mock_garmin_client.connectapi.call_count == 2
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("readback", [None, Exception("read-back unavailable")])
+async def test_set_nutrition_daily_settings_unverified_write(app_with_nutrition, mock_garmin_client, readback):
+    mock_garmin_client.connectapi.side_effect = [deepcopy(_CURRENT_SETTINGS), readback]
+    mock_garmin_client.client.put.return_value = None
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings", {"date": "2024-01-15", "calorie_goal": 1900}
+    )
+    assert "could not verify" in result[0][0].text
+    assert '"status": "updated"' not in result[0][0].text
 
 
 @pytest.mark.asyncio
@@ -1147,3 +1174,33 @@ async def test_log_custom_food_defaults_to_garmin_source(app_with_nutrition, moc
     payload = mock_garmin_client.client.put.call_args[1]["json"]
     item = payload["foodLogItems"][0]
     assert item["source"] == "GARMIN"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("macro_goals", [None, {}, {"fiber": 30}])
+async def test_set_nutrition_settings_handles_sparse_macros(
+    app_with_nutrition, mock_garmin_client, macro_goals
+):
+    current = deepcopy(_CURRENT_SETTINGS)
+    current["macroGoals"] = macro_goals
+    mock_garmin_client.connectapi.return_value = current
+    mock_garmin_client.client.put.side_effect = lambda *args, **kwargs: kwargs["json"]
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings", {"date": "2024-01-15", "protein_grams": 130}
+    )
+    assert json.loads(result[0][0].text)["protein_grams"] == 130
+    expected = deepcopy(current)
+    expected["macroGoals"] = {**(macro_goals or {}), "protein": 130}
+    assert mock_garmin_client.client.put.call_args.kwargs["json"] == expected
+
+
+@pytest.mark.asyncio
+async def test_set_nutrition_settings_rejects_invalid_macros(app_with_nutrition, mock_garmin_client):
+    current = deepcopy(_CURRENT_SETTINGS)
+    current["macroGoals"] = [250, 65, 120]
+    mock_garmin_client.connectapi.return_value = current
+    result = await app_with_nutrition.call_tool(
+        "set_nutrition_daily_settings", {"date": "2024-01-15", "protein_grams": 130}
+    )
+    assert "cannot apply update" in result[0][0].text
+    mock_garmin_client.client.put.assert_not_called()


### PR DESCRIPTION
`set_nutrition_daily_settings` writes the calorie target into the activity-calorie component and adds nonexistent top-level macro fields. Update `calorieGoal` and the supplied entries in `macroGoals`, preserving activity calories, omitted macros, and other plan settings.

Return goals from the PUT response, or read settings back when PUT returns no body, instead of reporting the request payload as stored data. If read-back fails, report that the update was submitted but could not be verified.

Validation: all nine GitHub checks pass, including the Python 3.10–3.13 test matrix, PR validation, installation, dependency checks, and code quality. All 596 unit and integration tests pass locally on Python 3.11.15. Six regression cases fail before the fix. Tests cover exact merged payloads, individual overrides, zero values, preservation of unrelated fields, server-adjusted values, empty PUT responses, failed read-back, sparse macro settings, and malformed macro settings.

API evidence and limitation: field names follow the reporter's payload in #294; fixture values are synthetic. The available account has no configured nutrition plan, so there is no independent live settings payload or write validation. Public documentation and code searches did not establish whether `macroGoals` uses grams or percentages. Existing `_grams` argument/response names are retained and values are passed through without conversion. The unsupported claims about Garmin's macro storage and discrepancy correction have been removed from the docstring. Macro units still need independent verification; passing tests establish field mapping and merge/reporting behavior, not units. No live account writes were performed.

Fixes #294.
