### PR TITLE
fix(health): don't crash on a night with null sleep-phase breakdowns

### DIFF
--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -64,12 +64,22 @@ def _extract_sleep_summary(sleep_data: Dict[str, Any]) -> Dict[str, Any]:
     if 'avgOvernightHrv' in sleep_data:
         summary['avg_overnight_hrv'] = sleep_data.get('avgOvernightHrv')
 
-    # Calculate sleep phase percentages if total sleep time is available
-    total_sleep = summary.get('sleep_seconds', 0)
+    # Calculate sleep phase percentages if total sleep time is available.
+    # The phase keys above are written unconditionally, so a `.get(key, 0)`
+    # default never fires: Garmin can report a total duration while leaving the
+    # breakdown as an explicit null, which raised "unsupported operand type(s)
+    # for /: 'NoneType' and 'int'". Skip unmeasured phases instead of defaulting
+    # them to 0, so an absent breakdown is not reported as 0%.
+    total_sleep = summary.get('sleep_seconds')
     if total_sleep and total_sleep > 0:
-        summary['deep_sleep_percent'] = round((summary.get('deep_sleep_seconds', 0) / total_sleep) * 100, 1)
-        summary['light_sleep_percent'] = round((summary.get('light_sleep_seconds', 0) / total_sleep) * 100, 1)
-        summary['rem_sleep_percent'] = round((summary.get('rem_sleep_seconds', 0) / total_sleep) * 100, 1)
+        for phase_key, percent_key in (
+            ('deep_sleep_seconds', 'deep_sleep_percent'),
+            ('light_sleep_seconds', 'light_sleep_percent'),
+            ('rem_sleep_seconds', 'rem_sleep_percent'),
+        ):
+            phase_seconds = summary.get(phase_key)
+            if phase_seconds is not None:
+                summary[percent_key] = round((phase_seconds / total_sleep) * 100, 1)
 
     # Convert sleep duration to hours for convenience
     if total_sleep:

--- a/tests/integration/test_health_wellness_tools.py
+++ b/tests/integration/test_health_wellness_tools.py
@@ -752,6 +752,69 @@ async def test_get_sleep_summary_handles_null_sleep_scores(app_with_health_welln
 
 
 @pytest.mark.asyncio
+async def test_get_sleep_summary_handles_null_sleep_phases(app_with_health_wellness, mock_garmin_client):
+    """A night with a total duration but null phase breakdowns must not crash.
+
+    The phase keys are always written into `summary` (as None when Garmin omits
+    the breakdown), so `summary.get('deep_sleep_seconds', 0)` never falls back
+    to the 0 default and the percentage math raised
+    "unsupported operand type(s) for /: 'NoneType' and 'int'".
+    """
+    mock_garmin_client.get_sleep_data.return_value = {
+        "dailySleepDTO": {
+            "sleepTimeSeconds": 28800,
+            "deepSleepSeconds": None,
+            "lightSleepSeconds": None,
+            "remSleepSeconds": None,
+            "awakeSleepSeconds": None,
+            "sleepScores": {"overall": {"value": 85, "qualifierKey": "GOOD"}},
+        },
+    }
+
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary",
+        {"date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    assert "Error" not in text
+    data = json.loads(text)
+    # The night still reports what Garmin did send ...
+    assert data["sleep_seconds"] == 28800
+    assert data["sleep_hours"] == 8.0
+    assert data["sleep_score"] == 85
+    # ... and unmeasured phases are omitted rather than reported as 0%.
+    assert "deep_sleep_percent" not in data
+    assert "light_sleep_percent" not in data
+    assert "rem_sleep_percent" not in data
+
+
+@pytest.mark.asyncio
+async def test_get_sleep_summary_handles_partial_sleep_phases(app_with_health_wellness, mock_garmin_client):
+    """A night with only some phases measured reports percentages for those."""
+    mock_garmin_client.get_sleep_data.return_value = {
+        "dailySleepDTO": {
+            "sleepTimeSeconds": 28800,
+            "deepSleepSeconds": 7200,
+            "lightSleepSeconds": None,
+            "remSleepSeconds": None,
+            "awakeSleepSeconds": 0,
+        },
+    }
+
+    result = await app_with_health_wellness.call_tool(
+        "get_sleep_summary",
+        {"date": "2024-01-15"},
+    )
+    text = result[0][0].text
+    assert "NoneType" not in text
+    data = json.loads(text)
+    assert data["deep_sleep_percent"] == 25.0
+    assert "light_sleep_percent" not in data
+    assert "rem_sleep_percent" not in data
+
+
+@pytest.mark.asyncio
 async def test_get_body_battery_handles_null_activity_events(app_with_health_wellness, mock_garmin_client):
     """A day whose bodyBatteryActivityEvent is an explicit null must not crash.
 


### PR DESCRIPTION
## Problem

`get_sleep_summary` (and `get_sleep_summary_range`) fail outright for any night where Garmin reports a sleep duration but leaves the phase breakdown null:

```
Error retrieving sleep summary: unsupported operand type(s) for /: 'NoneType' and 'int'
```

`_extract_sleep_summary` writes the phase keys unconditionally:

```python
summary['deep_sleep_seconds'] = daily_sleep.get('deepSleepSeconds')   # -> None
```

so the key is **present with value `None`**, and the `0` default in the percentage math never fires:

```python
summary.get('deep_sleep_seconds', 0) / total_sleep   # None / int
```

The blast radius is bigger than the missing field: the exception aborts the whole call, so the `sleep_score`, `sleep_hours` and everything else Garmin *did* send are lost too.

## Fix

Read each phase explicitly and skip the null ones instead of defaulting to `0`. An unmeasured phase is now **omitted** rather than reported as `0%` — a falsehood — which also matches the function's existing "remove None values" contract on the way out.

This is the same class as the batch in #253, and applies the standard documented at `training.py:581-583` ("so explicit null values … are treated as missing rather than causing NoneType errors") to the arithmetic path rather than the attribute-access path.

## Tests

Two regression tests in `tests/integration/test_health_wellness_tools.py`, both verified to fail before the change and pass after:

- `test_get_sleep_summary_handles_null_sleep_phases` — all phases null: no crash, score/duration still surface, percentages omitted.
- `test_get_sleep_summary_handles_partial_sleep_phases` — only `deepSleepSeconds` measured: reports `deep_sleep_percent == 25.0`, omits the other two.

Full suite: **590 passed** (588 before + these 2). The 4 pre-existing fixture errors in `tests/test_garmin.py` and `test_get_gear_tool_without_stats` are unchanged from `main` and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)