### PR TITLE
fix(training): correct calories units and drop misleading fields in progress summary

### DIFF
--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -26,6 +26,22 @@ def _as_dict(value: Any) -> Dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
+# The fitnessstats "calories" metric is stored pre-multiplied by this factor
+# (verified empirically: activity kcal totals from get_activity/get_stats
+# times exactly 4.19 reproduce the raw sum/avg/min/max here). It doesn't match
+# either standard kJ/kcal constant (4.184 thermochemical, 4.1868 IT), so this
+# is a Garmin-side unit quirk specific to this endpoint's "calories" field,
+# not a general kJ conversion.
+_PROGRESS_CALORIES_FACTOR = 4.19
+
+
+def _convert_progress_metric(metric: str, value: Optional[float]) -> Optional[float]:
+    """Convert a raw progress-summary stat value to its documented unit."""
+    if value is None or metric != "calories":
+        return value
+    return value / _PROGRESS_CALORIES_FACTOR
+
+
 def _extract_vo2_measurements(data: Any) -> Dict[str, float]:
     """Find all VO2 max values by sport in known Garmin response shapes."""
     if isinstance(data, list):
@@ -207,7 +223,11 @@ def register_tools(app):
         Args:
             start_date: Start date in YYYY-MM-DD format
             end_date: End date in YYYY-MM-DD format
-            metric: Metric to get progress for (e.g., "elevationGain", "duration", "distance", "movingDuration")
+            metric: Metric to get progress for (e.g., "elevationGain", "duration", "distance", "movingDuration", "calories")
+
+        Note: "calories" values are returned in kcal. Garmin's underlying
+        endpoint stores this metric pre-scaled by ~4.19; this tool undoes
+        that scaling before returning.
         """
         try:
             summary_data = garmin_client.get_progress_summary_between_dates(
@@ -223,13 +243,15 @@ def register_tools(app):
             else:
                 return f"Unexpected response format from API"
 
-            # Curate to essential fields only
+            # Curate to essential fields only. `date` and `countOfActivities`
+            # from the raw response are dropped/replaced below: Garmin's
+            # fitnessstats endpoint echoes today's date regardless of the
+            # queried range, and its countOfActivities matches neither the
+            # true activity count nor the per-type counts in `stats`.
             curated = {
                 "metric": metric,
                 "start_date": start_date,
                 "end_date": end_date,
-                "date": data.get("date"),
-                "count_of_activities": data.get("countOfActivities"),
                 "stats_by_activity_type": {},
             }
 
@@ -243,11 +265,15 @@ def register_tools(app):
                     if metric_data and metric_data.get("count", 0) > 0:
                         curated["stats_by_activity_type"][activity_type] = {
                             "count": metric_data.get("count"),
-                            "sum": metric_data.get("sum"),
-                            "avg": metric_data.get("avg"),
-                            "min": metric_data.get("min"),
-                            "max": metric_data.get("max"),
+                            "sum": _convert_progress_metric(metric, metric_data.get("sum")),
+                            "avg": _convert_progress_metric(metric, metric_data.get("avg")),
+                            "min": _convert_progress_metric(metric, metric_data.get("min")),
+                            "max": _convert_progress_metric(metric, metric_data.get("max")),
                         }
+
+            curated["count_of_activities"] = sum(
+                v["count"] for v in curated["stats_by_activity_type"].values()
+            )
 
             # Remove None values
             curated = {k: v for k, v in curated.items() if v is not None}

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -1136,6 +1136,100 @@ async def test_get_progress_summary_handles_null_stats(app_with_training, mock_g
 
 
 @pytest.mark.asyncio
+async def test_get_progress_summary_converts_calories_from_garmin_units(
+    app_with_training, mock_garmin_client
+):
+    """Garmin's fitnessstats endpoint stores "calories" pre-scaled by ~4.19
+    (verified against real activity kcal totals); the tool must undo that
+    scaling so callers get true kcal, not the raw Garmin figure.
+
+    Also covers count_of_activities: the raw field disagrees with the sum
+    of per-type counts, so the tool recomputes it instead of passing it
+    through; and the raw `date` field (which echoes today regardless of
+    the queried range) must not appear in curated output.
+    """
+    mock_garmin_client.get_progress_summary_between_dates.return_value = [
+        {
+            "date": "2024-06-01",  # today, per Garmin's behavior -- must be dropped
+            "countOfActivities": 1,  # disagrees with per-type counts below
+            "stats": {
+                "running": {
+                    "calories": {
+                        "count": 1,
+                        "min": 3703.9776799999995,
+                        "max": 3703.9776799999995,
+                        "avg": 3703.9776799999995,
+                        "sum": 3703.9776799999995,
+                    }
+                },
+                "fitness_equipment": {
+                    "calories": {
+                        "count": 2,
+                        "min": 276.54132,
+                        "max": 1508.4071999999999,
+                        "avg": 892.47426,
+                        "sum": 1784.94852,
+                    }
+                },
+            },
+        }
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_progress_summary_between_dates",
+        {"start_date": "2024-01-08", "end_date": "2024-01-15", "metric": "calories"},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert "date" not in data
+    assert data["count_of_activities"] == 3  # 1 running + 2 fitness_equipment
+
+    running = data["stats_by_activity_type"]["running"]
+    assert running["sum"] == pytest.approx(884.0, abs=0.01)
+    assert running["min"] == pytest.approx(884.0, abs=0.01)
+    assert running["max"] == pytest.approx(884.0, abs=0.01)
+    assert running["avg"] == pytest.approx(884.0, abs=0.01)
+
+    equipment = data["stats_by_activity_type"]["fitness_equipment"]
+    assert equipment["min"] == pytest.approx(66.0, abs=0.01)
+    assert equipment["max"] == pytest.approx(360.0, abs=0.01)
+    assert equipment["sum"] == pytest.approx(426.0, abs=0.01)
+
+
+@pytest.mark.asyncio
+async def test_get_progress_summary_leaves_non_calorie_metrics_unconverted(
+    app_with_training, mock_garmin_client
+):
+    """The calorie unit fix must be scoped to metric="calories" only."""
+    mock_garmin_client.get_progress_summary_between_dates.return_value = [
+        {
+            "date": "2024-06-01",
+            "countOfActivities": 1,
+            "stats": {
+                "running": {
+                    "duration": {
+                        "count": 1,
+                        "min": 4450.452,
+                        "max": 4450.452,
+                        "avg": 4450.452,
+                        "sum": 4450.452,
+                    }
+                }
+            },
+        }
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_progress_summary_between_dates",
+        {"start_date": "2024-01-08", "end_date": "2024-01-15", "metric": "duration"},
+    )
+    data = json.loads(result[0][0].text)
+
+    assert data["stats_by_activity_type"]["running"]["sum"] == 4450.452
+    assert data["count_of_activities"] == 1
+
+
+@pytest.mark.asyncio
 async def test_get_acclimation_returns_heat_data(app_with_training, mock_garmin_client):
     """Test get_acclimation returns curated heat/altitude acclimation data."""
     mock_garmin_client.get_max_metrics.return_value = [


### PR DESCRIPTION
Closes #296 via clean apply.

get_progress_summary_between_dates(metric="calories") returned Garmin's raw internal figure, pre-scaled by a fixed ~4.19 factor (not a standard kJ/kcal constant) — verified live against real activity data across three activities of different types. count_of_activities in the raw response also disagreed with the sum of per-type activity counts (observed 2 vs. an actual 53 over a 29-day window), and the raw date field echoed today's date regardless of the queried range.

Converts calories to kcal, recomputes count_of_activities from the per-type counts, and drops the misleading date field.