### PR TITLE
feat(health): add get_stats_range for multi-day calorie/step totals

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 This MCP server implements **110+ tools** covering ~90% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.3.2):
 
 - ✅ Activity Management (20 tools) - includes write tools for type, description, event type, perceived effort, and feel
-- ✅ Health & Wellness (31 tools) - includes custom lightweight summary tools
+- ✅ Health & Wellness (32 tools) - includes custom lightweight summary tools
 - ✅ Training & Performance (13 tools) - includes CTL/ATL/TSB, HRV, VO2 max, and respiration trends
 - ✅ Workouts (8 tools)
 - ✅ Devices (7 tools)

--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -99,6 +99,12 @@ def register_tools(app):
         Returns a summary of daily health and activity data including steps,
         calories, heart rate, stress, body battery, and sleep metrics.
 
+        Note: bmr_calories is Garmin's bmrKilocalories field -- per Garmin's
+        own documentation this is RMR (BMR plus sedentary-to-light movement),
+        not true basal metabolic rate. For the current date, all calorie and
+        duration fields are a partial-day accumulator (elapsed hours so far),
+        not a full-day total.
+
         Args:
             date: Date in YYYY-MM-DD format
         """
@@ -168,6 +174,89 @@ def register_tools(app):
             return json.dumps(summary, indent=2)
         except Exception as e:
             return f"Error retrieving stats: {str(e)}"
+
+    @app.tool()
+    async def get_stats_range(start_date: str, end_date: str) -> str:
+        """Get lightweight per-day calorie and step totals for a date range.
+
+        Returns total/active/resting calories and steps for each day between
+        start_date and end_date, inclusive, instead of the full get_stats
+        payload per day. Use this for multi-day analysis (e.g. comparing
+        measured intake/expenditure against Garmin's calorie model) instead
+        of calling get_stats once per day.
+
+        resting_calories is Garmin's bmrKilocalories field -- per Garmin's
+        own documentation this is RMR (BMR plus sedentary-to-light movement),
+        not true basal metabolic rate.
+
+        is_partial is true for the current date, whose accumulator only
+        covers elapsed hours so far -- treating it as a full day will
+        overstate a mean. Days with no device data (e.g. before the account
+        existed, or future dates within the range) return has_data: false
+        and null values rather than zeros, so a missing day never silently
+        enters an average as zero.
+
+        Maximum range: 28 days per call (Garmin's own limit for this endpoint).
+
+        Args:
+            start_date: Start date in YYYY-MM-DD format
+            end_date: End date in YYYY-MM-DD format
+        """
+        MAX_DAYS = 28
+        try:
+            start = datetime.date.fromisoformat(start_date)
+            end = datetime.date.fromisoformat(end_date)
+        except ValueError as e:
+            return f"Invalid date format: {e}. Use YYYY-MM-DD."
+
+        days_requested = (end - start).days + 1
+        if days_requested < 1:
+            return "end_date must be on or after start_date."
+        if days_requested > MAX_DAYS:
+            return f"Date range too large ({days_requested} days). Maximum is {MAX_DAYS} days."
+
+        url = f"/usersummary-service/stats/daily/{start_date}/{end_date}"
+        try:
+            calories_resp = garmin_client.connectapi(url, params={"statsType": "CALORIES"})
+            steps_resp = garmin_client.connectapi(url, params={"statsType": "STEPS"})
+        except Exception as e:
+            return f"Error retrieving stats range: {str(e)}"
+
+        calories_by_date = {
+            entry.get("calendarDate"): entry.get("values") or {}
+            for entry in (calories_resp or {}).get("values") or []
+        }
+        steps_by_date = {
+            entry.get("calendarDate"): entry.get("values") or {}
+            for entry in (steps_resp or {}).get("values") or []
+        }
+
+        today = datetime.date.today().isoformat()
+        daily = []
+        current = start
+        while current <= end:
+            date_str = current.isoformat()
+            cal = calories_by_date.get(date_str)
+            steps = steps_by_date.get(date_str)
+            daily.append({
+                "date": date_str,
+                "total_calories": (cal or {}).get("totalCalories"),
+                "active_calories": (cal or {}).get("activeCalories"),
+                "resting_calories": (cal or {}).get("restingCalories"),
+                "steps": (steps or {}).get("totalSteps"),
+                "has_data": cal is not None or steps is not None,
+                "is_partial": date_str == today,
+            })
+            current += datetime.timedelta(days=1)
+
+        if not any(d["has_data"] for d in daily):
+            return f"No stats found between {start_date} and {end_date}."
+
+        return json.dumps({
+            "start_date": start_date,
+            "end_date": end_date,
+            "days": daily,
+        }, indent=2)
 
     @app.tool()
     async def get_user_summary(date: str) -> str:

--- a/tests/integration/test_health_wellness_tools.py
+++ b/tests/integration/test_health_wellness_tools.py
@@ -3,6 +3,7 @@ Integration tests for health_wellness module MCP tools
 
 Tests all 22 health and wellness tools using FastMCP integration with mocked Garmin API responses.
 """
+import datetime
 import json
 
 import pytest
@@ -60,6 +61,114 @@ async def test_get_stats_tool(app_with_health_wellness, mock_garmin_client):
     # Verify
     assert result is not None
     mock_garmin_client.get_stats.assert_called_once_with("2024-01-15")
+
+
+@pytest.mark.asyncio
+async def test_get_stats_range_tool(app_with_health_wellness, mock_garmin_client):
+    """Curates calories + steps into one per-day entry and flags today as partial.
+
+    Response shapes mirror what Garmin's /usersummary-service/stats/daily
+    actually returns: one CALORIES call and one STEPS call, each with a
+    "values" list keyed by calendarDate; a day with no device data (e.g. a
+    future date) is simply absent from that list rather than null/zeroed.
+    """
+    today = datetime.date.today().isoformat()
+    yesterday = (datetime.date.today() - datetime.timedelta(days=1)).isoformat()
+    calories_resp = {
+        "values": [
+            {
+                "calendarDate": yesterday,
+                "values": {"restingCalories": 2081, "totalCalories": 2656, "activeCalories": 575},
+            },
+            {
+                "calendarDate": today,
+                "values": {"restingCalories": 1393, "totalCalories": 1900, "activeCalories": 507},
+            },
+        ]
+    }
+    steps_resp = {
+        "values": [
+            {"calendarDate": yesterday, "values": {"totalSteps": 9238}},
+            # today has no STEPS entry yet -- still has_data via calories
+        ]
+    }
+    mock_garmin_client.connectapi.side_effect = [calories_resp, steps_resp]
+
+    result = await app_with_health_wellness.call_tool(
+        "get_stats_range",
+        {"start_date": yesterday, "end_date": today},
+    )
+
+    data = json.loads(result[0][0].text)
+    days = {d["date"]: d for d in data["days"]}
+
+    past_day = days[yesterday]
+    assert past_day["total_calories"] == 2656
+    assert past_day["active_calories"] == 575
+    assert past_day["resting_calories"] == 2081
+    assert past_day["steps"] == 9238
+    assert past_day["has_data"] is True
+    assert past_day["is_partial"] is False
+
+    today_entry = days[today]
+    assert today_entry["total_calories"] == 1900
+    assert today_entry["steps"] is None  # no STEPS entry for today yet
+    assert today_entry["has_data"] is True
+    assert today_entry["is_partial"] is True
+
+
+@pytest.mark.asyncio
+async def test_get_stats_range_no_data_day(app_with_health_wellness, mock_garmin_client):
+    """A day absent from both CALORIES and STEPS responses is has_data: false with nulls."""
+    mock_garmin_client.connectapi.side_effect = [
+        {"values": [{"calendarDate": "2024-01-14", "values": {"restingCalories": 2081, "totalCalories": 2656, "activeCalories": 575}}]},
+        {"values": [{"calendarDate": "2024-01-14", "values": {"totalSteps": 9238}}]},
+    ]
+
+    result = await app_with_health_wellness.call_tool(
+        "get_stats_range",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"},
+    )
+
+    data = json.loads(result[0][0].text)
+    days = {d["date"]: d for d in data["days"]}
+    missing_day = days["2024-01-15"]
+    assert missing_day["has_data"] is False
+    assert missing_day["total_calories"] is None
+    assert missing_day["active_calories"] is None
+    assert missing_day["resting_calories"] is None
+    assert missing_day["steps"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_stats_range_rejects_oversized_range(app_with_health_wellness, mock_garmin_client):
+    """The tool enforces Garmin's own 28-day cap before making a request."""
+    result = await app_with_health_wellness.call_tool(
+        "get_stats_range",
+        {"start_date": "2024-01-01", "end_date": "2024-03-01"},
+    )
+    assert "too large" in result[0][0].text
+    mock_garmin_client.connectapi.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_stats_range_rejects_inverted_range(app_with_health_wellness, mock_garmin_client):
+    result = await app_with_health_wellness.call_tool(
+        "get_stats_range",
+        {"start_date": "2024-01-15", "end_date": "2024-01-01"},
+    )
+    assert "end_date must be on or after start_date" in result[0][0].text
+    mock_garmin_client.connectapi.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_stats_range_error(app_with_health_wellness, mock_garmin_client):
+    mock_garmin_client.connectapi.side_effect = Exception("API error")
+    result = await app_with_health_wellness.call_tool(
+        "get_stats_range",
+        {"start_date": "2024-01-14", "end_date": "2024-01-15"},
+    )
+    assert "Error retrieving stats range" in result[0][0].text
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #298 via clean apply.

get_stats takes a single date, so comparing measured TDEE against Garmin's own calorie model over a multi-week window required one get_stats call per day. Adds get_stats_range(start_date, end_date), backed by /usersummary-service/stats/daily/{start}/{end}?statsType=CALORIES|STEPS. Two calls cover the whole range instead of N calls to get_stats.

Garmin caps this endpoint at 28 days per range; the tool checks client-side first. Each day returns total_calories, active_calories, resting_calories, steps, plus has_data: false (not zeros) for days Garmin has no data for, and is_partial: true for the current date's partial-day accumulator.