### PR TITLE
fix(workouts): compare exercises by index, not value, for rest-step skip

### DIFF
--- a/src/garmin_mcp/workout_builders.py
+++ b/src/garmin_mcp/workout_builders.py
@@ -279,7 +279,7 @@ def build_strength_json(
     steps: List[dict] = []
     step_order = 1
 
-    for ex in exercises:
+    for index, ex in enumerate(exercises):
         ex_name = ex.get("name", "Exercise")
         sets = int(ex.get("sets", 1))
         reps = int(ex.get("reps", 1))
@@ -342,8 +342,10 @@ def build_strength_json(
         steps.append(step)
         step_order += 1
 
-        # Rest step (skip after last exercise)
-        if rest_seconds > 0 and ex != exercises[-1]:
+        # Rest step (skip after last exercise). Compared by index, not by value:
+        # two identical exercise dicts would otherwise make an earlier one look
+        # like the last and lose its rest step.
+        if rest_seconds > 0 and index != len(exercises) - 1:
             steps.append({
                 "type": "ExecutableStepDTO",
                 "stepOrder": step_order,

--- a/tests/unit/test_workout_builders.py
+++ b/tests/unit/test_workout_builders.py
@@ -170,6 +170,23 @@ def test_strength_multi_set_repeat_group_shape():
     assert rest["endConditionValue"] == 90.0
 
 
+def test_strength_single_set_identical_exercises_keep_middle_rest():
+    result = build_strength_json(
+        name="Duplicates",
+        exercises=[
+            {"name": "Plank Hold", "sets": 1, "reps": 1, "rest_seconds": 45},
+            {"name": "Plank Hold", "sets": 1, "reps": 1, "rest_seconds": 45},
+        ],
+    )
+    steps = result["workoutSegments"][0]["workoutSteps"]
+    # Two identical exercises must still be told apart by position, not value:
+    # a value comparison against exercises[-1] would make the first Plank Hold
+    # match the last one and lose its rest step.
+    assert len(steps) == 3
+    assert [s["type"] for s in steps] == ["ExecutableStepDTO"] * 3
+    assert steps[1]["stepType"]["stepTypeKey"] == "recovery"
+
+
 def test_strength_multi_set_without_rest_has_no_recovery_step():
     result = build_strength_json(
         name="No rest",


### PR DESCRIPTION
build_strength_json skipped the rest step after the last exercise by comparing `ex != exercises[-1]`, so two exercises with identical dicts (e.g. two "Plank Hold: 1x1, 45s rest" entries) made the earlier one match the last one by value and lose its rest step.

Surfaced while reviewing #292, which fixed the same bug as part of a larger diff that's otherwise superseded by b8ea726 (already on main).