### PR TITLE
docs: document endConditionZone for zone-based HR end conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,22 @@ Use ID `6` for heart rate:
 }
 ```
 
+For a zone-based heart-rate end condition, use `endConditionZone` (1-5) on the
+same `endCondition` object and omit `endConditionValue`. If both are sent,
+Garmin keeps the zone and drops the value (verified against the production API
+on 2026-09-01):
+
+```json
+{
+  "endCondition": {
+    "conditionTypeId": 6,
+    "conditionTypeKey": "heart.rate",
+    "endConditionZone": 2
+  }
+}
+```
+
+
 Common end-condition IDs:
 
 | ID | Key |


### PR DESCRIPTION
Closes #291 via clean apply.

Adding endConditionZone (1-5) to the endCondition object converts an absolute-HR end condition into a zone-based one. When both endConditionZone and endConditionValue are sent, Garmin keeps the zone and drops the value — the docs now tell builders to omit the value.

Docs-only change; no code or test surface.