### PR TITLE
fix: keep the original error message when translating Garmin exceptions

### DIFF
--- a/src/garmin_mcp/__init__.py
+++ b/src/garmin_mcp/__init__.py
@@ -166,20 +166,24 @@ class _GarminProxy:
        relative to the network round-trip it guards.
 
     2. Error translation: token expiry or rate-limiting during a tool call would
-       otherwise surface a raw library traceback. Known Garmin exceptions become
-       user-friendly messages instead.
+       otherwise surface a raw library traceback. Known Garmin exceptions are
+       re-raised with an actionable hint appended to the original message.
     """
 
+    # (prefix, hint): the original exception text is inserted between them so
+    # the real cause is never hidden behind the generic hint.
     _MESSAGES = {
         GarminConnectAuthenticationError: (
-            "Garmin authentication expired. "
-            "Re-run 'garmin-mcp-auth' to refresh your tokens and restart the server."
+            "Garmin authentication failed",
+            "Re-run 'garmin-mcp-auth' to refresh your tokens and restart the server.",
         ),
         GarminConnectTooManyRequestsError: (
-            "Garmin rate limit hit. Wait a few minutes before retrying."
+            "Garmin rate limit hit",
+            "Wait a few minutes before retrying.",
         ),
         GarminConnectConnectionError: (
-            "Garmin Connect is unreachable. Check your network connection or try again later."
+            "Garmin Connect request failed",
+            "Garmin Connect may be unreachable; check your network connection or try again later.",
         ),
     }
 
@@ -196,10 +200,10 @@ class _GarminProxy:
             try:
                 return attr(*args, **kwargs)
             except tuple(self._MESSAGES) as exc:
-                for exc_type, msg in self._MESSAGES.items():
+                for exc_type, (prefix, hint) in self._MESSAGES.items():
                     if isinstance(exc, exc_type):
-                        error_details = str(exc)
-                        full_msg = f"{msg} (Details: {error_details})" if error_details else msg
+                        details = str(exc).strip().rstrip(".") or "unknown error"
+                        full_msg = f"{prefix}: {details}. {hint}"
                         raise type(exc)(full_msg) from None
                 raise
 

--- a/tests/unit/test_garmin_proxy.py
+++ b/tests/unit/test_garmin_proxy.py
@@ -37,17 +37,25 @@ class TestGarminProxy:
     def test_auth_error_message_is_actionable(self):
         proxy = self._proxy(get_activities=GarminConnectAuthenticationError("expired"))
         exc = pytest.raises(GarminConnectAuthenticationError, proxy.get_activities)
+        assert str(exc.value).startswith("Garmin authentication failed: expired.")
         assert "Re-run 'garmin-mcp-auth'" in str(exc.value)
 
     def test_rate_limit_error_message_is_actionable(self):
         proxy = self._proxy(get_activities=GarminConnectTooManyRequestsError("429"))
         exc = pytest.raises(GarminConnectTooManyRequestsError, proxy.get_activities)
+        assert str(exc.value).startswith("Garmin rate limit hit: 429.")
         assert "Wait a few minutes" in str(exc.value)
 
     def test_connection_error_message_is_actionable(self):
         proxy = self._proxy(get_steps_data=GarminConnectConnectionError("timeout"))
         exc = pytest.raises(GarminConnectConnectionError, proxy.get_steps_data)
+        assert str(exc.value).startswith("Garmin Connect request failed: timeout.")
         assert "unreachable" in str(exc.value)
+
+    def test_empty_original_message_still_gets_hint(self):
+        proxy = self._proxy(get_steps_data=GarminConnectConnectionError())
+        exc = pytest.raises(GarminConnectConnectionError, proxy.get_steps_data)
+        assert str(exc.value).startswith("Garmin Connect request failed: unknown error. ")
 
     def test_unknown_exception_is_re_raised_unchanged(self):
         proxy = self._proxy(get_activities=ValueError("unexpected"))


### PR DESCRIPTION
Partial cherry-pick from #300 (which also bundles a garminconnect 0.3.11 / Python 3.12 bump — flagging that part separately as a version-policy decision).

_GarminProxy replaced GarminConnectConnectionError with a generic "Garmin Connect is unreachable" message and tucked the real cause into a "(Details: ...)" suffix, so failures that had nothing to do with the network were reported as network problems. Turns each mapping into a (prefix, hint) pair and builds the message as "<prefix>: <original>. <hint>" so the library's own text is always front and centre.

Closes #299.