### PR TITLE
feat(calendar): add goal_time_seconds and fix distance_meters units

### DIFF
--- a/src/garmin_mcp/calendar_events.py
+++ b/src/garmin_mcp/calendar_events.py
@@ -16,6 +16,16 @@ garmin_client = None
 # and badges share the same feed and are ignored here.
 EVENT_ITEM_TYPE = "event"
 
+# Garmin's calendar-service sends completionTarget.unit as one of these
+# strings (Connect's custom-event picker: meter, kilometer, yard, mile).
+# Always report meters; unknown units become None.
+_DISTANCE_UNIT_TO_METERS = {
+    "meter": 1.0,
+    "kilometer": 1000.0,
+    "yard": 0.9144,
+    "mile": 1609.344,
+}
+
 
 def configure(client):
     """Configure the module with the Garmin client instance"""
@@ -62,7 +72,43 @@ def _target_distance_meters(item: Dict[str, Any]) -> Optional[float]:
     if target.get("unitType") != "distance":
         return None
     value = target.get("value")
-    return value if isinstance(value, (int, float)) else None
+    scale = _DISTANCE_UNIT_TO_METERS.get(target.get("unit"))
+    if not isinstance(value, (int, float)) or isinstance(value, bool) or scale is None:
+        return None
+    return float(value) * scale
+
+
+def _fetch_event_detail(item: Dict[str, Any]) -> Dict[str, Any]:
+    """Fetch the event detail payload, which contains the custom goal."""
+    event_id = item.get("id")
+    event_uuid = _clean_str(item.get("shareableEventUuid"))
+    if isinstance(event_id, (int, str)) and not isinstance(event_id, bool):
+        path = f"/calendar-service/event/{event_id}"
+    elif event_uuid:
+        path = f"/calendar-service/event/{event_uuid}/shareable"
+    else:
+        return {}
+
+    try:
+        return _as_dict(garmin_client.connectapi(path))
+    except Exception:
+        # Event-detail availability must not make the calendar list unusable.
+        return {}
+
+
+def _goal_time_seconds(detail: Dict[str, Any]) -> Optional[float]:
+    """Return the user's custom event goal when Garmin stores it as time."""
+    customization = _as_dict(detail.get("eventCustomization"))
+    goal = _as_dict(customization.get("customGoal"))
+    value = goal.get("value")
+    if (
+        goal.get("unitType") != "time"
+        or goal.get("unit") != "second"
+        or not isinstance(value, (int, float))
+        or isinstance(value, bool)
+    ):
+        return None
+    return float(value)
 
 
 def _clean_str(value: Any) -> Optional[str]:
@@ -73,7 +119,9 @@ def _clean_str(value: Any) -> Optional[str]:
     return trimmed or None
 
 
-def _curate_event(item: Dict[str, Any]) -> Dict[str, Any]:
+def _curate_event(
+    item: Dict[str, Any], detail: Optional[Dict[str, Any]] = None
+) -> Dict[str, Any]:
     """Curate one raw calendar event into a compact shape."""
     event_time = _as_dict(item.get("eventTimeLocal"))
     return {
@@ -83,6 +131,7 @@ def _curate_event(item: Dict[str, Any]) -> Dict[str, Any]:
         "primary_event": bool(item.get("primaryEvent")),
         "subscribed": bool(item.get("subscribed")),
         "distance_meters": _target_distance_meters(item),
+        "goal_time_seconds": _goal_time_seconds(detail or {}),
         "start_time_local": event_time.get("startTimeHhMm"),
         "time_zone": event_time.get("timeZoneId"),
         "location": _clean_str(item.get("location")),
@@ -106,10 +155,12 @@ def register_tools(app):
         only workouts, nor by get_goals. This is the only tool that exposes
         them.
 
-        Each event reports its target distance in meters when Garmin stores one,
-        the local start time when the organiser published it, and two flags:
-        is_race marks the entry as a race rather than a general event, and
-        primary_event marks the goal race that an active training plan targets.
+        Each event reports its distance in meters when Garmin stores one,
+        the user's custom goal time in seconds when set, the local start
+        time when the organiser published it, and two flags: is_race marks
+        the entry as a race rather than a general event, and primary_event
+        marks the goal race that an active training plan targets. Goal time
+        comes from a per-event detail request.
 
         Args:
             start_date: Start date in YYYY-MM-DD format
@@ -138,7 +189,7 @@ def register_tools(app):
                     if key in seen:
                         continue
                     seen.add(key)
-                    events.append(_curate_event(item))
+                    events.append(_curate_event(item, _fetch_event_detail(item)))
 
             events.sort(key=lambda event: (event["date"], event["title"] or ""))
 

--- a/tests/integration/test_calendar_events_tools.py
+++ b/tests/integration/test_calendar_events_tools.py
@@ -232,6 +232,25 @@ async def test_get_calendar_events_ignores_non_distance_target(
 
 
 @pytest.mark.asyncio
+async def test_get_calendar_events_converts_mile_distance_to_meters(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A mile completion target is reported in meters."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race(
+            "2026-10-17",
+            completionTarget={"value": 1.0, "unit": "mile", "unitType": "distance"},
+        )
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    assert json.loads(_result_text(result))["events"][0]["distance_meters"] == 1609.344
+
+
+@pytest.mark.asyncio
 async def test_get_calendar_events_normalises_blank_location(
     app_with_calendar_events, mock_garmin_client
 ):
@@ -244,6 +263,138 @@ async def test_get_calendar_events_normalises_blank_location(
 
     data = json.loads(_result_text(result))
     assert data["events"][0]["location"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_enriches_custom_event_goal(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A custom event uses its numeric id to fetch the user's time goal."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race(
+            "2026-10-17",
+            id=12345,
+            shareableEventUuid=None,
+            completionTarget={
+                "value": 5.0,
+                "unit": "kilometer",
+                "unitType": "distance",
+            },
+        )
+    )
+    mock_garmin_client.connectapi.return_value = {
+        "eventCustomization": {
+            "customGoal": {
+                "value": 1800.0,
+                "unit": "second",
+                "unitType": "time",
+            }
+        }
+    }
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    event = json.loads(_result_text(result))["events"][0]
+    assert event["distance_meters"] == 5000.0
+    assert event["goal_time_seconds"] == 1800.0
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/calendar-service/event/12345"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_enriches_shareable_event_goal(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A subscribed event uses its shareable UUID to fetch the time goal."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", id=None, uuid="shareable-uuid")
+    )
+    mock_garmin_client.connectapi.return_value = {
+        "eventCustomization": {
+            "customGoal": {
+                "value": 14400.0,
+                "unit": "second",
+                "unitType": "time",
+            }
+        }
+    }
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    event = json.loads(_result_text(result))["events"][0]
+    assert event["distance_meters"] == 42195.0
+    assert event["goal_time_seconds"] == 14400.0
+    mock_garmin_client.connectapi.assert_called_once_with(
+        "/calendar-service/event/shareable-uuid/shareable"
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_ignores_non_time_custom_goal(
+    app_with_calendar_events, mock_garmin_client
+):
+    """Only second-based time goals are exposed as goal_time_seconds."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17")
+    )
+    mock_garmin_client.connectapi.return_value = {
+        "eventCustomization": {
+            "customGoal": {
+                "value": 10.0,
+                "unit": "kilometer",
+                "unitType": "distance",
+            }
+        }
+    }
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    assert json.loads(_result_text(result))["events"][0]["goal_time_seconds"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_skips_detail_without_event_identity(
+    app_with_calendar_events, mock_garmin_client
+):
+    """An event with neither id nor UUID remains usable without a detail call."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17", id=None, shareableEventUuid=None)
+    )
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    event = json.loads(_result_text(result))["events"][0]
+    assert event["goal_time_seconds"] is None
+    mock_garmin_client.connectapi.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_get_calendar_events_keeps_event_when_detail_fetch_fails(
+    app_with_calendar_events, mock_garmin_client
+):
+    """A missing detail response does not make the calendar list fail."""
+    mock_garmin_client.get_scheduled_workouts.return_value = _month(
+        _race("2026-10-17")
+    )
+    mock_garmin_client.connectapi.side_effect = Exception("detail unavailable")
+
+    result = await app_with_calendar_events.call_tool(
+        "get_calendar_events", {"start_date": "2026-10-01", "end_date": "2026-10-31"}
+    )
+
+    data = json.loads(_result_text(result))
+    assert data["count"] == 1
+    assert data["events"][0]["distance_meters"] == 42195.0
+    assert data["events"][0]["goal_time_seconds"] is None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Issues
- `get_calendar_events` only read the calendar-service event list, where `completionTarget` is the race distance. The user's finish-time goal lives on the event detail payload as `eventCustomization.customGoal`, so the tool never returned it.
- distance_meters copied completionTarget.value and labelled it meters. The list payload stores that value in the unit Garmin chose (meter, kilometer, yard, mile), so a custom 5 km event was returned as 5.0.

## Fixes
- After listing events, fetch detail with `connectapi`: 
  - numeric `id` -> `/calendar-service/event/{id}` (custom events); 
  - `shareableEventUuid` -> `/calendar-service/event/{uuid}/shareable` (subscribed races). 
- Map a time/second `customGoal` to `goal_time_seconds`, or `null` when detail is missing, the fetch fails, or the goal is not a time.
- Convert completionTarget to meters using that unit so distance_meters matches its name.

## Test plan
- [x] `pytest tests/integration/test_calendar_events_tools.py`
- [x] Custom event with a numeric `id` and a time goal returns `goal_time_seconds`
- [x] Subscribed/shareable race with `id: null` returns `goal_time_seconds` via the `/shareable` path
- [x] Custom event stored as kilometers reports `distance_meters` in meters (e.g. 5 km -> 5000)
- [x] Detail fetch failure still returns the event with `goal_time_seconds: null`
