### PR TITLE
fix(training): fall back to activity list when training effect details 403

### DIFF
--- a/README.md
+++ b/README.md
@@ -882,6 +882,17 @@ Once connected in Claude, you can ask questions like:
 
 ## Troubleshooting
 
+### `get_training_effect` returns HTTP 403 for a valid activity
+
+Garmin's activity-details endpoint (`/activity-service/activity/{id}`) can
+return **403 Forbidden** even when the same activity is visible in list tools.
+`get_training_effect` now falls back to activity list search, which still
+includes aerobic/anaerobic training effect for recent activities.
+
+If the activity is older than the recent-search window, list the activity with
+`get_activities` / `get_activities_by_date` and retry, or use those list fields
+directly.
+
 ### "Failed to spawn process: No such file or directory"
 
 If Claude Desktop can't find `uvx`, it's because `uvx` is not in the PATH that Claude Desktop uses. To fix this:

--- a/src/garmin_mcp/training.py
+++ b/src/garmin_mcp/training.py
@@ -123,6 +123,141 @@ def _get_max_metrics_range(
     return True, connectapi(f"{metrics_url}/{start_date}/{end_date}")
 
 
+def _is_forbidden_error(exc: Exception) -> bool:
+    """True when Garmin rejected the call with HTTP 403 Forbidden."""
+    text = str(exc).lower()
+    return "403" in text or "forbidden" in text
+
+
+def _first_present(mapping: Any, *keys: str) -> Any:
+    """Return the first non-None value for keys on a mapping-like object."""
+    data = _as_dict(mapping)
+    for key in keys:
+        value = data.get(key)
+        if value is not None:
+            return value
+    return None
+
+
+def _activity_id_matches(item: Any, activity_id: int) -> bool:
+    """Compare Garmin activityId values that may arrive as int or str."""
+    raw = _as_dict(item).get("activityId")
+    try:
+        return int(raw) == int(activity_id)
+    except (TypeError, ValueError):
+        return str(raw) == str(activity_id)
+
+
+def _as_activity_list(payload: Any) -> List[Dict[str, Any]]:
+    """Normalize activity-search payloads to a list of dicts."""
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    data = _as_dict(payload)
+    for key in ("activityList", "activities"):
+        nested = data.get(key)
+        if isinstance(nested, list):
+            return [item for item in nested if isinstance(item, dict)]
+    return []
+
+
+def _lookup_activity_in_list(client: Any, activity_id: int, limit: int = 100):
+    """Find an activity in the list-search endpoint, which often works when details 403.
+
+    Garmin's `/activity-service/activity/{id}` endpoint returns HTTP 403 for some
+    valid, recently synced activities. The list search used by get_activities
+    still includes aerobic/anaerobic training effect on those same records.
+    """
+    url = getattr(
+        client,
+        "garmin_connect_activities",
+        "/activitylist-service/activities/search/activities",
+    )
+    connectapi = getattr(client, "connectapi", None)
+    search_attempts: List[Dict[str, str]] = [
+        {"activityIds": str(activity_id), "start": "0", "limit": "1"},
+        {"start": "0", "limit": str(limit)},
+    ]
+    if callable(connectapi):
+        for params in search_attempts:
+            try:
+                payload = connectapi(url, params=params)
+            except Exception:
+                continue
+            match = next(
+                (
+                    item
+                    for item in _as_activity_list(payload)
+                    if _activity_id_matches(item, activity_id)
+                ),
+                None,
+            )
+            if match is not None:
+                return match
+
+    get_activities = getattr(client, "get_activities", None)
+    if callable(get_activities):
+        try:
+            payload = get_activities(0, limit)
+        except Exception:
+            payload = None
+        return next(
+            (
+                item
+                for item in _as_activity_list(payload)
+                if _activity_id_matches(item, activity_id)
+            ),
+            None,
+        )
+    return None
+
+
+def _minutes_to_hours(value: Any) -> Optional[float]:
+    """Convert Garmin recovery minutes to hours, or None if missing/invalid."""
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        return None
+    if value <= 0 or not math.isfinite(value):
+        return None
+    return round(value / 60.0, 1)
+
+
+def _curate_training_effect(
+    activity: Any, activity_id: int, source: str
+) -> Dict[str, Any]:
+    """Pull training-effect fields from either details or list-search shapes."""
+    activity = _as_dict(activity)
+    summary = _as_dict(activity.get("summaryDTO"))
+    aerobic = _first_present(
+        summary, "trainingEffect", "aerobicTrainingEffect"
+    ) or _first_present(activity, "aerobicTrainingEffect", "trainingEffect")
+    anaerobic = _first_present(summary, "anaerobicTrainingEffect") or _first_present(
+        activity, "anaerobicTrainingEffect"
+    )
+    label = _first_present(summary, "trainingEffectLabel") or _first_present(
+        activity, "trainingEffectLabel", "aerobicTrainingEffectMessage"
+    )
+    recovery = _first_present(summary, "recoveryTime") or _first_present(
+        activity, "recoveryTime"
+    )
+    load = _first_present(summary, "activityTrainingLoad") or _first_present(
+        activity, "activityTrainingLoad"
+    )
+    performance = _first_present(summary, "performanceCondition") or _first_present(
+        activity, "performanceCondition"
+    )
+    curated = {
+        "activity_id": activity_id,
+        "source": source,
+        "training_effect": aerobic,
+        "aerobic_effect": aerobic,
+        "anaerobic_effect": anaerobic,
+        "training_effect_label": label,
+        "recovery_time_hours": _minutes_to_hours(recovery),
+        "training_load": load,
+        "performance_condition": performance,
+    }
+    return {key: value for key, value in curated.items() if value is not None}
+
+
 def _build_vo2_trend_series(
     history: List[Dict[str, Any]], end_date: datetime.date
 ) -> List[Dict[str, Any]]:
@@ -455,46 +590,48 @@ def register_tools(app):
 
     @app.tool()
     async def get_training_effect(activity_id: int) -> str:
-        """Get training effect data for a specific activity
+        """Get training effect data for a specific activity.
+
+        Uses activity details first. If Garmin returns HTTP 403 for that
+        endpoint (seen on valid, recent activities), falls back to activity
+        list search, which still includes aerobic/anaerobic training effect.
 
         Args:
             activity_id: ID of the activity to retrieve training effect for
         """
         try:
-            # Training effect data is available through get_activity
-            # The garminconnect library doesn't have a separate get_training_effect method
+            activity_id = int(activity_id)
+        except (TypeError, ValueError):
+            return f"Invalid activity ID: {activity_id}"
+
+        source = "activity_details"
+        detail_error: Optional[Exception] = None
+        try:
             activity = garmin_client.get_activity(activity_id)
+        except Exception as e:
+            if not _is_forbidden_error(e):
+                return f"Error retrieving training effect data: {e}"
+            activity = None
+            detail_error = e
+
+        if not activity:
+            source = "activity_list"
+            try:
+                activity = _lookup_activity_in_list(garmin_client, activity_id)
+            except Exception as e:
+                return f"Error retrieving training effect data: {e}"
             if not activity:
+                if detail_error is not None:
+                    return (
+                        "Error retrieving training effect data: Garmin returned HTTP 403 "
+                        f"for activity {activity_id} details, and the activity was not "
+                        "found in recent activity search."
+                    )
                 return f"No activity found with ID {activity_id}."
 
-            # Extract training effect data from activity summary
-            summary = activity.get("summaryDTO", {})
-
-            # Curate to essential fields only
-            curated = {
-                "activity_id": activity_id,
-                "training_effect": summary.get("trainingEffect"),
-                "aerobic_effect": summary.get("trainingEffect"),
-                "anaerobic_effect": summary.get("anaerobicTrainingEffect"),
-                "training_effect_label": summary.get("trainingEffectLabel"),
-                # Recovery metrics
-                "recovery_time_hours": (
-                    round(summary.get("recoveryTime", 0) / 60, 1)
-                    if summary.get("recoveryTime")
-                    else None
-                ),
-                # Training load
-                "training_load": summary.get("activityTrainingLoad"),
-                # Additional metrics that may be available
-                "performance_condition": summary.get("performanceCondition"),
-            }
-
-            # Remove None values
-            curated = {k: v for k, v in curated.items() if v is not None}
-
-            return json.dumps(curated, indent=2)
-        except Exception as e:
-            return f"Error retrieving training effect data: {str(e)}"
+        return json.dumps(
+            _curate_training_effect(activity, activity_id, source), indent=2
+        )
 
     @app.tool()
     async def get_hrv_data(date: str, return_timeseries: bool = False) -> str:

--- a/tests/integration/test_training_tools.py
+++ b/tests/integration/test_training_tools.py
@@ -170,6 +170,12 @@ async def test_get_training_effect_tool(app_with_training, mock_garmin_client):
     # Verify
     assert result is not None
     mock_garmin_client.get_activity.assert_called_once_with(12345678901)
+    data = json.loads(result[0][0].text)
+    assert data["training_effect"] == 3.5
+    assert data["aerobic_effect"] == 3.5
+    assert data["anaerobic_effect"] == 2.0
+    assert data["recovery_time_hours"] == 12.0
+    assert data["source"] == "activity_details"
 
 
 @pytest.mark.asyncio
@@ -882,6 +888,64 @@ async def test_get_training_effect_exception(app_with_training, mock_garmin_clie
 
     # Verify error is handled gracefully
     assert result is not None
+    assert "Error retrieving training effect data" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_get_training_effect_falls_back_to_activity_list_on_403(
+    app_with_training, mock_garmin_client
+):
+    """HTTP 403 on activity details should still return list-search training effect."""
+    mock_garmin_client.get_activity.side_effect = Exception(
+        "HTTP error: API Error 403 - HTTP 403 Forbidden"
+    )
+    mock_garmin_client.garmin_connect_activities = (
+        "/activitylist-service/activities/search/activities"
+    )
+    mock_garmin_client.connectapi.return_value = [
+        {
+            "activityId": 12345678901,
+            "aerobicTrainingEffect": 3.2,
+            "anaerobicTrainingEffect": 0.4,
+            "aerobicTrainingEffectMessage": "IMPROVING_AEROBIC_BASE_8",
+            "activityTrainingLoad": 140,
+        }
+    ]
+
+    result = await app_with_training.call_tool(
+        "get_training_effect",
+        {"activity_id": 12345678901},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["source"] == "activity_list"
+    assert data["training_effect"] == 3.2
+    assert data["anaerobic_effect"] == 0.4
+    assert data["training_load"] == 140
+
+
+@pytest.mark.asyncio
+async def test_get_training_effect_403_without_list_match(
+    app_with_training, mock_garmin_client
+):
+    """If details 403 and the activity is not in recent search, surface the 403."""
+    mock_garmin_client.get_activity.side_effect = Exception(
+        "HTTP error: API Error 403 - HTTP 403 Forbidden"
+    )
+    mock_garmin_client.garmin_connect_activities = (
+        "/activitylist-service/activities/search/activities"
+    )
+    mock_garmin_client.connectapi.return_value = []
+    mock_garmin_client.get_activities.return_value = []
+
+    result = await app_with_training.call_tool(
+        "get_training_effect",
+        {"activity_id": 12345678901},
+    )
+
+    text = result[0][0].text
+    assert "HTTP 403" in text
+    assert "12345678901" in text
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_training_effect.py
+++ b/tests/unit/test_training_effect.py
@@ -1,0 +1,135 @@
+"""Unit tests for training-effect helpers used by get_training_effect."""
+
+from garminconnect import GarminConnectConnectionError
+
+from garmin_mcp.training import (
+    _activity_id_matches,
+    _as_activity_list,
+    _curate_training_effect,
+    _is_forbidden_error,
+    _lookup_activity_in_list,
+    _minutes_to_hours,
+)
+
+
+class _FakeClient:
+    def __init__(self, payload=None, error=None):
+        self.garmin_connect_activities = "/activitylist-service/activities/search/activities"
+        self._payload = payload
+        self._error = error
+        self.calls = []
+
+    def connectapi(self, url, params=None):
+        self.calls.append((url, params))
+        if self._error:
+            raise self._error
+        return self._payload
+
+
+def test_is_forbidden_error_detects_403_and_forbidden():
+    assert _is_forbidden_error(Exception("HTTP error: API Error 403 - HTTP 403 Forbidden"))
+    assert _is_forbidden_error(GarminConnectConnectionError("Forbidden"))
+    assert not _is_forbidden_error(Exception("API Error"))
+    assert not _is_forbidden_error(Exception("timeout"))
+
+
+def test_activity_id_matches_int_and_str():
+    assert _activity_id_matches({"activityId": 123}, 123)
+    assert _activity_id_matches({"activityId": "123"}, 123)
+    assert not _activity_id_matches({"activityId": 999}, 123)
+    assert not _activity_id_matches({}, 123)
+
+
+def test_as_activity_list_accepts_list_and_wrapped_payloads():
+    item = {"activityId": 1}
+    assert _as_activity_list([item]) == [item]
+    assert _as_activity_list({"activityList": [item]}) == [item]
+    assert _as_activity_list({"activities": [item]}) == [item]
+    assert _as_activity_list(None) == []
+    assert _as_activity_list(object()) == []
+
+
+def test_curate_training_effect_from_details_summary():
+    curated = _curate_training_effect(
+        {
+            "summaryDTO": {
+                "trainingEffect": 3.5,
+                "anaerobicTrainingEffect": 2.0,
+                "trainingEffectLabel": "Highly Improving",
+                "activityTrainingLoad": 150,
+                "recoveryTime": 720,
+                "performanceCondition": 95,
+            }
+        },
+        123,
+        "activity_details",
+    )
+    assert curated["activity_id"] == 123
+    assert curated["source"] == "activity_details"
+    assert curated["training_effect"] == 3.5
+    assert curated["aerobic_effect"] == 3.5
+    assert curated["anaerobic_effect"] == 2.0
+    assert curated["training_effect_label"] == "Highly Improving"
+    assert curated["recovery_time_hours"] == 12.0
+    assert curated["training_load"] == 150
+    assert curated["performance_condition"] == 95
+
+
+def test_curate_training_effect_from_list_item():
+    curated = _curate_training_effect(
+        {
+            "activityId": 456,
+            "aerobicTrainingEffect": 2.4,
+            "anaerobicTrainingEffect": 0.3,
+            "aerobicTrainingEffectMessage": "IMPROVING_AEROBIC_BASE_8",
+            "activityTrainingLoad": 87.0,
+        },
+        456,
+        "activity_list",
+    )
+    assert curated == {
+        "activity_id": 456,
+        "source": "activity_list",
+        "training_effect": 2.4,
+        "aerobic_effect": 2.4,
+        "anaerobic_effect": 0.3,
+        "training_effect_label": "IMPROVING_AEROBIC_BASE_8",
+        "training_load": 87.0,
+    }
+
+
+def test_minutes_to_hours_rejects_invalid_values():
+    assert _minutes_to_hours(60) == 1.0
+    assert _minutes_to_hours(0) is None
+    assert _minutes_to_hours(None) is None
+    assert _minutes_to_hours(True) is None
+
+
+def test_lookup_activity_in_list_prefers_activity_ids_filter():
+    item = {"activityId": 99, "aerobicTrainingEffect": 3.1}
+    client = _FakeClient(payload=[item])
+
+    found = _lookup_activity_in_list(client, 99)
+
+    assert found is item
+    assert client.calls[0][1]["activityIds"] == "99"
+
+
+def test_lookup_activity_in_list_scans_recent_page_when_filter_misses():
+    wanted = {"activityId": "77", "aerobicTrainingEffect": 1.2}
+
+    class ScanningClient:
+        garmin_connect_activities = "/activitylist-service/activities/search/activities"
+
+        def connectapi(self, url, params=None):
+            if params and params.get("activityIds"):
+                return []
+            return [wanted, {"activityId": 1}]
+
+    found = _lookup_activity_in_list(ScanningClient(), 77)
+    assert found is wanted
+
+
+def test_lookup_activity_in_list_returns_none_when_missing():
+    client = _FakeClient(payload=[{"activityId": 1}])
+    assert _lookup_activity_in_list(client, 99) is None


### PR DESCRIPTION
## Summary
- `get_training_effect` currently calls `/activity-service/activity/{id}`, which returns HTTP 403 for some valid, recently synced activities even while list tools work.
- On 403, look the same activity up in activity list search and curate aerobic/anaerobic training effect, load, and label from that payload.
- If the activity is not in the recent-search window, return a clear 403 message instead of calling it a network failure.

Closes #304

## Test plan
- [x] `uv run pytest tests/unit/test_training_effect.py tests/integration/test_training_tools.py`
- [ ] With a live Garmin account that previously 403'd: `get_training_effect` on a recent activity returns TE fields with `"source": "activity_list"`
- [ ] A normal activity that still allows details keeps `"source": "activity_details"`


Made with [Cursor](https://cursor.com)