### PR TITLE
feat(health): expose daily recovery time remaining

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 This MCP server implements **110+ tools** covering ~90% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.3.2):
 
 - ✅ Activity Management (20 tools) - includes write tools for type, description, event type, perceived effort, and feel
-- ✅ Health & Wellness (33 tools) - includes custom lightweight summary tools
+- ✅ Health & Wellness (34 tools) - includes custom lightweight summary tools
 - ✅ Training & Performance (13 tools) - includes CTL/ATL/TSB, HRV, VO2 max, and respiration trends
 - ✅ Workouts (8 tools)
 - ✅ Devices (7 tools)

--- a/src/garmin_mcp/health_wellness.py
+++ b/src/garmin_mcp/health_wellness.py
@@ -15,6 +15,174 @@ def configure(client):
     garmin_client = client
 
 
+def _as_snapshot_list(payload: Any) -> List[Dict[str, Any]]:
+    """Normalize training-readiness payloads to a list of dicts."""
+    if isinstance(payload, list):
+        return [item for item in payload if isinstance(item, dict)]
+    if isinstance(payload, dict):
+        return [payload]
+    return []
+
+
+def _recovery_state(remaining_hours: Optional[float], phrase: Any) -> str:
+    """Map remaining hours / Garmin change phrase to a coarse state."""
+    if phrase == "REACHED_ZERO" or remaining_hours == 0:
+        return "recovered"
+    if remaining_hours is None:
+        return "unknown"
+    if remaining_hours <= 6:
+        return "nearly_recovered"
+    if remaining_hours <= 24:
+        return "recovering"
+    return "not_recovered"
+
+
+def _hours_from_recovery_minutes(minutes: Any, phrase: Any = None) -> Optional[float]:
+    """Convert Garmin recovery minutes to hours.
+
+    When ``recoveryTimeChangePhrase`` is ``REACHED_ZERO``, Garmin keeps the last
+    assigned minute value even though the clock has drained to zero.
+    """
+    if phrase == "REACHED_ZERO":
+        return 0.0
+    if isinstance(minutes, bool) or not isinstance(minutes, (int, float)):
+        return None
+    if minutes < 0:
+        return None
+    return round(float(minutes) / 60.0, 1)
+
+
+def _recovery_from_readiness(payload: Any, source: str) -> Optional[Dict[str, Any]]:
+    """Build a recovery-time payload from training-readiness snapshots."""
+    snapshots = _as_snapshot_list(payload)
+    if not snapshots:
+        return None
+    latest = max(
+        snapshots,
+        key=lambda item: str(item.get("timestampLocal") or item.get("timestamp") or ""),
+    )
+    phrase = latest.get("recoveryTimeChangePhrase")
+    hours = _hours_from_recovery_minutes(latest.get("recoveryTime"), phrase)
+    if hours is None:
+        return None
+    score = latest.get("score")
+    if score is None:
+        score = latest.get("readinessScore")
+    curated = {
+        "remaining_hours": hours,
+        "recovery_score": score,
+        "state": _recovery_state(hours, phrase),
+        "source": source,
+        "date": latest.get("calendarDate"),
+        "timestamp": latest.get("timestampLocal") or latest.get("timestamp"),
+        "change_phrase": phrase,
+        "level": latest.get("level") or latest.get("readinessLevel"),
+    }
+    return {key: value for key, value in curated.items() if value is not None}
+
+
+def _activity_end_utc(activity: Dict[str, Any]) -> Optional[datetime.datetime]:
+    """Estimate activity end time from list-search fields."""
+    begin = activity.get("beginTimestamp")
+    duration = activity.get("duration") or activity.get("elapsedDuration") or 0
+    try:
+        duration_s = float(duration)
+    except (TypeError, ValueError):
+        duration_s = 0.0
+    if isinstance(begin, (int, float)) and not isinstance(begin, bool) and begin > 0:
+        start = datetime.datetime.fromtimestamp(begin / 1000.0, tz=datetime.timezone.utc)
+        return start + datetime.timedelta(seconds=duration_s)
+    return None
+
+
+def _recovery_from_recent_activities(
+    client: Any, now: datetime.datetime
+) -> Optional[Dict[str, Any]]:
+    """Decay activity-assigned recoveryTime when Training Readiness is absent."""
+    get_activities = getattr(client, "get_activities", None)
+    if not callable(get_activities):
+        return None
+    try:
+        items = get_activities(0, 20)
+    except Exception:
+        return None
+    if not isinstance(items, list):
+        return None
+
+    best: Optional[Dict[str, Any]] = None
+    best_end: Optional[datetime.datetime] = None
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        recovery = item.get("recoveryTime")
+        if isinstance(recovery, bool) or not isinstance(recovery, (int, float)):
+            continue
+        end = _activity_end_utc(item)
+        if end is None:
+            continue
+        elapsed_min = max(0.0, (now - end).total_seconds() / 60.0)
+        remaining_hours = round(max(0.0, float(recovery) - elapsed_min) / 60.0, 1)
+        if best_end is None or end > best_end:
+            best_end = end
+            best = {
+                "remaining_hours": remaining_hours,
+                "recovery_score": None,
+                "state": _recovery_state(remaining_hours, None),
+                "source": "recent_activity",
+                "activity_id": item.get("activityId"),
+                "activity_name": item.get("activityName"),
+            }
+    if best is None:
+        return None
+    return {key: value for key, value in best.items() if value is not None}
+
+
+def _safe_call(fn: Any, *args: Any) -> Any:
+    try:
+        return fn(*args)
+    except Exception:
+        return None
+
+
+def _collect_recovery_time(
+    client: Any, date_str: str, now: Optional[datetime.datetime] = None
+) -> Dict[str, Any]:
+    """Resolve daily recovery-time remaining from readiness, then activities."""
+    readiness = _safe_call(getattr(client, "get_training_readiness", None), date_str)
+    curated = _recovery_from_readiness(readiness, "training_readiness")
+    if curated:
+        curated.setdefault("date", date_str)
+        return curated
+
+    morning = _safe_call(
+        getattr(client, "get_morning_training_readiness", None), date_str
+    )
+    curated = _recovery_from_readiness(morning, "morning_training_readiness")
+    if curated:
+        curated.setdefault("date", date_str)
+        return curated
+
+    if now is None:
+        now = datetime.datetime.now(datetime.timezone.utc)
+    curated = _recovery_from_recent_activities(client, now)
+    if curated:
+        curated.setdefault("date", date_str)
+        return curated
+
+    return {
+        "remaining_hours": None,
+        "recovery_score": None,
+        "state": "unavailable",
+        "date": date_str,
+        "message": (
+            "No recovery time remaining found for this date. Training Readiness "
+            "snapshots were empty and recent activities did not include recoveryTime. "
+            "Some devices (for example Forerunner 255) show recovery on-device without "
+            "publishing a Connect Training Readiness feed."
+        ),
+    }
+
+
 def _extract_sleep_summary(sleep_data: Dict[str, Any]) -> Dict[str, Any]:
     """Curate a single night's raw Garmin sleep payload down to essential metrics.
 
@@ -1496,5 +1664,30 @@ def register_tools(app):
             return json.dumps(curated, indent=2)
         except Exception as e:
             return f"Error retrieving morning training readiness: {str(e)}"
+
+    @app.tool()
+    async def get_recovery_time_remaining(date: str = "") -> str:
+        """Get remaining recovery time in hours for a day.
+
+        This is the Firstbeat recovery clock shown on-device, distinct from
+        Training Readiness score (missing on some devices such as Forerunner 255)
+        and from Training Status ACWR. When Training Readiness snapshots exist
+        they are the current remaining value. Otherwise the tool decays
+        recoveryTime assigned on recent activities.
+
+        Args:
+            date: Date in YYYY-MM-DD format. Defaults to today.
+        """
+        try:
+            date = (date or "").strip() or datetime.date.today().isoformat()
+            datetime.datetime.strptime(date, "%Y-%m-%d")
+        except ValueError:
+            return f"Invalid date {date!r}. Use YYYY-MM-DD."
+
+        try:
+            curated = _collect_recovery_time(garmin_client, date)
+            return json.dumps(curated, indent=2)
+        except Exception as e:
+            return f"Error retrieving recovery time remaining: {str(e)}"
 
     return app

--- a/tests/integration/test_health_wellness_tools.py
+++ b/tests/integration/test_health_wellness_tools.py
@@ -1371,3 +1371,49 @@ async def test_get_body_battery_handles_null_activity_events(app_with_health_wel
     assert "NoneType" not in text
     assert "Error" not in text
     assert "100" in text
+
+
+@pytest.mark.asyncio
+async def test_get_recovery_time_remaining_from_readiness(
+    app_with_health_wellness, mock_garmin_client
+):
+    mock_garmin_client.get_training_readiness.return_value = [
+        {
+            "calendarDate": "2026-09-12",
+            "timestampLocal": "2026-09-12T08:00:00",
+            "recoveryTime": 720,
+            "score": 64,
+            "level": "MODERATE",
+            "recoveryTimeChangePhrase": "NO_CHANGE_SLEEP",
+        }
+    ]
+
+    result = await app_with_health_wellness.call_tool(
+        "get_recovery_time_remaining",
+        {"date": "2026-09-12"},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["remaining_hours"] == 12.0
+    assert data["recovery_score"] == 64
+    assert data["state"] == "recovering"
+    assert data["source"] == "training_readiness"
+    mock_garmin_client.get_training_readiness.assert_called_once_with("2026-09-12")
+
+
+@pytest.mark.asyncio
+async def test_get_recovery_time_remaining_unavailable(
+    app_with_health_wellness, mock_garmin_client
+):
+    mock_garmin_client.get_training_readiness.return_value = []
+    mock_garmin_client.get_morning_training_readiness.return_value = None
+    mock_garmin_client.get_activities.return_value = []
+
+    result = await app_with_health_wellness.call_tool(
+        "get_recovery_time_remaining",
+        {"date": "2026-09-12"},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["state"] == "unavailable"
+    assert data["remaining_hours"] is None

--- a/tests/unit/test_recovery_time.py
+++ b/tests/unit/test_recovery_time.py
@@ -1,0 +1,117 @@
+"""Unit tests for daily recovery-time remaining helpers."""
+
+from datetime import datetime, timezone
+
+from garmin_mcp.health_wellness import (
+    _collect_recovery_time,
+    _hours_from_recovery_minutes,
+    _recovery_from_readiness,
+    _recovery_state,
+)
+
+
+def test_hours_from_recovery_minutes_and_reached_zero():
+    assert _hours_from_recovery_minutes(1728) == 28.8
+    assert _hours_from_recovery_minutes(106, "REACHED_ZERO") == 0.0
+    assert _hours_from_recovery_minutes(None) is None
+    assert _hours_from_recovery_minutes(True) is None
+
+
+def test_recovery_state_bands():
+    assert _recovery_state(0, None) == "recovered"
+    assert _recovery_state(3, None) == "nearly_recovered"
+    assert _recovery_state(12, None) == "recovering"
+    assert _recovery_state(36, None) == "not_recovered"
+    assert _recovery_state(12, "REACHED_ZERO") == "recovered"
+
+
+def test_recovery_from_readiness_uses_latest_snapshot():
+    payload = [
+        {
+            "calendarDate": "2026-09-12",
+            "timestampLocal": "2026-09-12T07:00:00",
+            "recoveryTime": 1728,
+            "score": 51,
+            "level": "MODERATE",
+            "recoveryTimeChangePhrase": "NO_CHANGE_SLEEP",
+        },
+        {
+            "calendarDate": "2026-09-12",
+            "timestampLocal": "2026-09-12T18:00:00",
+            "recoveryTime": 106,
+            "score": 72,
+            "level": "PRODUCTIVE",
+            "recoveryTimeChangePhrase": "NO_CHANGE_SLEEP",
+        },
+    ]
+    curated = _recovery_from_readiness(payload, "training_readiness")
+    assert curated["remaining_hours"] == 1.8
+    assert curated["recovery_score"] == 72
+    assert curated["state"] == "nearly_recovered"
+    assert curated["source"] == "training_readiness"
+
+
+class _FakeClient:
+    def __init__(self, readiness=None, morning=None, activities=None):
+        self._readiness = readiness
+        self._morning = morning
+        self._activities = activities
+        self.readiness_calls = []
+
+    def get_training_readiness(self, date):
+        self.readiness_calls.append(date)
+        return self._readiness
+
+    def get_morning_training_readiness(self, date):
+        return self._morning
+
+    def get_activities(self, start, limit):
+        return self._activities
+
+
+def test_collect_prefers_training_readiness():
+    client = _FakeClient(
+        readiness={
+            "recoveryTime": 600,
+            "score": 80,
+            "calendarDate": "2026-09-12",
+            "timestampLocal": "2026-09-12T08:00:00",
+        },
+        activities=[{"recoveryTime": 9999}],
+    )
+    curated = _collect_recovery_time(client, "2026-09-12")
+    assert curated["source"] == "training_readiness"
+    assert curated["remaining_hours"] == 10.0
+    assert curated["recovery_score"] == 80
+
+
+def test_collect_falls_back_to_decayed_activity_recovery():
+    now = datetime(2026, 9, 12, 18, 0, tzinfo=timezone.utc)
+    # Activity ended at 12:00 UTC with 8 hours (480 min) assigned -> 2 hours left.
+    client = _FakeClient(
+        readiness=[],
+        morning=None,
+        activities=[
+            {
+                "activityId": 42,
+                "activityName": "Lunch run",
+                "beginTimestamp": datetime(2026, 9, 12, 11, 0, tzinfo=timezone.utc).timestamp()
+                * 1000,
+                "duration": 3600,
+                "recoveryTime": 480,
+            }
+        ],
+    )
+    curated = _collect_recovery_time(client, "2026-09-12", now=now)
+    assert curated["source"] == "recent_activity"
+    assert curated["remaining_hours"] == 2.0
+    assert curated["activity_id"] == 42
+    assert curated["state"] == "nearly_recovered"
+
+
+def test_collect_unavailable_when_no_sources():
+    client = _FakeClient(readiness=[], morning=None, activities=[])
+    curated = _collect_recovery_time(client, "2026-09-12")
+    assert curated["state"] == "unavailable"
+    assert curated["remaining_hours"] is None
+    assert "message" in curated


### PR DESCRIPTION
## Summary
- Garmin devices show recovery time remaining as a standalone daily clock. That value was only nested inside Training Readiness, which some devices (e.g. Forerunner 255) never publish.
- Add `get_recovery_time_remaining(date?)` returning `{remaining_hours, recovery_score, state, source}`.
- Prefer the latest Training Readiness snapshot (including `REACHED_ZERO`), then morning readiness, then decay `recoveryTime` from recent activities.

Closes #305

## Test plan
- [x] `uv run pytest tests/unit/test_recovery_time.py tests/integration/test_health_wellness_tools.py`
- [ ] On a device with Training Readiness: remaining hours match Connect.
- [ ] On a Forerunner 255 (or similar): tool either decays activity recoveryTime or returns `state: unavailable` with a clear message instead of an empty readiness payload.


Made with [Cursor](https://cursor.com)