### PR TITLE
feat(activity): add delete_activity with a confirmation gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Garmin's API is accessed via the awesome [python-garminconnect](https://github.c
 
 This MCP server implements **110+ tools** covering ~90% of the [python-garminconnect](https://github.com/cyberjunky/python-garminconnect) library (v0.3.2):
 
-- ✅ Activity Management (20 tools) - includes write tools for type, description, event type, perceived effort, and feel
+- ✅ Activity Management (21 tools) - includes write tools for type, description, event type, perceived effort, feel, and confirmed delete
 - ✅ Health & Wellness (33 tools) - includes custom lightweight summary tools
 - ✅ Training & Performance (13 tools) - includes CTL/ATL/TSB, HRV, VO2 max, and respiration trends
 - ✅ Workouts (8 tools)
@@ -77,7 +77,10 @@ Some endpoints are not implemented due to performance or complexity consideratio
 - `upload_running_workout()`, `upload_cycling_workout()`, `upload_swimming_workout()` - Sport-specific workout uploads. Use `upload_workout()` for general workouts.
 
 **Maintenance & Destructive Operations:**
-- `delete_activity()`, `delete_blood_pressure()` - Destructive operations require careful consideration.
+- `delete_blood_pressure()` - Destructive operations require careful consideration.
+- `delete_activity()` is implemented with a confirmation gate: call once to
+  preview, then again with `confirm=true` to delete. Deletions are logged to
+  stderr. There is no undo.
 - Internal/Auth methods: `login()`, `resume_login()`, `connectapi()`, `download()` - Handled automatically by the library.
 
 If you need any of these endpoints, please [open an issue](https://github.com/Taxuspt/garmin_mcp/issues).

--- a/src/garmin_mcp/activity_management.py
+++ b/src/garmin_mcp/activity_management.py
@@ -3,6 +3,7 @@ Activity Management functions for Garmin Connect MCP Server
 """
 import json
 import datetime
+import sys
 from typing import Any, Dict, List, Optional, Union
 
 # The garmin_client will be set by the main file
@@ -13,6 +14,61 @@ def configure(client):
     """Configure the module with the Garmin client instance"""
     global garmin_client
     garmin_client = client
+
+
+def _activity_preview(client: Any, activity_id: int) -> Dict[str, Any]:
+    """Build a compact preview of an activity before deleting it."""
+    preview: Dict[str, Any] = {"activity_id": activity_id}
+
+    activity = None
+    try:
+        activity = client.get_activity(activity_id)
+    except Exception:
+        activity = None
+
+    if isinstance(activity, dict) and activity:
+        summary = activity.get("summaryDTO")
+        summary = summary if isinstance(summary, dict) else {}
+        type_dto = activity.get("activityTypeDTO")
+        type_dto = type_dto if isinstance(type_dto, dict) else {}
+        preview.update(
+            {
+                "name": activity.get("activityName"),
+                "type": type_dto.get("typeKey"),
+                "start_time": summary.get("startTimeLocal") or activity.get("startTimeLocal"),
+                "distance_meters": summary.get("distance") or activity.get("distance"),
+                "duration_seconds": summary.get("duration") or activity.get("duration"),
+            }
+        )
+        return {key: value for key, value in preview.items() if value is not None}
+
+    get_activities = getattr(client, "get_activities", None)
+    if not callable(get_activities):
+        return preview
+    try:
+        items = get_activities(0, 50)
+    except Exception:
+        items = None
+    if not isinstance(items, list):
+        return preview
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("activityId")) != str(activity_id):
+            continue
+        type_info = item.get("activityType")
+        type_info = type_info if isinstance(type_info, dict) else {}
+        preview.update(
+            {
+                "name": item.get("activityName"),
+                "type": type_info.get("typeKey"),
+                "start_time": item.get("startTimeLocal"),
+                "distance_meters": item.get("distance"),
+                "duration_seconds": item.get("duration"),
+            }
+        )
+        break
+    return {key: value for key, value in preview.items() if value is not None}
 
 
 def _put_activity_update(activity_id: int, payload: Dict[str, Any]) -> Any:
@@ -937,6 +993,58 @@ def register_tools(app):
             }, indent=2)
         except Exception as e:
             return f"Error creating manual activity: {str(e)}"
+
+    @app.tool()
+    async def delete_activity(
+        activity_id: Union[int, str], confirm: bool = False
+    ) -> str:
+        """Permanently delete an activity from Garmin Connect.
+
+        This cannot be undone. Call once with confirm=false (the default) to
+        preview the activity, then call again with confirm=true to delete it.
+        confirm=true is the scripting equivalent of a force flag.
+
+        Args:
+            activity_id: ID of the activity to delete
+            confirm: Must be true to actually delete. Default false returns a preview.
+        """
+        try:
+            activity_id = int(activity_id)
+        except (TypeError, ValueError):
+            return f"Invalid activity ID: {activity_id}"
+
+        try:
+            preview = _activity_preview(garmin_client, activity_id)
+            if not confirm:
+                return json.dumps(
+                    {
+                        "status": "needs_confirmation",
+                        "activity": preview,
+                        "message": (
+                            "This permanently deletes the activity from Garmin Connect "
+                            "and cannot be undone. Call again with confirm=true to proceed."
+                        ),
+                    },
+                    indent=2,
+                )
+
+            garmin_client.delete_activity(activity_id)
+            print(
+                "delete_activity: deleted activity "
+                f"{activity_id} name={preview.get('name')!r} "
+                f"at {datetime.datetime.now(datetime.timezone.utc).isoformat()}",
+                file=sys.stderr,
+            )
+            return json.dumps(
+                {
+                    "status": "deleted",
+                    "activity": preview,
+                    "message": f"Activity {activity_id} permanently deleted.",
+                },
+                indent=2,
+            )
+        except Exception as e:
+            return f"Error deleting activity: {str(e)}"
 
     @app.tool()
     async def get_activity_types() -> str:

--- a/tests/integration/test_activity_management_tools.py
+++ b/tests/integration/test_activity_management_tools.py
@@ -1068,3 +1068,68 @@ async def test_create_manual_activity_exception(app_with_activity_management, mo
     )
     assert "Error" in result[0][0].text
     assert "Garmin API error" in result[0][0].text
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_requires_confirmation(
+    app_with_activity_management, mock_garmin_client
+):
+    mock_garmin_client.get_activity.return_value = {
+        "activityId": 12345678901,
+        "activityName": "Morning Run",
+        "activityTypeDTO": {"typeKey": "running"},
+        "summaryDTO": {
+            "startTimeLocal": "2024-01-15 07:00:00",
+            "distance": 5000.0,
+            "duration": 1800.0,
+        },
+    }
+
+    result = await app_with_activity_management.call_tool(
+        "delete_activity",
+        {"activity_id": 12345678901},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["status"] == "needs_confirmation"
+    assert data["activity"]["name"] == "Morning Run"
+    mock_garmin_client.delete_activity.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_with_confirm(
+    app_with_activity_management, mock_garmin_client
+):
+    mock_garmin_client.get_activity.return_value = {
+        "activityId": 12345678901,
+        "activityName": "Morning Run",
+        "activityTypeDTO": {"typeKey": "running"},
+        "summaryDTO": {"startTimeLocal": "2024-01-15 07:00:00"},
+    }
+    mock_garmin_client.delete_activity.return_value = None
+
+    result = await app_with_activity_management.call_tool(
+        "delete_activity",
+        {"activity_id": 12345678901, "confirm": True},
+    )
+
+    data = json.loads(result[0][0].text)
+    assert data["status"] == "deleted"
+    assert data["activity"]["activity_id"] == 12345678901
+    mock_garmin_client.delete_activity.assert_called_once_with(12345678901)
+
+
+@pytest.mark.asyncio
+async def test_delete_activity_exception(
+    app_with_activity_management, mock_garmin_client
+):
+    mock_garmin_client.get_activity.return_value = {"activityName": "Morning Run"}
+    mock_garmin_client.delete_activity.side_effect = Exception("Garmin API error")
+
+    result = await app_with_activity_management.call_tool(
+        "delete_activity",
+        {"activity_id": 12345678901, "confirm": True},
+    )
+
+    assert "Error deleting activity" in result[0][0].text
+    assert "Garmin API error" in result[0][0].text

--- a/tests/unit/test_delete_activity.py
+++ b/tests/unit/test_delete_activity.py
@@ -1,0 +1,56 @@
+"""Unit tests for delete_activity preview helper."""
+
+from garmin_mcp.activity_management import _activity_preview
+
+
+class _FakeClient:
+    def __init__(self, activity=None, activities=None, error=None):
+        self._activity = activity
+        self._activities = activities
+        self._error = error
+
+    def get_activity(self, activity_id):
+        if self._error:
+            raise self._error
+        return self._activity
+
+    def get_activities(self, start, limit):
+        return self._activities
+
+
+def test_preview_from_activity_details():
+    client = _FakeClient(
+        activity={
+            "activityName": "Morning Run",
+            "activityTypeDTO": {"typeKey": "running"},
+            "summaryDTO": {
+                "startTimeLocal": "2024-01-15 07:00:00",
+                "distance": 5000.0,
+                "duration": 1800.0,
+            },
+        }
+    )
+    preview = _activity_preview(client, 99)
+    assert preview["activity_id"] == 99
+    assert preview["name"] == "Morning Run"
+    assert preview["type"] == "running"
+    assert preview["distance_meters"] == 5000.0
+
+
+def test_preview_falls_back_to_activity_list_on_details_error():
+    client = _FakeClient(
+        error=Exception("403 Forbidden"),
+        activities=[
+            {
+                "activityId": 99,
+                "activityName": "Easy Ride",
+                "activityType": {"typeKey": "cycling"},
+                "startTimeLocal": "2024-01-14 16:00:00",
+                "distance": 20000.0,
+                "duration": 3600.0,
+            }
+        ],
+    )
+    preview = _activity_preview(client, 99)
+    assert preview["name"] == "Easy Ride"
+    assert preview["type"] == "cycling"


### PR DESCRIPTION
## Summary
- `delete_activity()` was intentionally skipped as a destructive operation.
- Add the tool with a confirmation gate: the default call returns a preview (`status: needs_confirmation`); a second call with `confirm=true` performs the delete.
- Log each deletion to stderr for an audit trail. There is no undo.

## Test plan
- [x] `uv run pytest tests/unit/test_delete_activity.py tests/integration/test_activity_management_tools.py`
- [ ] Live: call `delete_activity` without `confirm` and verify nothing is deleted
- [ ] Live: call again with `confirm=true` on a disposable test activity and confirm it disappears from Connect


Made with [Cursor](https://cursor.com)